### PR TITLE
Fix missing comments and required packages

### DIFF
--- a/pglifecycle/generate_dump.py
+++ b/pglifecycle/generate_dump.py
@@ -320,7 +320,8 @@ class Generate:
                 owner=entry.owner,
                 dependencies=[entry.dump_id])
             self._objects += 1
-        elif 'comments' in data:
+
+        if 'comments' in data:
             for comment in data['comments']:
                 parsed = parse.sql(comment)
                 self._dump.add_entry(

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -10,3 +10,5 @@ flake8-rst-docstrings
 flake8-tuple
 nose
 psycopg2
+ruamel.yaml
+jsonschema


### PR DESCRIPTION
Changes generate_dump._maybe_add_comment to use two if statements instead of if/else.  This allows for database objects to have both object level comments and subcomments.  (i.e. table comment and column comments)

Adds 2 modules missing from requirements so nosetest can run without complaining of missing modules.