### PR TITLE
Phase 1: models, YAML I/O, validation, project loading

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+reviews:
+  auto_review:
+    enabled: true
+    base_branches:
+      - rust-rewrite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,35 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,10 +88,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cfg-if"
@@ -117,12 +185,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -142,16 +236,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "getrandom"
@@ -161,7 +307,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -172,7 +318,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -188,10 +345,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "indexmap"
@@ -218,6 +496,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +557,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,10 +584,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_threads"
@@ -275,13 +696,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pglifecycle"
 version = "2.0.0-alpha.0"
 dependencies = [
  "clap",
+ "include_dir",
+ "jsonschema",
  "log",
+ "serde",
+ "serde_json",
+ "serde_norway",
  "simplelog",
  "tempfile",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -320,9 +790,90 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
@@ -338,6 +889,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -378,11 +948,25 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
 ]
 
 [[package]]
@@ -395,6 +979,18 @@ dependencies = [
  "termcolor",
  "time",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -414,13 +1010,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -469,6 +1076,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,10 +1104,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wasip2"
@@ -502,6 +1159,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -654,6 +1356,109 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,12 @@ rust-version = "1.85"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
+include_dir = "0.7.4"
+jsonschema = { version = "0.46.5", default-features = false }
 log = "0.4"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
+serde_norway = "0.9.42"
 simplelog = "0.12"
 
 [dev-dependencies]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,4 @@
-//! Shared constants (ports constants.py)
+//! Shared constants (ports constants.py and project.py classifications)
 
 /// Project subdirectories, one per object-type path in the managed layout
 /// (constants.PATHS in the Python implementation, deduplicated — foreign
@@ -30,3 +30,213 @@ pub const PROJECT_DIRS: &[&str] = &[
     "users",
     "views",
 ];
+
+/// Database object types tracked in the project inventory
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ObjectType {
+    Aggregate,
+    Cast,
+    Collation,
+    Conversion,
+    Domain,
+    EventTrigger,
+    Extension,
+    ForeignDataWrapper,
+    Function,
+    Group,
+    MaterializedView,
+    Operator,
+    ProceduralLanguage,
+    Publication,
+    Role,
+    Schema,
+    Sequence,
+    Server,
+    Subscription,
+    Table,
+    Tablespace,
+    TextSearch,
+    Type,
+    User,
+    UserMapping,
+    View,
+}
+
+impl ObjectType {
+    /// The pg_dump-style description (constants.py values)
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Aggregate => "AGGREGATE",
+            Self::Cast => "CAST",
+            Self::Collation => "COLLATION",
+            Self::Conversion => "CONVERSION",
+            Self::Domain => "DOMAIN",
+            Self::EventTrigger => "EVENT TRIGGER",
+            Self::Extension => "EXTENSION",
+            Self::ForeignDataWrapper => "FOREIGN DATA WRAPPER",
+            Self::Function => "FUNCTION",
+            Self::Group => "GROUP",
+            Self::MaterializedView => "MATERIALIZED VIEW",
+            Self::Operator => "OPERATOR",
+            Self::ProceduralLanguage => "PROCEDURAL LANGUAGE",
+            Self::Publication => "PUBLICATION",
+            Self::Role => "ROLE",
+            Self::Schema => "SCHEMA",
+            Self::Sequence => "SEQUENCE",
+            Self::Server => "SERVER",
+            Self::Subscription => "SUBSCRIPTION",
+            Self::Table => "TABLE",
+            Self::Tablespace => "TABLESPACE",
+            Self::TextSearch => "TEXT SEARCH",
+            Self::Type => "TYPE",
+            Self::User => "USER",
+            Self::UserMapping => "USER MAPPING",
+            Self::View => "VIEW",
+        }
+    }
+
+    /// Project subdirectory holding this object type's files
+    pub fn path(&self) -> Option<&'static str> {
+        Some(match self {
+            Self::Aggregate => "aggregates",
+            Self::Cast => "casts",
+            Self::Collation => "collations",
+            Self::Conversion => "conversions",
+            Self::Domain => "domains",
+            Self::EventTrigger => "event_triggers",
+            Self::Function => "functions",
+            Self::Group => "groups",
+            Self::MaterializedView => "materialized_views",
+            Self::Operator => "operators",
+            Self::Publication => "publications",
+            Self::Role => "roles",
+            Self::Schema => "schemata",
+            Self::Sequence => "sequences",
+            Self::Server => "servers",
+            Self::Subscription => "subscriptions",
+            Self::Table => "tables",
+            Self::Tablespace => "tablespaces",
+            Self::TextSearch => "text_search",
+            Self::Type => "types",
+            Self::User => "users",
+            Self::UserMapping => "user_mappings",
+            Self::View => "views",
+            Self::Extension
+            | Self::ForeignDataWrapper
+            | Self::ProceduralLanguage => return None,
+        })
+    }
+
+    /// The JSON-Schema file stem for this object type
+    pub fn schema_file(&self) -> String {
+        self.as_str().to_lowercase().replace(' ', "_")
+    }
+
+    /// Map a plural container/dependency key to its object type
+    /// (constants.OBJ_KEYS)
+    pub fn from_plural_key(key: &str) -> Option<Self> {
+        Some(match key {
+            "casts" => Self::Cast,
+            "conversions" => Self::Conversion,
+            "domains" => Self::Domain,
+            "extensions" => Self::Extension,
+            "foreign data wrappers" => Self::ForeignDataWrapper,
+            "functions" => Self::Function,
+            "groups" => Self::Group,
+            "languages" => Self::ProceduralLanguage,
+            "operators" => Self::Operator,
+            "roles" => Self::Role,
+            "sequences" => Self::Sequence,
+            "schemata" => Self::Schema,
+            "tables" => Self::Table,
+            "tablespaces" => Self::Tablespace,
+            "text_search" => Self::TextSearch,
+            "types" => Self::Type,
+            "views" => Self::View,
+            _ => return None,
+        })
+    }
+
+    /// The plural key used by this type's per-schema container files
+    pub fn plural_key(&self) -> &'static str {
+        match self {
+            Self::Cast => "casts",
+            Self::Conversion => "conversions",
+            Self::Operator => "operators",
+            Self::TextSearch => "text_search",
+            Self::Type => "types",
+            other => unreachable!("no container key for {other:?}"),
+        }
+    }
+
+    /// Object types read from per-schema container files
+    /// (project.py _PER_SCHEMA_FILES)
+    pub fn is_per_schema_file(&self) -> bool {
+        matches!(
+            self,
+            Self::Cast
+                | Self::Conversion
+                | Self::Operator
+                | Self::TextSearch
+                | Self::Type
+        )
+    }
+
+    /// Object types without an `owner` field (project.py _OWNERLESS)
+    pub fn is_ownerless(&self) -> bool {
+        matches!(
+            self,
+            Self::EventTrigger
+                | Self::Group
+                | Self::Publication
+                | Self::Role
+                | Self::Server
+                | Self::Subscription
+                | Self::TextSearch
+                | Self::User
+                | Self::UserMapping
+        )
+    }
+
+    /// Object types without a `schema` field (project.py _SCHEMALESS)
+    pub fn is_schemaless(&self) -> bool {
+        matches!(
+            self,
+            Self::EventTrigger
+                | Self::Group
+                | Self::Publication
+                | Self::Role
+                | Self::Schema
+                | Self::Server
+                | Self::Subscription
+                | Self::Tablespace
+                | Self::User
+                | Self::UserMapping
+        )
+    }
+}
+
+/// The order object files are read in (project.py _READ_ORDER)
+pub const READ_ORDER: &[ObjectType] = &[
+    ObjectType::Schema,
+    ObjectType::Operator,
+    ObjectType::Aggregate,
+    ObjectType::Collation,
+    ObjectType::Conversion,
+    ObjectType::Type,
+    ObjectType::Domain,
+    ObjectType::Tablespace,
+    ObjectType::Table,
+    ObjectType::Sequence,
+    ObjectType::Function,
+    ObjectType::View,
+    ObjectType::MaterializedView,
+    ObjectType::Cast,
+    ObjectType::TextSearch,
+    ObjectType::Server,
+    ObjectType::EventTrigger,
+    ObjectType::Publication,
+    ObjectType::Subscription,
+];
+
+pub const DEPENDENCIES: &str = "dependencies";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+//! pglifecycle — PostgreSQL schema management
+
+pub mod cli;
+pub mod constants;
+pub mod models;
+pub mod project;
+pub mod skeleton;
+pub mod yamlio;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,9 @@
 //! CLI entry-point
 
-mod cli;
-mod constants;
-mod skeleton;
-
 use std::process::ExitCode;
 
 use clap::Parser;
+use pglifecycle::{cli, skeleton};
 
 fn main() -> ExitCode {
     let args = cli::Cli::parse();

--- a/src/models/function.rs
+++ b/src/models/function.rs
@@ -1,0 +1,98 @@
+//! Functions and procedures
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Represents a Function
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Function {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Vec<FunctionParameter>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub returns: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transform_types: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub immutable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volatile: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub leak_proof: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub called_on_null_input: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rows: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub support: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configuration: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub definition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_symbol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a single parameter for a function
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FunctionParameter {
+    pub mode: String,
+    pub data_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<Value>,
+}
+
+/// Represents a Procedure
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Procedure {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Vec<FunctionParameter>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transform_types: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configuration: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub definition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_symbol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}

--- a/src/models/misc.rs
+++ b/src/models/misc.rs
@@ -1,0 +1,395 @@
+//! Aggregates, casts, collations, conversions, domains, event triggers,
+//! extensions, FDWs, languages, operators, publications, schemas,
+//! sequences, servers, subscriptions, tablespaces, and user mappings
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Represents the implementation of an aggregate for a data type
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Aggregate {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    pub arguments: Vec<Argument>,
+    pub sfunc: String,
+    pub state_data_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_data_size: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ffunc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finalfunc_extra: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finalfunc_modify: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub combinefunc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serialfunc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deserialfunc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_condition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub msfunc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minvfunc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mstate_data_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mstate_data_size: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mffunc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mfinalfunc_extra: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mfinalfunc_modify: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minitial_condition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_operator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hypothetical: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents an argument to an aggregate
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Argument {
+    pub data_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Represents a cast between two data types
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Cast {
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inout: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignment: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub implicit: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a Collation
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Collation {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lc_collate: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lc_ctype: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deterministic: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub copy_from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a Conversion
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Conversion {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding_from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding_to: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a Domain
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Domain {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub check_constraints: Option<Vec<DomainConstraint>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a Check Constraint in a Domain
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DomainConstraint {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
+}
+
+/// Represents an event trigger
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EventTrigger {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<EventTriggerFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// An event trigger filter
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EventTriggerFilter {
+    pub tags: Vec<String>,
+}
+
+/// Represents an extension
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Extension {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cascade: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a Foreign Data Wrapper
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ForeignDataWrapper {
+    pub name: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handler: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a Procedural Language
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Language {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replace: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trusted: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handler: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline_handler: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents an operator used to compare values
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Operator {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    pub function: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub left_arg: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub right_arg: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commutator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub negator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub restrict: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub join: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hashes: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merges: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a Publication
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Publication {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tables: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub all_tables: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a schema/namespace
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Schema {
+    pub name: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a sequence
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Sequence {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub increment_by: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_value: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_value: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_with: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cycle: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owned_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a foreign server
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Server {
+    pub name: String,
+    pub foreign_data_wrapper: String,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub server_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a logical replication subscription
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Subscription {
+    pub name: String,
+    pub connection: String,
+    pub publications: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a tablespace
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Tablespace {
+    pub name: String,
+    pub owner: String,
+    pub location: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a user mapping
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserMapping {
+    pub name: String,
+    pub servers: Vec<UserMappingServer>,
+}
+
+/// Represents a server for a user mapping
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserMappingServer {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Map<String, Value>>,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,125 @@
+//! Models for database objects (ports models.py)
+//!
+//! Field order matches the Python dataclasses; serde serializes in
+//! declaration order, which sets the key order of emitted YAML. Optional
+//! fields skip serialization when None so emitted files only contain
+//! what was defined. `deny_unknown_fields` mirrors dataclass(**defn)
+//! raising on unexpected keys.
+
+mod function;
+mod misc;
+mod roles;
+mod table;
+mod text_search;
+mod types;
+mod views;
+
+use std::collections::BTreeSet;
+
+pub use function::*;
+pub use misc::*;
+pub use roles::*;
+pub use table::*;
+pub use text_search::*;
+pub use types::*;
+pub use views::*;
+
+/// One database object definition of any supported type
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(untagged)]
+pub enum Definition {
+    Aggregate(Aggregate),
+    Cast(Cast),
+    Collation(Collation),
+    Conversion(Conversion),
+    Domain(Domain),
+    EventTrigger(EventTrigger),
+    Extension(Extension),
+    ForeignDataWrapper(ForeignDataWrapper),
+    Function(Function),
+    Group(Group),
+    Language(Language),
+    MaterializedView(MaterializedView),
+    Operator(Operator),
+    Publication(Publication),
+    Role(Role),
+    Schema(Schema),
+    Sequence(Sequence),
+    Server(Server),
+    Subscription(Subscription),
+    Table(Table),
+    Tablespace(Tablespace),
+    TextSearch(TextSearch),
+    Type(Type),
+    User(User),
+    UserMapping(UserMapping),
+    View(View),
+}
+
+impl Definition {
+    /// The object name (`name` field; casts derive one from their types)
+    pub fn name(&self) -> String {
+        match self {
+            Definition::Aggregate(d) => d.name.clone(),
+            Definition::Cast(d) => format!(
+                "({} AS {})",
+                d.source_type.as_deref().unwrap_or_default(),
+                d.target_type.as_deref().unwrap_or_default()
+            ),
+            Definition::Collation(d) => d.name.clone(),
+            Definition::Conversion(d) => d.name.clone(),
+            Definition::Domain(d) => d.name.clone(),
+            Definition::EventTrigger(d) => d.name.clone(),
+            Definition::Extension(d) => d.name.clone(),
+            Definition::ForeignDataWrapper(d) => d.name.clone(),
+            Definition::Function(d) => d.name.clone(),
+            Definition::Group(d) => d.name.clone(),
+            Definition::Language(d) => d.name.clone(),
+            Definition::MaterializedView(d) => d.name.clone(),
+            Definition::Operator(d) => d.name.clone(),
+            Definition::Publication(d) => d.name.clone(),
+            Definition::Role(d) => d.name.clone(),
+            Definition::Schema(d) => d.name.clone(),
+            Definition::Sequence(d) => d.name.clone(),
+            Definition::Server(d) => d.name.clone(),
+            Definition::Subscription(d) => d.name.clone(),
+            Definition::Table(d) => d.name.clone(),
+            Definition::Tablespace(d) => d.name.clone(),
+            Definition::TextSearch(d) => d.schema.clone(),
+            Definition::Type(d) => d.name.clone(),
+            Definition::User(d) => d.name.clone(),
+            Definition::UserMapping(d) => d.name.clone(),
+            Definition::View(d) => d.name.clone(),
+        }
+    }
+
+    /// The schema the object belongs to, where the type has one
+    pub fn schema(&self) -> Option<&str> {
+        match self {
+            Definition::Aggregate(d) => Some(&d.schema),
+            Definition::Cast(d) => Some(&d.schema),
+            Definition::Collation(d) => Some(&d.schema),
+            Definition::Conversion(d) => Some(&d.schema),
+            Definition::Domain(d) => Some(&d.schema),
+            Definition::Extension(d) => d.schema.as_deref(),
+            Definition::Function(d) => Some(&d.schema),
+            Definition::MaterializedView(d) => Some(&d.schema),
+            Definition::Operator(d) => Some(&d.schema),
+            Definition::Sequence(d) => Some(&d.schema),
+            Definition::Table(d) => Some(&d.schema),
+            Definition::TextSearch(d) => Some(&d.schema),
+            Definition::Type(d) => Some(&d.schema),
+            Definition::View(d) => Some(&d.schema),
+            _ => None,
+        }
+    }
+}
+
+/// An item in the project inventory
+#[derive(Clone, Debug)]
+pub struct Item {
+    pub id: usize,
+    pub desc: crate::constants::ObjectType,
+    pub definition: Definition,
+    pub dependencies: BTreeSet<usize>,
+}

--- a/src/models/roles.rs
+++ b/src/models/roles.rs
@@ -1,0 +1,139 @@
+//! Groups, roles, users, and their ACLs
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Represents role grant/revoke ACLs
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Acls {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub columns: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub databases: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domains: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub foreign_data_wrappers: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub foreign_servers: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub functions: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub languages: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub large_objects: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub roles: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schemata: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sequences: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tables: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tablespaces: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub types: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub views: Option<Map<String, Value>>,
+}
+
+/// Represents a group
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Group {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environments: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grants: Option<Acls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revocations: Option<Acls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<GroupOptions>,
+}
+
+/// Options for a group
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GroupOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create_db: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create_role: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inherit: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superuser: Option<bool>,
+}
+
+/// Represents a role
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Role {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environments: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grants: Option<Acls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revocations: Option<Acls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<RoleOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<Map<String, Value>>,
+}
+
+/// Options for a role or user
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoleOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bypass_rls: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection_limit: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create_db: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create_role: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inherit: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub login: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replication: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superuser: Option<bool>,
+}
+
+/// Represents a user
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct User {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environments: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grants: Option<Acls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revocations: Option<Acls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<RoleOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<Map<String, Value>>,
+}

--- a/src/models/table.rs
+++ b/src/models/table.rs
@@ -1,0 +1,276 @@
+//! Tables and their child objects (columns, constraints, indexes,
+//! triggers, partitioning)
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Represents a table
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Table {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unlogged: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parents: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub like_table: Option<LikeTable>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub columns: Option<Vec<Column>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indexes: Option<Vec<Index>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_key: Option<ConstraintColumns>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub check_constraints: Option<Vec<CheckConstraint>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unique_constraints: Option<Vec<ConstraintColumns>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub foreign_keys: Option<Vec<ForeignKey>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub triggers: Option<Vec<Trigger>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partition: Option<TablePartitionBehavior>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partitions: Option<Vec<TablePartition>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_parameters: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tablespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_tablespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a column in a table
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Column {
+    pub name: String,
+    pub data_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub check_constraint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generated: Option<ColumnGenerated>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents configuration of a generated column
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ColumnGenerated {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sequence: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sequence_behavior: Option<String>,
+}
+
+/// Represents a Check Constraint in a Table
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckConstraint {
+    pub name: String,
+    pub expression: String,
+}
+
+/// Constraint columns for primary keys and unique constraints. The YAML
+/// form may be a single column name, a list of column names, or a
+/// mapping with `columns` and optional `include` (see table.yml)
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ConstraintColumns {
+    Name(String),
+    Columns(Vec<String>),
+    Detailed {
+        columns: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        include: Option<Vec<String>>,
+    },
+}
+
+/// Represents a Foreign Key on a Table
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ForeignKey {
+    pub name: String,
+    pub columns: Vec<String>,
+    pub references: ForeignKeyReference,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_delete: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_update: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deferrable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initially_deferred: Option<bool>,
+}
+
+/// Represents the table a Foreign Key references
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ForeignKeyReference {
+    pub name: String,
+    pub columns: Vec<String>,
+}
+
+/// Represents an Index on a table
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Index {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unique: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurse: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub columns: Option<Vec<IndexColumn>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include: Option<Vec<String>>,
+    #[serde(rename = "where", skip_serializing_if = "Option::is_none")]
+    pub where_clause: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_parameters: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tablespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a column in an index on a table
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IndexColumn {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opclass: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub null_placement: Option<String>,
+}
+
+/// Represents the settings for creating a table using LIKE
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LikeTable {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_comments: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_constraints: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_defaults: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_generated: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_identity: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_indexes: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_statistics: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_storage: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_all: Option<bool>,
+}
+
+/// Defines a table partition
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TablePartition {
+    pub name: String,
+    pub schema: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub for_values_in: Option<Vec<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub for_values_from: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub for_values_to: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub for_values_with: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Defines how a table is partitioned
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TablePartitionBehavior {
+    #[serde(rename = "type")]
+    pub partition_type: String,
+    pub columns: Vec<TablePartitionColumn>,
+}
+
+/// A table partition column: either a bare column name or a mapping
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TablePartitionColumn {
+    Name(String),
+    Detailed {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        expression: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        collation: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        opclass: Option<String>,
+    },
+}
+
+/// Table Triggers
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Trigger {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub when: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub for_each: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<Vec<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}

--- a/src/models/text_search.rs
+++ b/src/models/text_search.rs
@@ -1,0 +1,87 @@
+//! Text search configurations, dictionaries, parsers, and templates
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Represents a complex object for text search
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TextSearch {
+    pub schema: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configurations: Option<Vec<TextSearchConfig>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dictionaries: Option<Vec<TextSearchDict>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parsers: Option<Vec<TextSearchParser>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub templates: Option<Vec<TextSearchTemplate>>,
+}
+
+/// Represents a configuration object for Text Search
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TextSearchConfig {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parser: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a dictionary object for Text Search
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TextSearchDict {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a parser object for Text Search
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TextSearchParser {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gettoken_function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lextypes_function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headline_function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a template for Text Search
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TextSearchTemplate {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lexize_function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub init_function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -1,0 +1,79 @@
+//! User defined data types
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Represents a user defined data type
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Type {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub type_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receive: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub send: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub typmod_in: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub typmod_out: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub analyze: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub internal_length: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub passed_by_value: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alignment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub like_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preferred: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub element: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delimiter: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collatable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub columns: Option<Vec<TypeColumn>>,
+    #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subtype: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subtype_opclass: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subtype_diff: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Represents a column in a composite type
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TypeColumn {
+    pub name: String,
+    pub data_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collation: Option<String>,
+}

--- a/src/models/views.rs
+++ b/src/models/views.rs
@@ -1,0 +1,63 @@
+//! Views and materialized views
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Represents a View
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct View {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recursive: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub columns: Option<Vec<ViewColumn>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub check_option: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security_barrier: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// A column in a view or materialized view: a bare name or a mapping
+/// with a name and comment
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ViewColumn {
+    Name(String),
+    Detailed {
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        comment: Option<String>,
+    },
+}
+
+/// Represents a Materialized View
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MaterializedView {
+    pub name: String,
+    pub schema: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub columns: Option<Vec<ViewColumn>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table_access_method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_parameters: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tablespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}

--- a/src/project/load.rs
+++ b/src/project/load.rs
@@ -1,0 +1,467 @@
+//! The project directory loader (ports the load half of project.py)
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::constants::{DEPENDENCIES, ObjectType, READ_ORDER};
+use crate::models::{Definition, Item};
+use crate::project::{Project, validate};
+use crate::yamlio;
+
+/// A dependency recorded during the read pass and resolved once the
+/// whole inventory is in memory (project.py _ItemDependency)
+struct CachedDependency {
+    desc: ObjectType,
+    namespace: Option<String>,
+    tag: String,
+    parent_desc: ObjectType,
+    parent_namespace: String,
+    parent_tag: String,
+}
+
+pub struct Loader {
+    project: Project,
+    cached_dependencies: Vec<CachedDependency>,
+    errors: usize,
+}
+
+impl Loader {
+    pub fn new(path: &Path) -> Self {
+        Self {
+            project: Project {
+                name: String::from("postgres"),
+                encoding: String::from("UTF8"),
+                stdstrings: true,
+                superuser: String::from("postgres"),
+                default_schema: String::from("public"),
+                path: path.to_path_buf(),
+                inventory: Vec::new(),
+            },
+            cached_dependencies: Vec::new(),
+            errors: 0,
+        }
+    }
+
+    pub fn load(mut self) -> Result<Project, String> {
+        self.read_project_file()?;
+        for ot in READ_ORDER {
+            if ot.is_per_schema_file() {
+                self.read_container_files(*ot)?;
+            } else {
+                self.read_object_files(*ot)?;
+            }
+        }
+        for ot in [
+            ObjectType::Group,
+            ObjectType::Role,
+            ObjectType::User,
+            ObjectType::UserMapping,
+        ] {
+            self.read_object_files(ot)?;
+        }
+        self.apply_cached_dependencies()?;
+        if self.errors > 0 {
+            log::error!("Project load failed with {} errors", self.errors);
+            return Err(String::from("Project load failure"));
+        }
+        log::info!("Project loaded");
+        Ok(self.project)
+    }
+
+    fn read_project_file(&mut self) -> Result<(), String> {
+        log::info!("Loading project from {}", self.project.path.display());
+        let path = self.project.path.join("project.yaml");
+        if !path.exists() {
+            return Err(String::from("Missing project file"));
+        }
+        let project = yamlio::load(&path)?;
+        if !validate::validate_object("project", "project.yaml", &project) {
+            self.errors += 1;
+        }
+        if let Some(name) = project["name"].as_str() {
+            self.project.name = name.to_string();
+        }
+        if let Some(encoding) = project["encoding"].as_str() {
+            self.project.encoding = encoding.to_string();
+        }
+        for entry in array_field(&project, "extensions") {
+            self.add_definition(ObjectType::Extension, entry);
+        }
+        for mut entry in array_field(&project, "foreign_data_wrappers") {
+            inject(&mut entry, "owner", &self.project.superuser);
+            self.add_definition(ObjectType::ForeignDataWrapper, entry);
+        }
+        for entry in array_field(&project, "languages") {
+            self.add_definition(ObjectType::ProceduralLanguage, entry);
+        }
+        Ok(())
+    }
+
+    /// Read regular one-object-per-file definitions
+    fn read_object_files(&mut self, ot: ObjectType) -> Result<(), String> {
+        log::debug!("Reading {} definitions", ot.as_str());
+        for (mut defn, _) in self.iterate_files(ot)? {
+            let name = object_name(&defn)?;
+            if !validate::validate_object(&ot.schema_file(), &name, &defn) {
+                self.errors += 1;
+                continue;
+            }
+            self.cache_and_remove_dependencies(ot, &mut defn);
+            self.add_definition(ot, defn);
+        }
+        Ok(())
+    }
+
+    /// Read per-schema container files: casts, conversions, operators,
+    /// text search, and types (project.py _read_objects_files)
+    fn read_container_files(&mut self, ot: ObjectType) -> Result<(), String> {
+        log::debug!("Reading {} objects", ot.as_str());
+        let key = ot.plural_key();
+        for (mut container, _) in self.iterate_files(ot)? {
+            let container_schema =
+                container["schema"].as_str().unwrap_or_default().to_string();
+            if !validate::validate_object(key, &container_schema, &container) {
+                self.errors += 1;
+                continue;
+            }
+            if ot == ObjectType::TextSearch {
+                self.add_definition(ot, container);
+                continue;
+            }
+            let owner =
+                container["owner"].as_str().unwrap_or_default().to_string();
+            let Value::Array(entries) = container[key].take() else {
+                continue;
+            };
+            for mut entry in entries {
+                inject(&mut entry, "owner", &owner);
+                inject(&mut entry, "schema", &container_schema);
+                let name = if ot == ObjectType::Cast {
+                    format!(
+                        "({} AS {})",
+                        entry["source_type"].as_str().unwrap_or_default(),
+                        entry["target_type"].as_str().unwrap_or_default()
+                    )
+                } else {
+                    object_name(&entry)?
+                };
+                if !validate::validate_object(&ot.schema_file(), &name, &entry)
+                {
+                    self.errors += 1;
+                    continue;
+                }
+                self.cache_and_remove_dependencies(ot, &mut entry);
+                self.add_definition(ot, entry);
+            }
+        }
+        Ok(())
+    }
+
+    /// Yield preprocessed definitions for every YAML file of an object
+    /// type, in sorted path order (project.py _iterate_files)
+    fn iterate_files(
+        &mut self,
+        ot: ObjectType,
+    ) -> Result<Vec<(Value, PathBuf)>, String> {
+        let Some(subdir) = ot.path() else {
+            return Ok(Vec::new());
+        };
+        let path = self.project.path.join(subdir);
+        if !path.exists() {
+            log::warn!("No {} file found in project", ot.as_str());
+            return Ok(Vec::new());
+        }
+        let mut results = Vec::new();
+        for child in sorted_dir(&path)? {
+            if child.is_dir() {
+                for s_child in sorted_dir(&child)? {
+                    if yamlio::is_yaml(&s_child) {
+                        let defn = self.preprocess_definition(
+                            ot,
+                            &dir_name(&child),
+                            Some(&file_stem(&s_child)),
+                            yamlio::load(&s_child)?,
+                        );
+                        results.push((defn, s_child));
+                    }
+                }
+            } else if yamlio::is_yaml(&child) {
+                let defn = self.preprocess_definition(
+                    ot,
+                    &file_stem(&child),
+                    None,
+                    yamlio::load(&child)?,
+                );
+                results.push((defn, child));
+            }
+        }
+        Ok(results)
+    }
+
+    /// Inject schema, name, and owner defaults derived from the file
+    /// location (project.py _preprocess_definition)
+    fn preprocess_definition(
+        &self,
+        ot: ObjectType,
+        schema: &str,
+        name: Option<&str>,
+        mut defn: Value,
+    ) -> Value {
+        if !ot.is_schemaless() {
+            inject(&mut defn, "schema", schema);
+        }
+        if let Some(name) = name {
+            inject(&mut defn, "name", name);
+        }
+        if !ot.is_ownerless() {
+            inject(&mut defn, "owner", &self.project.superuser);
+        }
+        defn
+    }
+
+    /// Record `dependencies` for post-load resolution and strip the key
+    /// from the definition (project.py _cache_and_remove_dependencies)
+    fn cache_and_remove_dependencies(
+        &mut self,
+        desc: ObjectType,
+        defn: &mut Value,
+    ) {
+        let namespace = defn["schema"].as_str().map(str::to_string);
+        let tag = defn["name"].as_str().unwrap_or_default().to_string();
+        if let Value::Object(deps) = defn[DEPENDENCIES].take() {
+            for (key, names) in &deps {
+                let Some(parent_desc) = ObjectType::from_plural_key(key)
+                else {
+                    log::error!("Unknown dependency type {key:?}");
+                    self.errors += 1;
+                    continue;
+                };
+                for name in names.as_array().into_iter().flatten() {
+                    let name = name.as_str().unwrap_or_default();
+                    let (parent_namespace, parent_tag) = split_name(name);
+                    self.cached_dependencies.push(CachedDependency {
+                        desc,
+                        namespace: namespace.clone(),
+                        tag: tag.clone(),
+                        parent_desc,
+                        parent_namespace,
+                        parent_tag,
+                    });
+                }
+            }
+        }
+        if let Value::Object(map) = defn {
+            map.remove(DEPENDENCIES);
+        }
+    }
+
+    fn apply_cached_dependencies(&mut self) -> Result<(), String> {
+        for dep in &self.cached_dependencies {
+            let item = lookup_item(
+                &self.project.inventory,
+                dep.desc,
+                dep.namespace.as_deref(),
+                &dep.tag,
+            )
+            .ok_or_else(|| {
+                format!(
+                    "Failed to find {} {}.{} for {} {}.{}",
+                    dep.desc.as_str(),
+                    dep.namespace.as_deref().unwrap_or_default(),
+                    dep.tag,
+                    dep.parent_desc.as_str(),
+                    dep.parent_namespace,
+                    dep.parent_tag,
+                )
+            })?;
+            let parent = lookup_item(
+                &self.project.inventory,
+                dep.parent_desc,
+                Some(&dep.parent_namespace),
+                &dep.parent_tag,
+            )
+            .ok_or_else(|| {
+                format!(
+                    "Failed to find parent {} {}.{} for {} {}.{}",
+                    dep.parent_desc.as_str(),
+                    dep.parent_namespace,
+                    dep.parent_tag,
+                    dep.desc.as_str(),
+                    dep.namespace.as_deref().unwrap_or_default(),
+                    dep.tag,
+                )
+            })?;
+            self.project.inventory[item].dependencies.insert(parent);
+        }
+        Ok(())
+    }
+
+    /// Deserialize a definition into its model and add it to the
+    /// inventory, verifying the model round-trips to the same value
+    fn add_definition(&mut self, ot: ObjectType, value: Value) {
+        let definition = match to_definition(ot, value.clone()) {
+            Ok(definition) => definition,
+            Err(error) => {
+                log::error!(
+                    "Failed to load {} definition: {error}",
+                    ot.as_str()
+                );
+                self.errors += 1;
+                return;
+            }
+        };
+        let round_trip = serde_json::to_value(&definition)
+            .expect("model serialization cannot fail");
+        let normalized = strip_nulls(value);
+        if round_trip != normalized {
+            log::error!(
+                "{} {} did not round-trip: {normalized} != {round_trip}",
+                ot.as_str(),
+                definition.name(),
+            );
+            self.errors += 1;
+            return;
+        }
+        self.project.inventory.push(Item {
+            id: self.project.inventory.len(),
+            desc: ot,
+            definition,
+            dependencies: BTreeSet::new(),
+        });
+    }
+}
+
+/// Find an inventory item by type, schema, and name
+/// (project.py _lookup_item)
+fn lookup_item(
+    inventory: &[Item],
+    desc: ObjectType,
+    namespace: Option<&str>,
+    tag: &str,
+) -> Option<usize> {
+    inventory
+        .iter()
+        .find(|item| {
+            item.desc == desc
+                && item.definition.name() == tag
+                && (desc.is_schemaless()
+                    || item.definition.schema() == namespace)
+        })
+        .map(|item| item.id)
+}
+
+fn to_definition(
+    ot: ObjectType,
+    value: Value,
+) -> Result<Definition, serde_json::Error> {
+    use serde_json::from_value as from;
+    Ok(match ot {
+        ObjectType::Aggregate => Definition::Aggregate(from(value)?),
+        ObjectType::Cast => Definition::Cast(from(value)?),
+        ObjectType::Collation => Definition::Collation(from(value)?),
+        ObjectType::Conversion => Definition::Conversion(from(value)?),
+        ObjectType::Domain => Definition::Domain(from(value)?),
+        ObjectType::EventTrigger => Definition::EventTrigger(from(value)?),
+        ObjectType::Extension => Definition::Extension(from(value)?),
+        ObjectType::ForeignDataWrapper => {
+            Definition::ForeignDataWrapper(from(value)?)
+        }
+        ObjectType::Function => Definition::Function(from(value)?),
+        ObjectType::Group => Definition::Group(from(value)?),
+        ObjectType::MaterializedView => {
+            Definition::MaterializedView(from(value)?)
+        }
+        ObjectType::Operator => Definition::Operator(from(value)?),
+        ObjectType::ProceduralLanguage => Definition::Language(from(value)?),
+        ObjectType::Publication => Definition::Publication(from(value)?),
+        ObjectType::Role => Definition::Role(from(value)?),
+        ObjectType::Schema => Definition::Schema(from(value)?),
+        ObjectType::Sequence => Definition::Sequence(from(value)?),
+        ObjectType::Server => Definition::Server(from(value)?),
+        ObjectType::Subscription => Definition::Subscription(from(value)?),
+        ObjectType::Table => Definition::Table(from(value)?),
+        ObjectType::Tablespace => Definition::Tablespace(from(value)?),
+        ObjectType::TextSearch => Definition::TextSearch(from(value)?),
+        ObjectType::Type => Definition::Type(from(value)?),
+        ObjectType::User => Definition::User(from(value)?),
+        ObjectType::UserMapping => Definition::UserMapping(from(value)?),
+        ObjectType::View => Definition::View(from(value)?),
+    })
+}
+
+/// `schema.name` for logging (project.py _object_name); name is required
+fn object_name(defn: &Value) -> Result<String, String> {
+    let Some(name) = defn["name"].as_str() else {
+        log::error!("name missing from definition: {defn}");
+        return Err(String::from("Missing object name"));
+    };
+    match defn["schema"].as_str() {
+        Some(schema) => Ok(format!("{schema}.{name}")),
+        None => Ok(name.to_string()),
+    }
+}
+
+/// Set a string key on a mapping unless it is already present
+fn inject(defn: &mut Value, key: &str, value: &str) {
+    if let Value::Object(map) = defn {
+        if !map.contains_key(key) {
+            map.insert(key.to_string(), Value::String(value.to_string()));
+        }
+    }
+}
+
+fn array_field(value: &Value, key: &str) -> Vec<Value> {
+    value[key].as_array().cloned().unwrap_or_default()
+}
+
+/// `schema.name` → (schema, name); unqualified names get an empty
+/// namespace (utils.split_name)
+fn split_name(value: &str) -> (String, String) {
+    match value.split_once('.') {
+        Some((namespace, tag)) => (namespace.to_string(), tag.to_string()),
+        None => (String::new(), value.to_string()),
+    }
+}
+
+/// Drop null-valued keys so explicit YAML nulls compare equal to
+/// omitted optional fields in round-trip verification
+fn strip_nulls(value: Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .filter(|(_, v)| !v.is_null())
+                .map(|(k, v)| (k, strip_nulls(v)))
+                .collect(),
+        ),
+        Value::Array(items) => {
+            Value::Array(items.into_iter().map(strip_nulls).collect())
+        }
+        other => other,
+    }
+}
+
+fn sorted_dir(path: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .collect();
+    entries.sort();
+    Ok(entries)
+}
+
+fn file_stem(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|n| n.split('.').next())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn dir_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default()
+        .to_string()
+}

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1,0 +1,25 @@
+//! Project loading and validation (ports project.py)
+
+mod load;
+pub mod validate;
+
+use std::path::PathBuf;
+
+use crate::models;
+
+/// The complete project including all database objects
+#[derive(Debug)]
+pub struct Project {
+    pub name: String,
+    pub encoding: String,
+    pub stdstrings: bool,
+    pub superuser: String,
+    pub default_schema: String,
+    pub path: PathBuf,
+    pub inventory: Vec<models::Item>,
+}
+
+/// Load the project from the specified project directory
+pub fn load(path: &std::path::Path) -> Result<Project, String> {
+    load::Loader::new(path).load()
+}

--- a/src/project/validate.rs
+++ b/src/project/validate.rs
@@ -1,0 +1,129 @@
+//! Data validation using bundled JSON-Schema files (ports validation.py)
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use include_dir::{Dir, include_dir};
+use serde_json::Value;
+
+use crate::yamlio;
+
+static SCHEMATA: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/schemata");
+
+static CACHE: OnceLock<Mutex<HashMap<String, Value>>> = OnceLock::new();
+
+/// Validate a data object against the bundled schema for its type,
+/// logging each validation error. `obj_type` is the schema file stem
+/// form (lowercase, underscores).
+pub fn validate_object(obj_type: &str, name: &str, data: &Value) -> bool {
+    let schema = match load_schema(obj_type) {
+        Ok(schema) => schema,
+        Err(error) => {
+            log::error!("{error}");
+            return false;
+        }
+    };
+    let validator = match jsonschema::validator_for(&schema) {
+        Ok(validator) => validator,
+        Err(error) => {
+            log::error!("Invalid schema for {obj_type}: {error}");
+            return false;
+        }
+    };
+    let mut valid = true;
+    for error in validator.iter_errors(data) {
+        log::error!(
+            "Validation error for {obj_type} {name}: {error} at {}",
+            error.instance_path()
+        );
+        valid = false;
+    }
+    valid
+}
+
+/// Load a schema by object type stem, merging `$package_schema`
+/// references to other bundled schema files
+fn load_schema(obj_type: &str) -> Result<Value, String> {
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Some(schema) = cache.lock().unwrap().get(obj_type) {
+        return Ok(schema.clone());
+    }
+    let file_name = format!("{}.yml", obj_type.replace(' ', "_"));
+    let file = SCHEMATA.get_file(&file_name).ok_or_else(|| {
+        format!("Schema file not found for object type {obj_type:?}")
+    })?;
+    let raw = yamlio::load_str(file.contents_utf8().ok_or_else(|| {
+        format!("Schema file {file_name} is not valid UTF-8")
+    })?)
+    .map_err(|e| format!("Failed to parse schema {file_name}: {e}"))?;
+    let schema = preprocess(&raw)?;
+    cache
+        .lock()
+        .unwrap()
+        .insert(obj_type.to_string(), schema.clone());
+    Ok(schema)
+}
+
+/// Merge in other bundled schemas wherever `$package_schema` appears
+fn preprocess(schema: &Value) -> Result<Value, String> {
+    Ok(match schema {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (key, value) in map {
+                // the bundled files use the draft-agnostic
+                // http://json-schema.org/schema# URI, which this crate
+                // rejects; dropping it applies the default draft, as
+                // Python's jsonschema did
+                if key == "$schema" {
+                    continue;
+                }
+                if key == "$package_schema" {
+                    let name = value.as_str().ok_or_else(|| {
+                        format!("$package_schema is not a string: {value}")
+                    })?;
+                    if let Value::Object(merged) = load_schema(name)? {
+                        out.extend(merged);
+                    }
+                } else {
+                    out.insert(key.clone(), preprocess(value)?);
+                }
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(preprocess)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        other => other.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn validates_a_schema_object() {
+        let data = json!({"name": "test", "owner": "postgres"});
+        assert!(validate_object("schema", "test", &data));
+    }
+
+    #[test]
+    fn rejects_invalid_objects() {
+        let data = json!({"name": 42});
+        assert!(!validate_object("schema", "bad", &data));
+    }
+
+    #[test]
+    fn merges_package_schemas() {
+        // casts.yml composes cast.yml via $package_schema
+        let schema = load_schema("casts").unwrap();
+        let items = &schema["properties"]["casts"]["items"];
+        assert!(items.get("properties").is_some());
+        assert!(items.get("$package_schema").is_none());
+    }
+}

--- a/src/yamlio.rs
+++ b/src/yamlio.rs
@@ -205,6 +205,16 @@ mod tests {
     }
 
     #[test]
+    fn preserves_multiple_trailing_newlines() {
+        for body in ["text\n\n", "text\n\n\n"] {
+            let value = json!({ "body": body });
+            let emitted = dump(&value);
+            assert!(emitted.contains("|+"));
+            assert_eq!(load_str(&emitted).unwrap(), value);
+        }
+    }
+
+    #[test]
     fn quotes_ambiguous_scalars() {
         let value = json!({
             "a": "true", "b": "123", "c": "===", "d": "with: colon",

--- a/src/yamlio.rs
+++ b/src/yamlio.rs
@@ -1,0 +1,215 @@
+//! YAML load/save (ports yaml.py + the ruamel emission style)
+//!
+//! Loading goes through serde_norway into `serde_json::Value` (built with
+//! `preserve_order`, so mappings keep file order). Emission is a small
+//! custom emitter because no maintained serde YAML emitter offers scalar
+//! style control: multi-line strings must emit as literal block scalars
+//! to match the ruamel.yaml output the project format was built on
+//! (mapping indent 2, sequence indent 4, dash offset 2).
+
+use std::fmt::Write;
+use std::path::Path;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+pub fn is_yaml(path: &Path) -> bool {
+    path.is_file()
+        && matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("yml") | Some("yaml")
+        )
+}
+
+pub fn load(path: &Path) -> Result<Value, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    load_str(&content).map_err(|e| {
+        format!("failed to parse YAML from {}: {e}", path.display())
+    })
+}
+
+pub fn load_str(content: &str) -> Result<Value, serde_norway::Error> {
+    Value::deserialize(serde_norway::Deserializer::from_str(content))
+}
+
+/// Render a value as a YAML document with a `---` header
+pub fn dump(value: &Value) -> String {
+    let mut out = String::from("---\n");
+    match value {
+        Value::Object(_) | Value::Array(_) => emit(&mut out, value, 0),
+        scalar => {
+            out.push_str(&scalar_repr(scalar, 0));
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn emit(out: &mut String, value: &Value, indent: usize) {
+    match value {
+        Value::Object(map) => {
+            for (key, val) in map {
+                pad(out, indent);
+                out.push_str(&plain_or_quoted(key));
+                out.push(':');
+                emit_nested(out, val, indent);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                pad(out, indent);
+                out.push('-');
+                emit_nested(out, item, indent + 2);
+            }
+        }
+        scalar => {
+            pad(out, indent);
+            out.push_str(&scalar_repr(scalar, indent));
+            out.push('\n');
+        }
+    }
+}
+
+/// Emit a mapping value or sequence item after its `key:` / `-` prefix
+fn emit_nested(out: &mut String, value: &Value, indent: usize) {
+    match value {
+        Value::Object(map) if !map.is_empty() => {
+            out.push('\n');
+            emit(out, value, indent + 2);
+        }
+        Value::Array(items) if !items.is_empty() => {
+            out.push('\n');
+            emit(out, value, indent + 2);
+        }
+        Value::Object(_) => out.push_str(" {}\n"),
+        Value::Array(_) => out.push_str(" []\n"),
+        scalar => {
+            out.push(' ');
+            out.push_str(&scalar_repr(scalar, indent));
+            out.push('\n');
+        }
+    }
+}
+
+fn pad(out: &mut String, indent: usize) {
+    for _ in 0..indent {
+        out.push(' ');
+    }
+}
+
+fn scalar_repr(value: &Value, indent: usize) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) if s.contains('\n') => block_scalar(s, indent),
+        Value::String(s) => plain_or_quoted(s),
+        _ => unreachable!("containers handled by emit"),
+    }
+}
+
+/// Literal block scalar (`|` / `|-` / `|+`) with content indented two
+/// spaces past the current level, matching ruamel.yaml
+fn block_scalar(value: &str, indent: usize) -> String {
+    let header = if value.ends_with('\n') {
+        if value.ends_with("\n\n") { "|+" } else { "|" }
+    } else {
+        "|-"
+    };
+    let mut out = String::from(header);
+    for line in value.trim_end_matches('\n').split('\n') {
+        out.push('\n');
+        if !line.is_empty() {
+            let _ = write!(out, "{:width$}{line}", "", width = indent + 2);
+        }
+    }
+    for _ in value.trim_end_matches('\n').len()..value.len().saturating_sub(1)
+    {
+        out.push('\n');
+    }
+    out
+}
+
+fn plain_or_quoted(value: &str) -> String {
+    if is_plain_safe(value) {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "''"))
+    }
+}
+
+/// Conservative plain-scalar test: anything ambiguous gets single-quoted
+fn is_plain_safe(value: &str) -> bool {
+    if value.is_empty()
+        || value != value.trim()
+        || value.starts_with([
+            '!', '&', '*', '-', '?', '#', '|', '>', '@', '`', '"', '\'', '%',
+            '[', ']', '{', '}', ',', ' ',
+        ])
+    {
+        return false;
+    }
+    if value.contains(": ")
+        || value.ends_with(':')
+        || value.contains(" #")
+        || value.contains('\t')
+    {
+        return false;
+    }
+    // strings that would parse as another scalar type need quoting
+    let lowered = value.to_ascii_lowercase();
+    if matches!(
+        lowered.as_str(),
+        "null" | "~" | "true" | "false" | "yes" | "no" | "on" | "off"
+    ) {
+        return false;
+    }
+    !looks_numeric(value)
+}
+
+fn looks_numeric(value: &str) -> bool {
+    value.parse::<i64>().is_ok()
+        || value.parse::<f64>().is_ok()
+        || (value.starts_with("0x") && value.len() > 2)
+        || (value.starts_with("0o") && value.len() > 2)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn round_trips_nested_structures() {
+        let value = json!({
+            "name": "users",
+            "columns": [
+                {"name": "id", "nullable": false},
+                {"name": "email", "tags": ["a", "b"]},
+            ],
+            "count": 3,
+            "ratio": 1.5,
+        });
+        let parsed = load_str(&dump(&value)).unwrap();
+        assert_eq!(parsed, value);
+    }
+
+    #[test]
+    fn multiline_strings_emit_literal_blocks() {
+        let value = json!({"query": "SELECT id\n  FROM users\n"});
+        let text = dump(&value);
+        assert!(text.contains("query: |\n  SELECT id\n    FROM users\n"));
+        assert_eq!(load_str(&text).unwrap(), value);
+    }
+
+    #[test]
+    fn quotes_ambiguous_scalars() {
+        let value = json!({
+            "a": "true", "b": "123", "c": "===", "d": "with: colon",
+            "e": "", "f": "trailing \n", "g": "it's",
+        });
+        assert_eq!(load_str(&dump(&value)).unwrap(), value);
+    }
+}

--- a/tests/load.rs
+++ b/tests/load.rs
@@ -1,0 +1,118 @@
+//! Phase 1 gate: the full test-project loads, validates, and every
+//! definition round-trips through its model to a semantically
+//! identical value (the loader itself fails on round-trip mismatch)
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use pglifecycle::{project, yamlio};
+
+#[test]
+fn loads_the_full_test_project() {
+    let project = project::load(Path::new("test-project")).unwrap();
+    assert_eq!(project.name, "test-project");
+    assert_eq!(project.encoding, "UTF-8");
+
+    let mut counts: HashMap<&'static str, usize> = HashMap::new();
+    for item in &project.inventory {
+        *counts.entry(item.desc.as_str()).or_default() += 1;
+    }
+    // one inventory item per definition in test-project/
+    assert_eq!(counts["EXTENSION"], 3);
+    assert_eq!(counts["FOREIGN DATA WRAPPER"], 1);
+    assert_eq!(counts["PROCEDURAL LANGUAGE"], 1);
+    assert_eq!(counts["SCHEMA"], 1);
+    assert_eq!(counts["AGGREGATE"], 1);
+    assert_eq!(counts["CAST"], 1);
+    assert_eq!(counts["COLLATION"], 1);
+    assert_eq!(counts["CONVERSION"], 1);
+    assert_eq!(counts["DOMAIN"], 2);
+    assert_eq!(counts["EVENT TRIGGER"], 1);
+    assert_eq!(counts["FUNCTION"], 3);
+    assert_eq!(counts["GROUP"], 1);
+    assert_eq!(counts["MATERIALIZED VIEW"], 1);
+    assert_eq!(counts["OPERATOR"], 1);
+    assert_eq!(counts["PUBLICATION"], 1);
+    assert_eq!(counts["ROLE"], 1);
+    assert_eq!(counts["SEQUENCE"], 1);
+    assert_eq!(counts["SERVER"], 1);
+    assert_eq!(counts["SUBSCRIPTION"], 1);
+    assert_eq!(counts["TABLE"], 3);
+    assert_eq!(counts["TABLESPACE"], 1);
+    assert_eq!(counts["TEXT SEARCH"], 1);
+    assert_eq!(counts["TYPE"], 4);
+    assert_eq!(counts["USER"], 1);
+    assert_eq!(counts["USER MAPPING"], 1);
+    assert_eq!(counts["VIEW"], 1);
+}
+
+#[test]
+fn resolves_dependencies() {
+    let project = project::load(Path::new("test-project")).unwrap();
+    let mut edges: Vec<String> = project
+        .inventory
+        .iter()
+        .filter(|item| !item.dependencies.is_empty())
+        .map(|item| {
+            let mut parents: Vec<String> = item
+                .dependencies
+                .iter()
+                .map(|dep| {
+                    let parent = &project.inventory[*dep];
+                    format!(
+                        "{}:{}",
+                        parent.desc.as_str(),
+                        parent.definition.name()
+                    )
+                })
+                .collect();
+            parents.sort();
+            format!(
+                "{}:{} -> {}",
+                item.desc.as_str(),
+                item.definition.name(),
+                parents.join(", ")
+            )
+        })
+        .collect();
+    edges.sort();
+    // the exact edge set the Python implementation resolves
+    assert_eq!(
+        edges,
+        vec![
+            "AGGREGATE:test_agg -> \
+             FUNCTION:test_aggregate(integer, integer)",
+            "DOMAIN:bcp47_locale -> EXTENSION:citext",
+            "MATERIALIZED VIEW:user_addresses -> \
+             TABLE:addresses, TABLE:users",
+            "SERVER:localhost -> EXTENSION:postgres_fdw",
+            "TABLE:addresses -> TYPE:address_type",
+            "TABLE:users -> DOMAIN:bcp47_locale, DOMAIN:email_address, \
+             TYPE:user_state",
+            "VIEW:user_addresses -> TABLE:addresses, TABLE:users",
+        ]
+    );
+}
+
+#[test]
+fn definitions_round_trip_through_yaml_emission() {
+    let project = project::load(Path::new("test-project")).unwrap();
+    for item in &project.inventory {
+        let value = serde_json::to_value(&item.definition).unwrap();
+        let emitted = yamlio::dump(&value);
+        let parsed = yamlio::load_str(&emitted).unwrap_or_else(|e| {
+            panic!(
+                "emitted YAML for {} {} failed to parse: {e}\n{emitted}",
+                item.desc.as_str(),
+                item.definition.name()
+            )
+        });
+        assert_eq!(
+            parsed,
+            value,
+            "{} {} changed through emission",
+            item.desc.as_str(),
+            item.definition.name()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Second incremental PR into `rust-rewrite`, porting models.py, yaml.py, validation.py, and the load half of project.py.

- **Models** (`src/models/`): serde structs for all 27 object types; field order matches the Python dataclasses (sets emitted YAML key order); `deny_unknown_fields` mirrors `dataclass(**defn)` strictness; flexible YAML shapes (`primary_key` as string/list/object, view columns as string/mapping) use untagged enums.
- **YAML I/O** (`src/yamlio.rs`): loading via serde_norway into insertion-ordered `serde_json::Value`. The PLAN.md emitter spike resolved in favor of a small custom emitter — no maintained serde YAML emitter offers scalar-style control, and the project format needs literal block scalars and ruamel-style indentation for clean diffs.
- **Validation** (`src/project/validate.rs`): `schemata/` embedded via `include_dir`, `$package_schema` composition ported. The bundled files' draft-agnostic `$schema` URI is stripped (the jsonschema crate rejects it; Python treated it as latest-draft).
- **Loader** (`src/project/load.rs`): read order, per-schema container files, schema/name/owner injection from file layout, dependency caching/resolution. Every definition is verified to round-trip model → value against its preprocessed source, so model drift fails the load.

## Phase 1 gate

`test-project/` loads and validates with the **same 36-item inventory and the same 7 dependency edges as the Python implementation** (verified against the oracle, pinned in `tests/load.rs`), and every definition survives YAML emission round-trip.

## Intentional deviations

- Role/group/user validation failures count as load errors (Python ignored the result).
- Missing `extensions`/`foreign_data_wrappers`/`languages` keys in project.yaml are treated as empty (Python crashed on `None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load and validate YAML project files with JSON-Schema validation and detailed errors.
  * Broad support for many database object types and deterministic inventory loading with dependency resolution.
  * Improved YAML load/dump with ruamel-style formatting and safe multiline/string handling.
  * Public library surface expanded for CLI, project, models, skeleton, and YAML I/O.

* **Tests**
  * Integration tests for project loading, dependency resolution, and YAML round-tripping.

* **Chores**
  * Updated dependencies and manifest entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->