### PR TITLE
Phase 2: the build command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .venv
 .vscode
-build/
+/build/
 site/
-target/
+/target/
+!/src/build/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +139,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +201,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "data-encoding"
@@ -251,6 +278,22 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fluent-uri"
@@ -496,6 +539,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +604,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libpgdump"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4340abdd7461f03fd10b6566f5eb13f595e49d041d8ee667ea6a1549a4031c7"
+dependencies = [
+ "flate2",
+ "lz4_flex",
+ "tempfile",
+ "thiserror",
+ "zstd",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +663,16 @@ name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "num"
@@ -737,6 +822,7 @@ dependencies = [
  "clap",
  "include_dir",
  "jsonschema",
+ "libpgdump",
  "log",
  "serde",
  "serde_json",
@@ -744,6 +830,12 @@ dependencies = [
  "simplelog",
  "tempfile",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -970,6 +1062,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simplelog"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1147,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1208,12 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "unicode-general-category"
@@ -1466,3 +1596,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,13 @@ edition = "2024"
 description = "PostgreSQL schema management tool"
 license = "BSD-3-Clause"
 repository = "https://github.com/gmr/pglifecycle"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 include_dir = "0.7.4"
 jsonschema = { version = "0.46.5", default-features = false }
+libpgdump = "2.1"
 log = "0.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150", features = ["preserve_order"] }
@@ -18,6 +19,7 @@ serde_norway = "0.9.42"
 simplelog = "0.12"
 
 [dev-dependencies]
+libpgdump = "2.1"
 tempfile = "3"
 
 [profile.release]

--- a/PLAN.md
+++ b/PLAN.md
@@ -47,7 +47,7 @@ selected pieces of [postgres-lsp](https://crates.io/crates/postgres-lsp-parse).
 | — (new capability) | SQL/PL-pgSQL formatting for clean YAML diffs | **libpgfmt 1.1** — format view queries and function bodies during `generate` |
 | ruamel.yaml | YAML I/O with literal block scalars | serde + a YAML emitter with scalar-style control (see Risks) |
 | jsonschema | Validate YAML objects against `schemata/*.yml` | **jsonschema** crate (Stranger6667) — validate via `serde_json::Value` |
-| toposort | Build-order linearization | **petgraph** for the project-level graph; libpgdump also re-sorts entries on `save()` as a backstop |
+| toposort | Build-order linearization | **libpgdump's weighted topological sort** (the pg_dump_sort.c port run by `save()`) — inventory dependency edges are recorded on the archive entries and ordering is delegated entirely to it; no petgraph |
 | argparse | CLI | **clap** (derive) |
 | pg_dump subprocess (`pgdump.py`) | Extract schema from live database | unchanged — `std::process::Command` wrapping `pg_dump -Fc` |
 | stringcase, arrow, python-dotenv, faker | Misc / dev-only | heck (case conversion); the rest are fixture-generation only and stay in `bin/` as-is |
@@ -103,7 +103,6 @@ src/
 ├── project/           # load, validate, dependency graph (project.py)
 │   ├── load.rs        #   YAML walk in _READ_ORDER
 │   ├── validate.rs    #   jsonschema against schemata/*.yml (validation.py)
-│   └── graph.rs       #   petgraph toposort (replaces toposort)
 ├── build/             # project → libpgdump archive (dump.py, 1,555 lines)
 │   ├── mod.rs         #   per-object SQL rendering
 │   └── acls.rs        #   GRANT/REVOKE generation
@@ -169,8 +168,9 @@ in both but differs.
 
 - **Pipeline:** load + validate the repo (the `build` front half) → snapshot
   the live database into the same models (the `pull` front half) → `diff` →
-  render an ordered DDL script. Creates are ordered by the petgraph
-  toposort; drops in reverse topological order.
+  render an ordered DDL script. Creates are ordered by libpgdump's
+  weighted toposort over the dependency edges; drops in reverse
+  topological order.
 - **Output first, execution second.** Default is a plan: the SQL script on
   stdout (or `-o FILE`) plus a human-readable summary. `--apply` executes
   it, wrapped in a single transaction (PostgreSQL DDL is transactional;
@@ -212,8 +212,9 @@ ships something testable against the Python implementation.
   byte-diff — see Risks).
 
 ### Phase 2 — `build`
-- Dependency caching/application, petgraph toposort, per-object SQL
-  rendering, ACLs, comments; emit via `libpgdump::new()` + `add_entry()`.
+- Dependency caching/application, per-object SQL rendering, ACLs,
+  comments; emit via `libpgdump::new()` + `add_entry()`, recording
+  dependency edges so libpgdump's weighted toposort orders the archive.
 - This ports `dump.py`, the largest and highest-complexity module.
 - **Gate (parity):** build `test-project/` with both implementations;
   compare archives entry-by-entry (`libpgdump::load` both, diff

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,0 +1,1857 @@
+//! Build a pg_restore-compatible archive from a project (ports dump.py)
+//!
+//! Rendering is bug-for-bug faithful to the Python implementation so
+//! the Phase 2 parity gate can compare archives entry-by-entry, except
+//! where the Python output was unambiguously broken SQL. Those fixes
+//! are listed in tests/build_parity.rs as explicit deviations:
+//!
+//! 1. BYPASSRLS for roles/users renders from `bypass_rls` (Python read
+//!    `create_db`)
+//! 2. Primary keys render from the YAML value (Python's loader turned
+//!    them into an empty list and silently dropped them)
+//! 3. Unique constraint INCLUDE columns render as `INCLUDE (...)`
+//! 4. Foreign keys render `ON DELETE` / `ON UPDATE` (Python emitted
+//!    `ON_DELETE` / `ON_UPDATE`)
+//! 5. Text search entries are tagged with the object name and proper
+//!    option clauses (Python tagged them with the comment text and
+//!    interpolated Python list reprs into the SQL)
+//! 6. Event trigger filters render `WHEN TAG IN ('x', 'y')` (Python
+//!    interpolated a Python list repr)
+//! 7. Table column collations render `COLLATE x` (Python crashed)
+//! 8. Base/range type options render from their own fields (Python
+//!    read `receive` for SEND and `subtype` for SUBTYPE_OPCLASS)
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+use crate::models::{
+    Acls, Column, ConstraintColumns, Definition, Index, Item, RoleOptions,
+    TablePartitionColumn, Trigger, ViewColumn,
+};
+use crate::project::Project;
+use crate::utils::{postgres_value, quote_ident, raw_value};
+
+pub fn build(project: &Project, destination: &Path) -> Result<(), String> {
+    log::info!(
+        "Saving build artifact to {} for {}",
+        destination.display(),
+        project.name
+    );
+    let dump = libpgdump::new(&project.name, &project.encoding, "18.0")
+        .map_err(|e| e.to_string())?;
+    let mut builder = Builder {
+        dump,
+        dump_id_map: HashMap::new(),
+        superuser: project.superuser.clone(),
+    };
+    for item in &project.inventory {
+        builder.dump_item(item)?;
+    }
+    // record inventory dependency edges on the entries so the weighted
+    // pg_dump topological sort in libpgdump (run by save) can order
+    // them; the Python implementation instead pre-ordered its adds with
+    // a flat toposort and recorded no edges
+    for item in &project.inventory {
+        if item.dependencies.is_empty() {
+            continue;
+        }
+        let deps: Vec<i32> = item
+            .dependencies
+            .iter()
+            .filter_map(|dep| builder.dump_id_map.get(dep).copied())
+            .collect();
+        if let Some(dump_id) = builder.dump_id_map.get(&item.id)
+            && let Some(entry) = builder.dump.get_entry_mut(*dump_id)
+        {
+            entry.dependencies.extend(deps);
+        }
+    }
+    builder
+        .dump
+        .save(destination)
+        .map_err(|e| format!("failed to save archive: {e}"))?;
+    log::debug!(
+        "Saved pg_dump -Fc compatible dump to {} with {} entries",
+        destination.display(),
+        builder.dump.entries().len(),
+    );
+    Ok(())
+}
+
+struct Builder {
+    dump: libpgdump::Dump,
+    dump_id_map: HashMap<usize, i32>,
+    superuser: String,
+}
+
+impl Builder {
+    fn dump_item(&mut self, item: &Item) -> Result<(), String> {
+        match &item.definition {
+            Definition::Aggregate(_) => self.dump_aggregate(item),
+            Definition::Cast(_) => self.dump_cast(item),
+            Definition::Collation(_) => self.dump_collation(item),
+            Definition::Conversion(_) => self.dump_conversion(item),
+            Definition::Domain(_) => self.dump_domain(item),
+            Definition::EventTrigger(_) => self.dump_event_trigger(item),
+            Definition::Extension(_) => self.dump_extension(item),
+            Definition::ForeignDataWrapper(_) => self.dump_fdw(item),
+            Definition::Function(_) => self.dump_function(item),
+            Definition::Group(_) => self.dump_group(item),
+            Definition::Language(_) => self.dump_language(item),
+            Definition::MaterializedView(_) => {
+                self.dump_materialized_view(item)
+            }
+            Definition::Operator(_) => self.dump_operator(item),
+            Definition::Publication(_) => self.dump_publication(item),
+            Definition::Role(_) => self.dump_role(item),
+            Definition::Schema(_) => self.dump_schema(item),
+            Definition::Sequence(_) => self.dump_sequence(item),
+            Definition::Server(_) => self.dump_server(item),
+            Definition::Subscription(_) => self.dump_subscription(item),
+            Definition::Table(_) => self.dump_table(item),
+            Definition::Tablespace(_) => self.dump_tablespace(item),
+            Definition::TextSearch(_) => self.dump_text_search(item),
+            Definition::Type(_) => self.dump_type(item),
+            Definition::User(_) => self.dump_user(item),
+            Definition::UserMapping(_) => self.dump_user_mapping(item),
+            Definition::View(_) => self.dump_view(item),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn add_entry(
+        &mut self,
+        desc: &str,
+        namespace: &str,
+        tag: &str,
+        owner: &str,
+        defn: &[String],
+        drop_stmt: &[String],
+        dependencies: &[i32],
+        tablespace: Option<&str>,
+    ) -> Result<i32, String> {
+        log::debug!("Adding {desc} {namespace}.{tag}");
+        let dump_id = self
+            .dump
+            .add_entry(
+                libpgdump::ObjectType::from(desc),
+                Some(namespace),
+                Some(tag),
+                Some(owner),
+                Some(&format!("{};\n", defn.join(" "))),
+                Some(&format!("{};\n", drop_stmt.join(" "))),
+                None,
+                dependencies,
+            )
+            .map_err(|e| format!("failed to add {desc} {tag}: {e}"))?;
+        if let Some(tablespace) = tablespace
+            && let Some(entry) = self.dump.get_entry_mut(dump_id)
+        {
+            entry.tablespace = Some(tablespace.to_string());
+        }
+        Ok(dump_id)
+    }
+
+    /// Add the entry for an inventory item plus its comment entry
+    /// (ports _add_item)
+    fn add_item(
+        &mut self,
+        item: &Item,
+        defn: Vec<String>,
+        drop_stmt: Vec<String>,
+        no_owner: bool,
+    ) -> Result<(), String> {
+        let namespace =
+            item.definition.schema().unwrap_or_default().to_string();
+        let tag = item.definition.name();
+        let owner = match item.definition.owner() {
+            Some(owner) => owner.to_string(),
+            None if no_owner => String::new(),
+            None => self.superuser.clone(),
+        };
+        let tablespace = item.definition.tablespace().map(str::to_string);
+        let dump_id = self.add_entry(
+            item.desc.as_str(),
+            &namespace,
+            &tag,
+            &owner,
+            &defn,
+            &drop_stmt,
+            &[],
+            tablespace.as_deref(),
+        )?;
+        self.dump_id_map.insert(item.id, dump_id);
+        if let Some(comment) = item.definition.comment() {
+            self.add_comment(
+                item.desc.as_str(),
+                &namespace,
+                &tag,
+                &owner,
+                dump_id,
+                comment,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Add a COMMENT ON entry tied to its parent (ports _add_comment)
+    fn add_comment(
+        &mut self,
+        desc: &str,
+        namespace: &str,
+        tag: &str,
+        owner: &str,
+        parent_dump_id: i32,
+        comment: &str,
+    ) -> Result<(), String> {
+        let name = if namespace.is_empty() {
+            tag.to_string()
+        } else {
+            format!("{namespace}.{tag}")
+        };
+        let defn = vec![
+            String::from("COMMENT"),
+            String::from("ON"),
+            desc.to_string(),
+            name,
+            String::from("IS"),
+            format!("$${comment}$$;\n"),
+        ];
+        self.add_entry(
+            "COMMENT",
+            namespace,
+            tag,
+            owner,
+            &defn,
+            &[],
+            &[parent_dump_id],
+            None,
+        )?;
+        Ok(())
+    }
+
+    /// `schema.name` with identifier quoting (ports _item_name)
+    fn item_name(&self, item: &Item) -> String {
+        let name = item.definition.name();
+        match item.definition.schema() {
+            Some(schema) if !schema.is_empty() => {
+                format!("{}.{}", quote_ident(schema), quote_ident(&name))
+            }
+            _ => quote_ident(&name),
+        }
+    }
+
+    fn dump_aggregate(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Aggregate(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let mut create =
+            vec!["CREATE".into(), "AGGREGATE".into(), self.item_name(item)];
+        let args: Vec<String> = d
+            .arguments
+            .iter()
+            .map(|a| {
+                let mut arg = vec![a.mode.clone().unwrap_or("IN".into())];
+                if let Some(name) = &a.name {
+                    arg.push(name.clone());
+                }
+                arg.push(a.data_type.clone());
+                arg.join(" ")
+            })
+            .collect();
+        create.push(format!("({})", args.join(", ")));
+        let mut options = vec![
+            format!("SFUNC = {}", d.sfunc),
+            format!("STYPE = {}", d.state_data_type),
+        ];
+        if let Some(v) = d.state_data_size {
+            options.push(format!("SSPACE = {v}"));
+        }
+        if let Some(v) = &d.ffunc {
+            options.push(format!("FINALFUNC = {v}"));
+        }
+        if d.finalfunc_extra == Some(true) {
+            options.push("FINALFUNC_EXTRA = True".into());
+        }
+        if let Some(v) = &d.finalfunc_modify {
+            options.push(format!("FINALFUNC_MODIFY = {v}"));
+        }
+        if let Some(v) = &d.combinefunc {
+            options.push(format!("COMBINEFUNC = {v}"));
+        }
+        if let Some(v) = &d.serialfunc {
+            options.push(format!("SERIALFUNC = {v}"));
+        }
+        if let Some(v) = &d.deserialfunc {
+            options.push(format!("DESERIALFUNC = {v}"));
+        }
+        if let Some(v) = &d.initial_condition {
+            options.push(format!("INITCOND = {v}"));
+        }
+        if let Some(v) = &d.msfunc {
+            options.push(format!("MSFUNC = {v}"));
+        }
+        if let Some(v) = &d.minvfunc {
+            options.push(format!("MINVFUNC = {v}"));
+        }
+        if let Some(v) = &d.mstate_data_type {
+            options.push(format!("MSTYPE = {v}"));
+        }
+        if let Some(v) = d.mstate_data_size {
+            options.push(format!("MSSPACE = {v}"));
+        }
+        if let Some(v) = &d.mffunc {
+            options.push(format!("MFINALFUNC = {v}"));
+        }
+        if d.mfinalfunc_extra == Some(true) {
+            options.push("MFINALFUNC_EXTRA".into());
+        }
+        if let Some(v) = &d.mfinalfunc_modify {
+            options.push(format!("MFINALFUNC_MODIFY = {v}"));
+        }
+        if let Some(v) = &d.minitial_condition {
+            options.push(format!("MINITCOND = {v}"));
+        }
+        if let Some(v) = &d.sort_operator {
+            options.push(format!("SORTOP = {v}"));
+        }
+        if let Some(v) = &d.parallel {
+            options.push(format!("PARALLEL = {v}"));
+        }
+        if d.hypothetical == Some(true) {
+            options.push("HYPOTHETICAL".into());
+        }
+        create.push(format!("({})", options.join(", ")));
+        let drop = vec![
+            "DROP AGGREGATE IF EXISTS".into(),
+            self.item_name(item),
+            format!("({})", args.join(", ")),
+        ];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_cast(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Cast(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let name = format!(
+            "({} AS {})",
+            quote_ident(d.source_type.as_deref().unwrap_or_default()),
+            quote_ident(d.target_type.as_deref().unwrap_or_default())
+        );
+        let mut create = vec!["CREATE".into(), "CAST".into(), name.clone()];
+        if let Some(function) = &d.function {
+            create.push("WITH FUNCTION".into());
+            create.push(function.clone());
+        } else if d.inout == Some(true) {
+            create.push("WITH INOUT".into());
+        } else {
+            create.push("WITHOUT FUNCTION".into());
+        }
+        if d.assignment == Some(true) {
+            create.push("AS ASSIGNMENT".into());
+        }
+        if d.implicit == Some(true) {
+            create.push("AS IMPLICIT".into());
+        }
+        let drop = vec!["DROP CAST IF EXISTS".into(), name];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_collation(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Collation(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let mut create =
+            vec!["CREATE".into(), "COLLATION".into(), self.item_name(item)];
+        if let Some(copy_from) = &d.copy_from {
+            create.push("FROM".into());
+            create.push(copy_from.clone());
+        } else {
+            let mut options = Vec::new();
+            if let Some(v) = &d.locale {
+                options.push(format!("LOCALE = {v}"));
+            }
+            if let Some(v) = &d.lc_collate {
+                options.push(format!("LC_COLLATE = {v}"));
+            }
+            if let Some(v) = &d.lc_ctype {
+                options.push(format!("LC_CTYPE = {v}"));
+            }
+            if let Some(v) = &d.provider {
+                options.push(format!("PROVIDER = {v}"));
+            }
+            if d.deterministic == Some(true) {
+                options.push("DETERMINISTIC = True".into());
+            }
+            if let Some(v) = &d.version {
+                options.push(format!("VERSION = {v}"));
+            }
+            create.push(format!("({})", options.join(", ")));
+        }
+        let drop =
+            vec!["DROP COLLATION IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_conversion(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Conversion(d) = &item.definition else {
+            unreachable!()
+        };
+        let create = if let Some(sql) = &d.sql {
+            vec![sql.clone()]
+        } else {
+            let mut create = vec!["CREATE".into()];
+            if d.default == Some(true) {
+                create.push("DEFAULT".into());
+            }
+            create.push("CONVERSION".into());
+            create.push(self.item_name(item));
+            create.push("FOR".into());
+            create.push(d.encoding_from.clone().unwrap_or_default());
+            create.push("TO".into());
+            create.push(d.encoding_to.clone().unwrap_or_default());
+            create.push("FROM".into());
+            create.push(d.function.clone().unwrap_or_default());
+            create
+        };
+        let drop =
+            vec!["DROP CONVERSION IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_domain(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Domain(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let mut create = vec![
+            "CREATE".into(),
+            "DOMAIN".into(),
+            self.item_name(item),
+            "AS".into(),
+            d.data_type.clone().unwrap_or_default(),
+        ];
+        if let Some(collation) = &d.collation {
+            create.push("COLLATE".into());
+            create.push(collation.clone());
+        }
+        if let Some(default) = &d.default {
+            create.push("DEFAULT".into());
+            create.push(postgres_value(&Value::String(default.clone())));
+        }
+        if let Some(constraints) = &d.check_constraints {
+            let mut rendered = Vec::new();
+            for c in constraints {
+                let mut value = vec![String::from("CONSTRAINT")];
+                if let Some(name) = &c.name {
+                    value.push(name.clone());
+                }
+                if let Some(nullable) = c.nullable {
+                    value.push(
+                        if nullable { "NULL" } else { "NOT NULL" }.into(),
+                    );
+                }
+                if let Some(expression) = &c.expression {
+                    value.push(format!("CHECK ({expression})"));
+                }
+                rendered.push(value.join(" "));
+            }
+            create.push(rendered.join(" "));
+        }
+        let drop = vec!["DROP DOMAIN IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_event_trigger(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::EventTrigger(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let mut create = vec![
+            "CREATE".into(),
+            "EVENT TRIGGER".into(),
+            self.item_name(item),
+            "ON".into(),
+            d.event.clone().unwrap_or_default(),
+        ];
+        if let Some(filter) = &d.filter {
+            let tags: Vec<String> = filter
+                .tags
+                .iter()
+                .map(|t| postgres_value(&Value::String(t.clone())))
+                .collect();
+            create.push(format!("WHEN TAG IN ({})", tags.join(", ")));
+        }
+        create.push("EXECUTE".into());
+        create.push("FUNCTION".into());
+        create.push(d.function.clone().unwrap_or_default());
+        let drop =
+            vec!["DROP EVENT TRIGGER IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_extension(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Extension(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create = vec![
+            "CREATE".into(),
+            "EXTENSION".into(),
+            "IF NOT EXISTS".into(),
+            quote_ident(&d.name),
+        ];
+        if d.schema.is_some() || d.version.is_some() {
+            create.push("WITH".into());
+        }
+        if let Some(schema) = &d.schema {
+            create.push("SCHEMA".into());
+            create.push(quote_ident(schema));
+        }
+        if let Some(version) = &d.version {
+            create.push("VERSION".into());
+            create.push(quote_ident(version));
+        }
+        if d.cascade == Some(true) {
+            create.push("CASCADE".into());
+        }
+        let drop =
+            vec!["DROP EXTENSION IF EXISTS".into(), quote_ident(&d.name)];
+        self.add_item(item, create, drop, true)
+    }
+
+    fn dump_fdw(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::ForeignDataWrapper(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create = vec![
+            "CREATE".into(),
+            "FOREIGN DATA WRAPPER".into(),
+            self.item_name(item),
+        ];
+        if let Some(handler) = &d.handler {
+            create.push("HANDLER".into());
+            create.push(handler.clone());
+        } else {
+            create.push("NO HANDLER".into());
+        }
+        if let Some(validator) = &d.validator {
+            create.push("VALIDATOR".into());
+            create.push(validator.clone());
+        } else {
+            create.push("NO VALIDATOR".into());
+        }
+        if let Some(options) = &d.options {
+            create.push(format!("OPTIONS ({})", render_options(options)));
+        }
+        let drop = vec![
+            "DROP FOREIGN DATA WRAPPER IF EXISTS".into(),
+            self.item_name(item),
+        ];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_function(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Function(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let func_name = match &d.parameters {
+            Some(parameters) if !parameters.is_empty() => {
+                let params: Vec<String> = parameters
+                    .iter()
+                    .map(|p| {
+                        let mut value = vec![p.mode.clone()];
+                        if let Some(name) = &p.name {
+                            value.push(name.clone());
+                        }
+                        value.push(p.data_type.clone());
+                        if let Some(default) = &p.default {
+                            value.push("=".into());
+                            value.push(raw_value(default));
+                        }
+                        value.join(" ")
+                    })
+                    .collect();
+                format!(
+                    "{}({})",
+                    d.name.split('(').next().unwrap_or_default(),
+                    params.join(", ")
+                )
+            }
+            _ => d.name.clone(),
+        };
+        let mut create = vec![
+            "CREATE".into(),
+            "FUNCTION".into(),
+            func_name.clone(),
+            "RETURNS".into(),
+            d.returns.clone().unwrap_or_default(),
+            "LANGUAGE".into(),
+            d.language.clone().unwrap_or_default(),
+        ];
+        let drop = vec!["DROP FUNCTION IF EXISTS".into(), func_name];
+        if let Some(transform_types) = &d.transform_types {
+            let tts: Vec<String> = transform_types
+                .iter()
+                .map(|t| format!("FOR TYPE {t}"))
+                .collect();
+            create.push(format!("TRANSFORM {}", tts.join(", ")));
+        }
+        if d.window == Some(true) {
+            create.push("WINDOW".into());
+        }
+        if d.immutable == Some(true) {
+            create.push("IMMUTABLE".into());
+        }
+        if d.stable == Some(true) {
+            create.push("STABLE".into());
+        }
+        if d.volatile == Some(true) {
+            create.push("VOLATILE".into());
+        }
+        if let Some(leak_proof) = d.leak_proof {
+            if !leak_proof {
+                create.push("NOT".into());
+            }
+            create.push("LEAKPROOF".into());
+        }
+        match d.called_on_null_input {
+            Some(true) => create.push("CALLED ON NULL INPUT".into()),
+            Some(false) => create.push("RETURNS NULL ON NULL INPUT".into()),
+            None => {}
+        }
+        if d.strict == Some(true) {
+            create.push("STRICT".into());
+        }
+        if let Some(security) = &d.security {
+            create.push("SECURITY".into());
+            create.push(security.clone());
+        }
+        if let Some(parallel) = &d.parallel {
+            create.push("PARALLEL".into());
+            create.push(parallel.clone());
+        }
+        if let Some(cost) = d.cost {
+            create.push("COST".into());
+            create.push(cost.to_string());
+        }
+        if let Some(rows) = d.rows {
+            create.push("ROWS".into());
+            create.push(rows.to_string());
+        }
+        if let Some(support) = &d.support {
+            create.push("SUPPORT".into());
+            create.push(support.clone());
+        }
+        if let Some(configuration) = &d.configuration {
+            for (k, v) in configuration {
+                create.push(format!("SET {k} = {}", postgres_value(v)));
+            }
+        }
+        create.push("AS".into());
+        if let Some(definition) = &d.definition {
+            let create_sql =
+                vec![format!("{} $$\n{}\n$$", create.join(" "), definition)];
+            return self.add_item(item, create_sql, drop, false);
+        }
+        if let (Some(object_file), Some(link_symbol)) =
+            (&d.object_file, &d.link_symbol)
+        {
+            create.push(format!(
+                "{}, {}",
+                postgres_value(&Value::String(object_file.clone())),
+                postgres_value(&Value::String(link_symbol.clone()))
+            ));
+        }
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_group(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Group(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create =
+            vec!["CREATE".into(), "GROUP".into(), quote_ident(&d.name)];
+        if let Some(options) = &d.options {
+            push_bool_option(&mut create, "CREATEDB", options.create_db);
+            push_bool_option(&mut create, "CREATEROLE", options.create_role);
+            push_bool_option(&mut create, "INHERIT", options.inherit);
+            push_bool_option(&mut create, "SUPERUSER", options.superuser);
+        }
+        let drop = vec!["DROP GROUP IF EXISTS".into(), quote_ident(&d.name)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_language(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Language(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create = vec!["CREATE".into()];
+        if d.replace == Some(true) {
+            create.push("OR REPLACE".into());
+        }
+        if d.trusted == Some(true) {
+            create.push("TRUSTED".into());
+        }
+        create.push("LANGUAGE".into());
+        create.push(self.item_name(item));
+        if let Some(handler) = &d.handler {
+            create.push("HANDLER".into());
+            create.push(handler.clone());
+        }
+        if let Some(inline_handler) = &d.inline_handler {
+            create.push("INLINE".into());
+            create.push(inline_handler.clone());
+        }
+        if let Some(validator) = &d.validator {
+            create.push("VALIDATOR".into());
+            create.push(validator.clone());
+        }
+        let drop =
+            vec!["DROP LANGUAGE IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_materialized_view(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::MaterializedView(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let mut create = vec![
+            "CREATE".into(),
+            "MATERIALIZED VIEW".into(),
+            self.item_name(item),
+        ];
+        if let Some(columns) = &d.columns {
+            let names: Vec<&str> =
+                columns.iter().map(view_column_name).collect();
+            create.push(format!("({})", names.join(", ")));
+        }
+        if let Some(method) = &d.table_access_method {
+            create.push("USING".into());
+            create.push(method.clone());
+        }
+        if let Some(storage_parameters) = &d.storage_parameters {
+            create.push("WITH".into());
+            let params: Vec<String> = storage_parameters
+                .iter()
+                .map(|(k, v)| format!("{k} = {}", raw_value(v)))
+                .collect();
+            create.push(params.join(", "));
+        }
+        if let Some(tablespace) = &d.tablespace {
+            create.push("TABLESPACE".into());
+            create.push(tablespace.clone());
+        }
+        create.push("AS".into());
+        create.push(d.query.clone().unwrap_or_default());
+        let drop = vec![
+            "DROP MATERIALIZED VIEW IF EXISTS".into(),
+            self.item_name(item),
+        ];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_operator(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Operator(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let name = format!("{}.{}", d.schema, d.name);
+        let mut create =
+            vec!["CREATE".into(), "OPERATOR".into(), name.clone()];
+        let mut options = vec![format!("PROCEDURE = {}", d.function)];
+        if let Some(v) = &d.left_arg {
+            options.push(format!("LEFTARG = {v}"));
+        }
+        if let Some(v) = &d.right_arg {
+            options.push(format!("RIGHTARG = {v}"));
+        }
+        if let Some(v) = &d.commutator {
+            options.push(format!("COMMUTATOR = {v}"));
+        }
+        if let Some(v) = &d.negator {
+            options.push(format!("NEGATOR = {v}"));
+        }
+        if let Some(v) = &d.restrict {
+            options.push(format!("RESTRICT = {v}"));
+        }
+        if let Some(v) = &d.join {
+            options.push(format!("JOIN = {v}"));
+        }
+        if d.hashes == Some(true) {
+            options.push("HASHES".into());
+        }
+        if d.merges == Some(true) {
+            options.push("MERGES".into());
+        }
+        create.push(format!("({})", options.join(", ")));
+        let drop = vec![
+            "DROP OPERATOR IF EXISTS".into(),
+            name,
+            format!(
+                "({}, {})",
+                d.left_arg.as_deref().unwrap_or("NONE"),
+                d.right_arg.as_deref().unwrap_or("NONE")
+            ),
+        ];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_publication(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Publication(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create =
+            vec!["CREATE".into(), "PUBLICATION".into(), self.item_name(item)];
+        if d.all_tables == Some(true) {
+            create.push("FOR ALL TABLES".into());
+        } else {
+            create.push("FOR".into());
+            create.push("TABLE".into());
+            create.push(d.tables.clone().unwrap_or_default().join(", "));
+        }
+        if let Some(parameters) = &d.parameters {
+            create.push("WITH".into());
+            create.push(render_parameters(parameters));
+        }
+        let drop =
+            vec!["DROP PUBLICATION IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_role(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Role(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create =
+            vec!["CREATE".into(), "ROLE".into(), quote_ident(&d.name)];
+        if let Some(options) = &d.options {
+            push_role_options(&mut create, options, false);
+        }
+        let drop = if d.name == self.superuser {
+            vec![]
+        } else {
+            vec!["DROP ROLE IF EXISTS".into(), quote_ident(&d.name)]
+        };
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_schema(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Schema(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create = vec![
+            "CREATE".into(),
+            "SCHEMA".into(),
+            "IF NOT EXISTS".into(),
+            self.item_name(item),
+        ];
+        if let Some(authorization) = &d.authorization {
+            create.push("AUTHORIZATION".into());
+            create.push(quote_ident(authorization));
+        }
+        let drop = vec!["DROP SCHEMA IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_sequence(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Sequence(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let mut create =
+            vec!["CREATE".into(), "SEQUENCE".into(), self.item_name(item)];
+        if let Some(data_type) = &d.data_type {
+            create.push("AS".into());
+            create.push(data_type.clone());
+        }
+        if let Some(v) = d.increment_by {
+            create.push("INCREMENT BY".into());
+            create.push(v.to_string());
+        }
+        if let Some(v) = d.min_value {
+            create.push("MINVALUE".into());
+            create.push(v.to_string());
+        }
+        if let Some(v) = d.max_value {
+            create.push("MAXVALUE".into());
+            create.push(v.to_string());
+        }
+        if let Some(v) = d.start_with {
+            create.push("START WITH".into());
+            create.push(v.to_string());
+        }
+        if let Some(v) = d.cache {
+            create.push("CACHE".into());
+            create.push(v.to_string());
+        }
+        if let Some(cycle) = d.cycle {
+            if !cycle {
+                create.push("NO".into());
+            }
+            create.push("CYCLE".into());
+        }
+        if let Some(owned_by) = &d.owned_by {
+            create.push("OWNED BY".into());
+            create.push(owned_by.clone());
+        }
+        let drop =
+            vec!["DROP SEQUENCE IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_server(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Server(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create =
+            vec!["CREATE".into(), "SERVER".into(), self.item_name(item)];
+        if let Some(server_type) = &d.server_type {
+            create.push("TYPE".into());
+            create.push(postgres_value(&Value::String(server_type.clone())));
+        }
+        if let Some(version) = &d.version {
+            create.push("VERSION".into());
+            create.push(postgres_value(&Value::String(version.clone())));
+        }
+        create.push("FOREIGN DATA WRAPPER".into());
+        create.push(d.foreign_data_wrapper.clone());
+        if let Some(options) = &d.options {
+            create.push(format!("OPTIONS {}", render_options(options)));
+        }
+        let drop = vec!["DROP SERVER IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_subscription(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Subscription(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create = vec![
+            "CREATE".into(),
+            "SUBSCRIPTION".into(),
+            self.item_name(item),
+            "CONNECTION".into(),
+            d.connection.clone(),
+            "PUBLICATION".into(),
+            d.publications.join(", "),
+        ];
+        if let Some(parameters) = &d.parameters {
+            create.push("WITH".into());
+            create.push(render_parameters(parameters));
+        }
+        let drop =
+            vec!["DROP SUBSCRIPTION IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_table(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Table(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            self.add_item(item, vec![sql.clone()], vec![], false)?;
+        } else {
+            let mut create = vec!["CREATE".into()];
+            if d.unlogged == Some(true) {
+                create.push("UNLOGGED".into());
+            }
+            create.push("TABLE".into());
+            create.push(self.item_name(item));
+            create.push("(".into());
+            if let Some(like_table) = &d.like_table {
+                create.push("LIKE".into());
+                create.push(like_table.name.clone());
+                for (field, value) in [
+                    ("comments", like_table.include_comments),
+                    ("constraints", like_table.include_constraints),
+                    ("defaults", like_table.include_defaults),
+                    ("generated", like_table.include_generated),
+                    ("identity", like_table.include_identity),
+                    ("indexes", like_table.include_indexes),
+                    ("statistics", like_table.include_statistics),
+                    ("storage", like_table.include_storage),
+                    ("all", like_table.include_all),
+                ] {
+                    if let Some(value) = value {
+                        create.push(
+                            if value { "INCLUDING" } else { "EXCLUDING" }
+                                .into(),
+                        );
+                        create.push(format!("include_{field}"));
+                    }
+                }
+            } else {
+                let mut inner = Vec::new();
+                for column in d.columns.as_deref().unwrap_or_default() {
+                    inner.push(render_table_column(column));
+                }
+                for constraint in
+                    d.unique_constraints.as_deref().unwrap_or_default()
+                {
+                    inner.push(render_constraint("UNIQUE", constraint));
+                }
+                if let Some(primary_key) = &d.primary_key {
+                    inner.push(render_constraint("PRIMARY KEY", primary_key));
+                }
+                for fk in d.foreign_keys.as_deref().unwrap_or_default() {
+                    let mut fk_sql = vec![
+                        format!("FOREIGN KEY ({})", fk.columns.join(", ")),
+                        "REFERENCES".into(),
+                        fk.references.name.clone(),
+                        format!("({})", fk.references.columns.join(", ")),
+                    ];
+                    if let Some(match_type) = &fk.match_type {
+                        fk_sql.push("MATCH".into());
+                        fk_sql.push(match_type.clone());
+                    }
+                    if let Some(on_delete) = &fk.on_delete
+                        && on_delete != "NO ACTION"
+                    {
+                        fk_sql.push("ON DELETE".into());
+                        fk_sql.push(on_delete.clone());
+                    }
+                    if let Some(on_update) = &fk.on_update
+                        && on_update != "NO ACTION"
+                    {
+                        fk_sql.push("ON UPDATE".into());
+                        fk_sql.push(on_update.clone());
+                    }
+                    if fk.deferrable == Some(true) {
+                        fk_sql.push("DEFERRABLE".into());
+                    }
+                    if fk.initially_deferred == Some(true) {
+                        fk_sql.push("INITIALLY DEFERRED".into());
+                    }
+                    inner.push(fk_sql.join(" "));
+                }
+                create.push(inner.join(", "));
+                create.push(")".into());
+            }
+            if let Some(parents) = &d.parents {
+                create.push(parents.join(", "));
+            }
+            if let Some(partition) = &d.partition {
+                create.push("PARTITION BY".into());
+                create.push(partition.partition_type.clone());
+                create.push("(".into());
+                let columns: Vec<String> = partition
+                    .columns
+                    .iter()
+                    .map(render_partition_column)
+                    .collect();
+                create.push(columns.join(", "));
+                create.push(")".into());
+            }
+            if let Some(access_method) = &d.access_method {
+                create.push("USING".into());
+                create.push(access_method.clone());
+            }
+            if let Some(storage_parameters) = &d.storage_parameters {
+                create.push("WITH".into());
+                let params: Vec<String> = storage_parameters
+                    .iter()
+                    .map(|(k, v)| format!("{k}={}", raw_value(v)))
+                    .collect();
+                create.push(params.join(", "));
+            }
+            if let Some(tablespace) = &d.tablespace {
+                create.push("TABLESPACE".into());
+                create.push(tablespace.clone());
+            }
+            let drop =
+                vec!["DROP TABLE IF EXISTS".into(), self.item_name(item)];
+            self.add_item(item, create, drop, false)?;
+        }
+        for index in d.indexes.as_deref().unwrap_or_default() {
+            self.dump_index(index, item, d)?;
+        }
+        for trigger in d.triggers.as_deref().unwrap_or_default() {
+            self.dump_trigger(trigger, item, d)?;
+        }
+        Ok(())
+    }
+
+    fn dump_index(
+        &mut self,
+        index: &Index,
+        parent: &Item,
+        table: &crate::models::Table,
+    ) -> Result<(), String> {
+        let name = format!(
+            "{}.{}",
+            quote_ident(&table.schema),
+            quote_ident(&index.name)
+        );
+        let mut create = vec!["CREATE".into()];
+        if index.unique == Some(true) {
+            create.push("UNIQUE".into());
+        }
+        create.push("INDEX".into());
+        create.push(name.clone());
+        create.push("ON".into());
+        if index.recurse == Some(false) {
+            create.push("ONLY".into());
+        }
+        create.push(self.item_name(parent));
+        if let Some(method) = &index.method {
+            create.push("USING".into());
+            create.push(method.clone());
+        }
+        create.push("(".into());
+        let columns: Vec<String> = index
+            .columns
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|c| {
+                let mut sql = vec![
+                    c.name
+                        .clone()
+                        .or_else(|| c.expression.clone())
+                        .unwrap_or_default(),
+                ];
+                if let Some(collation) = &c.collation {
+                    sql.push("COLLATION".into());
+                    sql.push(collation.clone());
+                }
+                if let Some(opclass) = &c.opclass {
+                    sql.push(opclass.clone());
+                }
+                if let Some(direction) = &c.direction {
+                    sql.push(direction.clone());
+                }
+                if let Some(null_placement) = &c.null_placement {
+                    sql.push("NULLS".into());
+                    sql.push(null_placement.clone());
+                }
+                sql.join(" ")
+            })
+            .collect();
+        create.push(columns.join(", "));
+        create.push(")".into());
+        if let Some(include) = &index.include {
+            create.push(format!("INCLUDE ({})", include.join(", ")));
+        }
+        if let Some(storage_parameters) = &index.storage_parameters {
+            create.push("WITH".into());
+            let params: Vec<String> = storage_parameters
+                .iter()
+                .map(|(k, v)| format!("{k}={}", raw_value(v)))
+                .collect();
+            create.push(params.join(", "));
+        }
+        if let Some(tablespace) = &index.tablespace {
+            create.push("TABLESPACE".into());
+            create.push(tablespace.clone());
+        }
+        if let Some(where_clause) = &index.where_clause {
+            create.push("WHERE".into());
+            create.push(where_clause.clone());
+        }
+        let drop = vec!["DROP INDEX IF EXISTS".into(), name];
+        let parent_dump_id = self.dump_id_map[&parent.id];
+        let dump_id = self.add_entry(
+            "INDEX",
+            &table.schema,
+            &index.name,
+            &table.owner,
+            &create,
+            &drop,
+            &[parent_dump_id],
+            index.tablespace.as_deref(),
+        )?;
+        if let Some(comment) = &index.comment {
+            self.add_comment(
+                "INDEX",
+                &table.schema,
+                &index.name,
+                &table.owner,
+                dump_id,
+                comment,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn dump_trigger(
+        &mut self,
+        trigger: &Trigger,
+        parent: &Item,
+        table: &crate::models::Table,
+    ) -> Result<(), String> {
+        let name = trigger.name.clone().unwrap_or_default();
+        let (create, drop) = if let Some(sql) = &trigger.sql {
+            (vec![sql.clone()], vec![])
+        } else {
+            let mut create = vec![
+                "CREATE".into(),
+                "TRIGGER".into(),
+                name.clone(),
+                trigger.when.clone().unwrap_or_default(),
+                trigger.events.clone().unwrap_or_default().join(" OR "),
+                "ON".into(),
+                self.item_name(parent),
+            ];
+            if let Some(for_each) = &trigger.for_each {
+                create.push("FOR EACH".into());
+                create.push(for_each.clone());
+            }
+            if let Some(condition) = &trigger.condition {
+                create.push("WHEN".into());
+                create.push(condition.clone());
+            }
+            create.push("EXECUTE".into());
+            create.push("FUNCTION".into());
+            create.push(trigger.function.clone().unwrap_or_default());
+            if let Some(arguments) = &trigger.arguments {
+                let args: Vec<String> =
+                    arguments.iter().map(raw_value).collect();
+                create.push(format!("({})", args.join(", ")));
+            }
+            let drop = vec![
+                "DROP TRIGGER IF EXISTS".into(),
+                name.clone(),
+                "ON".into(),
+                self.item_name(parent),
+            ];
+            (create, drop)
+        };
+        let parent_dump_id = self.dump_id_map[&parent.id];
+        let dump_id = self.add_entry(
+            "TRIGGER",
+            &table.schema,
+            &name,
+            &table.owner,
+            &create,
+            &drop,
+            &[parent_dump_id],
+            None,
+        )?;
+        if let Some(comment) = &trigger.comment {
+            self.add_comment(
+                "TRIGGER",
+                &table.schema,
+                &name,
+                &table.owner,
+                dump_id,
+                comment,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn dump_tablespace(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Tablespace(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create = vec![
+            "CREATE".into(),
+            "TABLESPACE".into(),
+            self.item_name(item),
+            "OWNER".into(),
+            d.owner.clone(),
+            "LOCATION".into(),
+            d.location.clone(),
+        ];
+        if let Some(options) = &d.options {
+            let opts: Vec<String> = options
+                .iter()
+                .map(|(k, v)| format!("{k}={}", postgres_value(v)))
+                .collect();
+            create.push(format!("WITH ({})", opts.join(",")));
+        }
+        let drop =
+            vec!["DROP TABLESPACE IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_text_search(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::TextSearch(d) = &item.definition else {
+            unreachable!()
+        };
+        for config in d.configurations.as_deref().unwrap_or_default() {
+            let (create, drop) = if let Some(sql) = &config.sql {
+                (vec![sql.clone()], vec![])
+            } else {
+                let value = if let Some(parser) = &config.parser {
+                    format!("PARSER = {parser}")
+                } else if let Some(source) = &config.source {
+                    format!("SOURCE = {source}")
+                } else {
+                    return Err(format!(
+                        "text search configuration {} has no parser or \
+                         source",
+                        config.name
+                    ));
+                };
+                (
+                    vec![
+                        "CREATE".into(),
+                        "TEXT SEARCH CONFIGURATION".into(),
+                        quote_ident(&config.name),
+                        format!("({value})"),
+                    ],
+                    vec![
+                        "DROP TEXT SEARCH CONFIGURATION IF EXISTS".into(),
+                        quote_ident(&config.name),
+                    ],
+                )
+            };
+            self.add_text_search_item(
+                d,
+                "TEXT SEARCH CONFIGURATION",
+                &config.name,
+                create,
+                drop,
+                config.comment.as_deref(),
+            )?;
+        }
+        for dictionary in d.dictionaries.as_deref().unwrap_or_default() {
+            let (create, drop) = if let Some(sql) = &dictionary.sql {
+                (vec![sql.clone()], vec![])
+            } else {
+                let mut value = vec![format!(
+                    "TEMPLATE = {}",
+                    dictionary.template.clone().unwrap_or_default()
+                )];
+                if let Some(options) = &dictionary.options {
+                    for (k, v) in options {
+                        value.push(format!("{k} = {}", postgres_value(v)));
+                    }
+                }
+                (
+                    vec![
+                        "CREATE".into(),
+                        "TEXT SEARCH DICTIONARY".into(),
+                        quote_ident(&dictionary.name),
+                        format!("({})", value.join(", ")),
+                    ],
+                    vec![
+                        "DROP TEXT SEARCH DICTIONARY IF EXISTS".into(),
+                        quote_ident(&dictionary.name),
+                    ],
+                )
+            };
+            self.add_text_search_item(
+                d,
+                "TEXT SEARCH DICTIONARY",
+                &dictionary.name,
+                create,
+                drop,
+                dictionary.comment.as_deref(),
+            )?;
+        }
+        for parser in d.parsers.as_deref().unwrap_or_default() {
+            let (create, drop) = if let Some(sql) = &parser.sql {
+                (vec![sql.clone()], vec![])
+            } else {
+                let mut value = vec![
+                    format!(
+                        "START = {}",
+                        parser.start_function.clone().unwrap_or_default()
+                    ),
+                    format!(
+                        "GETTOKEN = {}",
+                        parser.gettoken_function.clone().unwrap_or_default()
+                    ),
+                    format!(
+                        "END = {}",
+                        parser.end_function.clone().unwrap_or_default()
+                    ),
+                    format!(
+                        "LEXTYPES = {}",
+                        parser.lextypes_function.clone().unwrap_or_default()
+                    ),
+                ];
+                if let Some(headline) = &parser.headline_function {
+                    value.push(format!("HEADLINE = {headline}"));
+                }
+                (
+                    vec![
+                        "CREATE".into(),
+                        "TEXT SEARCH PARSER".into(),
+                        quote_ident(&parser.name),
+                        format!("({})", value.join(", ")),
+                    ],
+                    vec![
+                        "DROP TEXT SEARCH PARSER IF EXISTS".into(),
+                        quote_ident(&parser.name),
+                    ],
+                )
+            };
+            self.add_text_search_item(
+                d,
+                "TEXT SEARCH PARSER",
+                &parser.name,
+                create,
+                drop,
+                parser.comment.as_deref(),
+            )?;
+        }
+        for template in d.templates.as_deref().unwrap_or_default() {
+            let (create, drop) = if let Some(sql) = &template.sql {
+                (vec![sql.clone()], vec![])
+            } else {
+                let mut value = Vec::new();
+                if let Some(init) = &template.init_function {
+                    value.push(format!("INIT = {init}"));
+                }
+                value.push(format!(
+                    "LEXIZE = {}",
+                    template.lexize_function.clone().unwrap_or_default()
+                ));
+                (
+                    vec![
+                        "CREATE".into(),
+                        "TEXT SEARCH TEMPLATE".into(),
+                        quote_ident(&template.name),
+                        format!("({})", value.join(", ")),
+                    ],
+                    vec![
+                        "DROP TEXT SEARCH TEMPLATE IF EXISTS".into(),
+                        quote_ident(&template.name),
+                    ],
+                )
+            };
+            self.add_text_search_item(
+                d,
+                "TEXT SEARCH TEMPLATE",
+                &template.name,
+                create,
+                drop,
+                template.comment.as_deref(),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn add_text_search_item(
+        &mut self,
+        parent: &crate::models::TextSearch,
+        desc: &str,
+        name: &str,
+        defn: Vec<String>,
+        drop_stmt: Vec<String>,
+        comment: Option<&str>,
+    ) -> Result<(), String> {
+        let dump_id = self.add_entry(
+            desc,
+            &parent.schema,
+            name,
+            &self.superuser.clone(),
+            &defn,
+            &drop_stmt,
+            &[],
+            None,
+        )?;
+        if let Some(comment) = comment {
+            self.add_comment(
+                desc,
+                &parent.schema,
+                name,
+                &self.superuser.clone(),
+                dump_id,
+                comment,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn dump_type(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::Type(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let mut create = vec![
+            "CREATE".into(),
+            "TYPE".into(),
+            self.item_name(item),
+            "AS".into(),
+        ];
+        match d.type_kind.as_deref() {
+            Some("base") => {
+                let mut options = vec![
+                    format!("INPUT = {}", d.input.clone().unwrap_or_default()),
+                    format!(
+                        "OUTPUT = {}",
+                        d.output.clone().unwrap_or_default()
+                    ),
+                ];
+                if let Some(v) = &d.receive {
+                    options.push(format!("RECEIVE = {v}"));
+                }
+                if let Some(v) = &d.send {
+                    options.push(format!("SEND = {v}"));
+                }
+                if let Some(v) = &d.typmod_in {
+                    options.push(format!("TYPMOD_IN = {v}"));
+                }
+                if let Some(v) = &d.typmod_out {
+                    options.push(format!("TYPMOD_OUT = {v}"));
+                }
+                if let Some(v) = &d.analyze {
+                    options.push(format!("ANALYZE = {v}"));
+                }
+                if let Some(v) = &d.internal_length {
+                    options.push(format!("INTERNALLENGTH = {}", raw_value(v)));
+                }
+                if d.passed_by_value == Some(true) {
+                    options.push("PASSEDBYVALUE".into());
+                }
+                if let Some(v) = &d.alignment {
+                    options.push(format!("ALIGNMENT = {v}"));
+                }
+                if let Some(v) = &d.storage {
+                    options.push(format!("STORAGE = {v}"));
+                }
+                if let Some(v) = &d.like_type {
+                    options.push(format!("LIKE = {v}"));
+                }
+                if let Some(v) = &d.category {
+                    options.push(format!(
+                        "CATEGORY = {}",
+                        postgres_value(&Value::String(v.clone()))
+                    ));
+                }
+                if let Some(v) = &d.preferred {
+                    options.push(format!("PREFERRED = {}", raw_value(v)));
+                }
+                if let Some(v) = &d.default {
+                    options.push(format!("DEFAULT = {}", postgres_value(v)));
+                }
+                if let Some(v) = &d.element {
+                    options.push(format!("ELEMENT = {v}"));
+                }
+                if let Some(v) = &d.delimiter {
+                    options.push(format!(
+                        "DELIMITER = {}",
+                        postgres_value(&Value::String(v.clone()))
+                    ));
+                }
+                if d.collatable == Some(true) {
+                    options.push("COLLATABLE = True".into());
+                }
+                create.push(format!("({})", options.join(", ")));
+            }
+            Some("composite") => {
+                let columns: Vec<String> = d
+                    .columns
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|column| {
+                        let mut col = vec![
+                            column.name.clone(),
+                            column.data_type.clone(),
+                        ];
+                        if let Some(collation) = &column.collation {
+                            col.push("COLLATE".into());
+                            col.push(collation.clone());
+                        }
+                        col.join(" ")
+                    })
+                    .collect();
+                create.push(format!("({})", columns.join(", ")));
+            }
+            Some("enum") => {
+                create.push("ENUM".into());
+                let values: Vec<String> = d
+                    .enum_values
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|e| postgres_value(&Value::String(e.clone())))
+                    .collect();
+                create.push(format!("({})", values.join(", ")));
+            }
+            Some("range") => {
+                create.push("RANGE".into());
+                let mut options = vec![format!(
+                    "SUBTYPE = {}",
+                    d.subtype.clone().unwrap_or_default()
+                )];
+                if let Some(v) = &d.subtype_opclass {
+                    options.push(format!("SUBTYPE_OPCLASS = {v}"));
+                }
+                if let Some(v) = &d.collation {
+                    options.push(format!("COLLATION = {v}"));
+                }
+                if let Some(v) = &d.canonical {
+                    options.push(format!("CANONICAL = {v}"));
+                }
+                if let Some(v) = &d.subtype_diff {
+                    options.push(format!("SUBTYPE_DIFF = {v}"));
+                }
+                create.push(format!("({})", options.join(", ")));
+            }
+            _ => {}
+        }
+        let drop = vec!["DROP TYPE IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_user(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::User(d) = &item.definition else {
+            unreachable!()
+        };
+        let mut create =
+            vec!["CREATE".into(), "USER".into(), quote_ident(&d.name)];
+        if let Some(options) = &d.options {
+            push_role_options(&mut create, options, true);
+        } else {
+            create.push("LOGIN".into());
+        }
+        if let Some(valid_until) = &d.valid_until {
+            create.push("VALID UNTIL".into());
+            create.push(postgres_value(&Value::String(valid_until.clone())));
+        }
+        match &d.password {
+            None => create.push("PASSWORD NULL".into()),
+            Some(password) if !password.is_empty() => {
+                if password.starts_with("md5") {
+                    create.push("ENCRYPTED".into());
+                }
+                create.push("PASSWORD".into());
+                create.push(postgres_value(&Value::String(password.clone())));
+            }
+            Some(_) => {}
+        }
+        let drop = if d.name == self.superuser {
+            vec![]
+        } else {
+            vec!["DROP USER IF EXISTS".into(), quote_ident(&d.name)]
+        };
+        self.add_item(item, create, drop, false)
+    }
+
+    fn dump_user_mapping(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::UserMapping(d) = &item.definition else {
+            unreachable!()
+        };
+        for server in &d.servers {
+            let mut create = vec![
+                "CREATE".into(),
+                "USER MAPPING".into(),
+                "FOR".into(),
+                quote_ident(&d.name),
+                "SERVER".into(),
+                quote_ident(&server.name),
+            ];
+            if let Some(options) = &server.options {
+                let opts: Vec<String> = options
+                    .iter()
+                    .map(|(k, v)| format!("{k} {}", postgres_value(v)))
+                    .collect();
+                create.push(format!("OPTIONS ({})", opts.join(",")));
+            }
+            let drop = vec![
+                "DROP USER MAPPING IF EXISTS".into(),
+                "FOR".into(),
+                quote_ident(&d.name),
+                "SERVER".into(),
+                quote_ident(&server.name),
+            ];
+            self.add_item(item, create, drop, false)?;
+        }
+        Ok(())
+    }
+
+    fn dump_view(&mut self, item: &Item) -> Result<(), String> {
+        let Definition::View(d) = &item.definition else {
+            unreachable!()
+        };
+        if let Some(sql) = &d.sql {
+            return self.add_item(item, vec![sql.clone()], vec![], false);
+        }
+        let mut create = vec!["CREATE".into()];
+        if d.recursive == Some(true) {
+            create.push("RECURSIVE".into());
+        }
+        create.push("VIEW".into());
+        create.push(self.item_name(item));
+        if let Some(columns) = &d.columns {
+            let names: Vec<&str> =
+                columns.iter().map(view_column_name).collect();
+            create.push(format!("({})", names.join(", ")));
+        }
+        if let Some(check_option) = &d.check_option {
+            create.push(format!("WITH (check_option = {check_option})"));
+        }
+        if d.security_barrier == Some(true) {
+            create.push("WITH (security_barrier = true)".into());
+        }
+        create.push("AS".into());
+        create.push(d.query.clone().unwrap_or_default());
+        let drop = vec!["DROP VIEW IF EXISTS".into(), self.item_name(item)];
+        self.add_item(item, create, drop, false)
+    }
+}
+
+/// CREATEDB / NOCREATEDB style option rendering
+/// (ports _format_bool_option)
+fn push_bool_option(sql: &mut Vec<String>, name: &str, value: Option<bool>) {
+    match value {
+        Some(true) => sql.push(name.to_string()),
+        Some(false) => sql.push(format!("NO{name}")),
+        None => {}
+    }
+}
+
+/// Shared role/user option rendering (ports _dump_role / _dump_user,
+/// with the BYPASSRLS-reads-create_db bug fixed)
+fn push_role_options(
+    sql: &mut Vec<String>,
+    options: &RoleOptions,
+    is_user: bool,
+) {
+    push_bool_option(sql, "BYPASSRLS", options.bypass_rls);
+    if let Some(limit) = options.connection_limit {
+        sql.push("CONNECTION LIMIT".into());
+        sql.push(limit.to_string());
+    }
+    push_bool_option(sql, "CREATEDB", options.create_db);
+    push_bool_option(sql, "CREATEROLE", options.create_role);
+    push_bool_option(sql, "INHERIT", options.inherit);
+    if is_user {
+        sql.push("LOGIN".into());
+    } else {
+        push_bool_option(sql, "LOGIN", options.login);
+    }
+    push_bool_option(sql, "SUPERUSER", options.superuser);
+}
+
+fn render_table_column(column: &Column) -> String {
+    let mut sql = vec![column.name.clone(), column.data_type.clone()];
+    if let Some(collation) = &column.collation {
+        sql.push("COLLATE".into());
+        sql.push(collation.clone());
+    }
+    if column.nullable == Some(false) {
+        sql.push("NOT NULL".into());
+    }
+    if let Some(check_constraint) = &column.check_constraint {
+        sql.push("CHECK".into());
+        sql.push(check_constraint.clone());
+    }
+    if let Some(default) = &column.default {
+        sql.push("DEFAULT".into());
+        sql.push(postgres_value(default));
+    }
+    if let Some(generated) = &column.generated {
+        if let Some(expression) = &generated.expression {
+            sql.push("GENERATED ALWAYS AS".into());
+            sql.push(expression.clone());
+            sql.push("STORED".into());
+        } else if generated.sequence.is_some() {
+            sql.push("GENERATED".into());
+            sql.push(generated.sequence_behavior.clone().unwrap_or_default());
+            sql.push("AS IDENTITY".into());
+        }
+    }
+    sql.join(" ")
+}
+
+/// UNIQUE / PRIMARY KEY constraint rendering
+/// (ports _format_sql_constraint; INCLUDE columns get a proper clause)
+fn render_constraint(
+    constraint_type: &str,
+    constraint: &ConstraintColumns,
+) -> String {
+    let (columns, include): (Vec<String>, Option<&Vec<String>>) =
+        match constraint {
+            ConstraintColumns::Name(name) => (vec![name.clone()], None),
+            ConstraintColumns::Columns(columns) => (columns.clone(), None),
+            ConstraintColumns::Detailed { columns, include } => {
+                (columns.clone(), include.as_ref())
+            }
+        };
+    let mut sql = vec![format!("{constraint_type} ({})", columns.join(", "))];
+    if let Some(include) = include {
+        sql.push(format!("INCLUDE ({})", include.join(", ")));
+    }
+    sql.join(" ")
+}
+
+fn render_partition_column(column: &TablePartitionColumn) -> String {
+    match column {
+        TablePartitionColumn::Name(name) => name.clone(),
+        TablePartitionColumn::Detailed {
+            name,
+            expression,
+            collation,
+            opclass,
+        } => {
+            let mut sql = vec![
+                name.clone()
+                    .or_else(|| expression.clone())
+                    .unwrap_or_default(),
+            ];
+            if let Some(collation) = collation {
+                sql.push("COLLATION".into());
+                sql.push(collation.clone());
+            }
+            if let Some(opclass) = opclass {
+                sql.push(opclass.clone());
+            }
+            sql.join(" ")
+        }
+    }
+}
+
+fn view_column_name(column: &ViewColumn) -> &str {
+    match column {
+        ViewColumn::Name(name) => name,
+        ViewColumn::Detailed { name, .. } => name,
+    }
+}
+
+/// `key 'value'` option rendering for FDW objects
+fn render_options(options: &Map<String, Value>) -> String {
+    options
+        .iter()
+        .map(|(k, v)| format!("{k} {}", postgres_value(v)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// `key = value` parameter rendering (ports _format_parameters)
+fn render_parameters(parameters: &Map<String, Value>) -> String {
+    parameters
+        .iter()
+        .map(|(k, v)| format!("{k} = {}", postgres_value(v)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+// Acls intentionally unused for now: the Python build never emitted
+// grants/revocations into the archive; ACL entries arrive with the
+// pull/deploy work.
+const _: fn(&Acls) = |_| {};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 //! pglifecycle — PostgreSQL schema management
 
+pub mod build;
 pub mod cli;
 pub mod constants;
 pub mod models;
 pub mod project;
 pub mod skeleton;
+pub mod utils;
 pub mod yamlio;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use pglifecycle::{cli, skeleton};
+use pglifecycle::{build, cli, project, skeleton};
 
 fn main() -> ExitCode {
     let args = cli::Cli::parse();
@@ -14,9 +14,8 @@ fn main() -> ExitCode {
         args.action.name()
     );
     let result = match &args.action {
-        cli::Action::Build(_) => {
-            Err("build is not implemented yet".to_string())
-        }
+        cli::Action::Build(args) => project::load(&args.project)
+            .and_then(|p| build::build(&p, &args.destination)),
         cli::Action::Create(create) => skeleton::create(create),
         cli::Action::Pull(_) => Err("pull is not implemented yet".to_string()),
     };

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -93,6 +93,68 @@ impl Definition {
         }
     }
 
+    /// The owning role, where the type has one
+    pub fn owner(&self) -> Option<&str> {
+        match self {
+            Definition::Aggregate(d) => Some(&d.owner),
+            Definition::Cast(d) => Some(&d.owner),
+            Definition::Collation(d) => Some(&d.owner),
+            Definition::Conversion(d) => Some(&d.owner),
+            Definition::Domain(d) => Some(&d.owner),
+            Definition::ForeignDataWrapper(d) => Some(&d.owner),
+            Definition::Function(d) => Some(&d.owner),
+            Definition::MaterializedView(d) => Some(&d.owner),
+            Definition::Operator(d) => Some(&d.owner),
+            Definition::Schema(d) => Some(&d.owner),
+            Definition::Sequence(d) => Some(&d.owner),
+            Definition::Table(d) => Some(&d.owner),
+            Definition::Tablespace(d) => Some(&d.owner),
+            Definition::Type(d) => Some(&d.owner),
+            Definition::View(d) => Some(&d.owner),
+            _ => None,
+        }
+    }
+
+    /// The object comment, where the type has one
+    pub fn comment(&self) -> Option<&str> {
+        match self {
+            Definition::Aggregate(d) => d.comment.as_deref(),
+            Definition::Cast(d) => d.comment.as_deref(),
+            Definition::Collation(d) => d.comment.as_deref(),
+            Definition::Conversion(d) => d.comment.as_deref(),
+            Definition::Domain(d) => d.comment.as_deref(),
+            Definition::EventTrigger(d) => d.comment.as_deref(),
+            Definition::Extension(d) => d.comment.as_deref(),
+            Definition::ForeignDataWrapper(d) => d.comment.as_deref(),
+            Definition::Function(d) => d.comment.as_deref(),
+            Definition::Group(d) => d.comment.as_deref(),
+            Definition::Language(d) => d.comment.as_deref(),
+            Definition::MaterializedView(d) => d.comment.as_deref(),
+            Definition::Operator(d) => d.comment.as_deref(),
+            Definition::Publication(d) => d.comment.as_deref(),
+            Definition::Role(d) => d.comment.as_deref(),
+            Definition::Schema(d) => d.comment.as_deref(),
+            Definition::Sequence(d) => d.comment.as_deref(),
+            Definition::Server(d) => d.comment.as_deref(),
+            Definition::Subscription(d) => d.comment.as_deref(),
+            Definition::Table(d) => d.comment.as_deref(),
+            Definition::Tablespace(d) => d.comment.as_deref(),
+            Definition::Type(d) => d.comment.as_deref(),
+            Definition::User(d) => d.comment.as_deref(),
+            Definition::View(d) => d.comment.as_deref(),
+            Definition::TextSearch(_) | Definition::UserMapping(_) => None,
+        }
+    }
+
+    /// The tablespace assignment, where the type has one
+    pub fn tablespace(&self) -> Option<&str> {
+        match self {
+            Definition::MaterializedView(d) => d.tablespace.as_deref(),
+            Definition::Table(d) => d.tablespace.as_deref(),
+            _ => None,
+        }
+    }
+
     /// The schema the object belongs to, where the type has one
     pub fn schema(&self) -> Option<&str> {
         match self {

--- a/src/project/load.rs
+++ b/src/project/load.rs
@@ -405,10 +405,10 @@ fn object_name(defn: &Value) -> Result<String, String> {
 
 /// Set a string key on a mapping unless it is already present
 fn inject(defn: &mut Value, key: &str, value: &str) {
-    if let Value::Object(map) = defn {
-        if !map.contains_key(key) {
-            map.insert(key.to_string(), Value::String(value.to_string()));
-        }
+    if let Value::Object(map) = defn
+        && !map.contains_key(key)
+    {
+        map.insert(key.to_string(), Value::String(value.to_string()));
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,78 @@
+//! Misc utilities (ports utils.py)
+
+use serde_json::Value;
+
+/// Quote a PostgreSQL identifier (object name, etc)
+pub fn quote_ident(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        value.to_string()
+    } else {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    }
+}
+
+/// Return a Postgres value as a string, quoted if required. Mirrors
+/// utils.postgres_value including Python's `str()` rendering of bools
+/// (`True`/`False`), which the Phase 3 round-trip work will revisit.
+pub fn postgres_value(value: &Value) -> String {
+    render_value(value, false)
+}
+
+fn render_value(value: &Value, nested: bool) -> String {
+    match value {
+        Value::String(s) if s.contains('\'') => format!("$${s}$$"),
+        Value::String(s) => format!("'{s}'"),
+        Value::Array(items) => {
+            let inner: Vec<String> =
+                items.iter().map(|v| render_value(v, true)).collect();
+            if nested {
+                format!("[{}]", inner.join(", "))
+            } else {
+                format!("ARRAY[{}]", inner.join(", "))
+            }
+        }
+        Value::Bool(true) => String::from("True"),
+        Value::Bool(false) => String::from("False"),
+        other => other.to_string(),
+    }
+}
+
+/// Render a value the way Python's `str()` does inside string
+/// interpolation (no quoting) — used for storage parameters and
+/// trigger arguments
+pub fn raw_value(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Bool(true) => String::from("True"),
+        Value::Bool(false) => String::from("False"),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn quotes_identifiers() {
+        assert_eq!(quote_ident("users"), "users");
+        assert_eq!(quote_ident("uuid-ossp"), "\"uuid-ossp\"");
+        assert_eq!(quote_ident("==="), "\"===\"");
+        assert_eq!(quote_ident("Has\"Quote"), "\"Has\"\"Quote\"");
+    }
+
+    #[test]
+    fn renders_postgres_values() {
+        assert_eq!(postgres_value(&json!("simple")), "'simple'");
+        assert_eq!(postgres_value(&json!("it's")), "$$it's$$");
+        assert_eq!(postgres_value(&json!(5)), "5");
+        assert_eq!(postgres_value(&json!(true)), "True");
+        assert_eq!(postgres_value(&json!(["a", ["b"]])), "ARRAY['a', ['b']]");
+    }
+}

--- a/tests/build_parity.rs
+++ b/tests/build_parity.rs
@@ -1,0 +1,300 @@
+//! Phase 2 parity gate: build test-project/ and compare the archive
+//! entry-by-entry against the Python implementation's output
+//! (tests/fixtures/python-build-entries.json, exported from a
+//! pglifecycle 1.0 build of the same project).
+//!
+//! The comparison is exact except for documented deviations where the
+//! Python output was broken; those entries are excluded from the exact
+//! match and asserted against their corrected forms below.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use pglifecycle::{build, project};
+
+type Key = (String, String, String);
+
+fn entry_key(desc: &str, namespace: &str, tag: &str) -> Key {
+    (desc.to_string(), namespace.to_string(), tag.to_string())
+}
+
+/// Python entries whose output was broken SQL; each maps to the
+/// assertion applied to the corrected Rust entry instead
+const DEVIATIONS: &[(&str, &str, &str)] = &[
+    // libpgdump writes the prelude entries with empty tags where
+    // pgdumplib repeated the desc (pg_dump itself uses the desc)
+    ("ENCODING", "", "ENCODING"),
+    ("STDSTRINGS", "", "STDSTRINGS"),
+    ("SEARCHPATH", "", "SEARCHPATH"),
+    // BYPASSRLS rendered from create_db in Python
+    ("ROLE", "", "postgres"),
+    // Python interpolated a Python list repr into WHEN TAG IN
+    ("EVENT TRIGGER", "", "disable_alter_domain"),
+    // Python's loader dropped primary keys and rendered ON_DELETE /
+    // ON_UPDATE
+    ("TABLE", "test", "addresses"),
+    ("TABLE", "test", "empty_table"),
+    ("TABLE", "test", "users"),
+    // Python tagged text search objects with their comment text (or
+    // nothing) and interpolated list reprs into the option clauses
+    (
+        "TEXT SEARCH CONFIGURATION",
+        "test",
+        "Copy of default things",
+    ),
+    ("TEXT SEARCH CONFIGURATION", "test", "Copy of german config"),
+    ("TEXT SEARCH DICTIONARY", "test", ""),
+    (
+        "TEXT SEARCH PARSER",
+        "test",
+        "Simple copy of the default parser values",
+    ),
+    (
+        "TEXT SEARCH TEMPLATE",
+        "test",
+        "Copied from the snowball template",
+    ),
+];
+
+/// (desc, namespace, tag, required defn fragment) for the corrected
+/// Rust entries replacing the deviations above
+const CORRECTED: &[(&str, &str, &str, &str)] = &[
+    ("ENCODING", "", "", "SET client_encoding = 'UTF-8';\n"),
+    (
+        "STDSTRINGS",
+        "",
+        "",
+        "SET standard_conforming_strings = 'on';\n",
+    ),
+    ("SEARCHPATH", "", "", "SELECT pg_catalog.set_config"),
+    ("ROLE", "", "postgres", "NOBYPASSRLS CREATEDB"),
+    (
+        "EVENT TRIGGER",
+        "",
+        "disable_alter_domain",
+        "WHEN TAG IN ('ALTER DOMAIN')",
+    ),
+    (
+        "TABLE",
+        "test",
+        "addresses",
+        "PRIMARY KEY (id), FOREIGN KEY (user_id) REFERENCES test.users (id) ON DELETE CASCADE ON UPDATE CASCADE",
+    ),
+    (
+        "TABLE",
+        "test",
+        "empty_table",
+        "value TEXT, PRIMARY KEY (id) )",
+    ),
+    ("TABLE", "test", "users", "icon oid, PRIMARY KEY (id) )"),
+    (
+        "TEXT SEARCH CONFIGURATION",
+        "test",
+        "custom_english",
+        "(PARSER = custom_default)",
+    ),
+    (
+        "TEXT SEARCH CONFIGURATION",
+        "test",
+        "custom_german",
+        "(SOURCE = german)",
+    ),
+    (
+        "TEXT SEARCH DICTIONARY",
+        "test",
+        "custom_simple",
+        "(TEMPLATE = custom_snowball, language = 'english', stopwords = 'english')",
+    ),
+    (
+        "TEXT SEARCH PARSER",
+        "test",
+        "custom_default",
+        "START = prsd_start",
+    ),
+    (
+        "TEXT SEARCH TEMPLATE",
+        "test",
+        "custom_snowball",
+        "(INIT = dsnowball_init, LEXIZE = dsnowball_lexize)",
+    ),
+];
+
+/// Comment entries Python lost entirely to the text search name bug
+const RECOVERED_COMMENTS: &[(&str, &str)] = &[
+    ("custom_english", "Copy of default things"),
+    ("custom_german", "Copy of german config"),
+    ("custom_default", "Simple copy of the default parser values"),
+    ("custom_snowball", "Copied from the snowball template"),
+];
+
+fn build_archive() -> libpgdump::Dump {
+    let project = project::load(Path::new("test-project")).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("build.dump");
+    build::build(&project, &path).unwrap();
+    libpgdump::load(&path).unwrap()
+}
+
+#[test]
+fn matches_python_build_output() {
+    let dump = build_archive();
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/python-build-entries.json"
+    ))
+    .unwrap();
+
+    let deviations: BTreeSet<Key> = DEVIATIONS
+        .iter()
+        .map(|(d, n, t)| entry_key(d, n, t))
+        .collect();
+
+    // full entry tuples (desc, ns, tag, owner, defn, drop, tablespace),
+    // excluding deviant entries by key — compared as sorted multisets
+    // so duplicate (desc, ns, tag) keys (e.g. two COMMENT ''.'test'
+    // entries) stay distinct
+    let rust_tuples: Vec<(Key, String, String, String, Option<String>)> = dump
+        .entries()
+        .iter()
+        .map(|e| {
+            (
+                entry_key(
+                    e.desc.as_str(),
+                    e.namespace.as_deref().unwrap_or_default(),
+                    e.tag.as_deref().unwrap_or_default(),
+                ),
+                e.owner.clone().unwrap_or_default(),
+                e.defn.clone().unwrap_or_default(),
+                e.drop_stmt.clone().unwrap_or_default(),
+                e.tablespace.clone(),
+            )
+        })
+        .collect();
+
+    let mut expected: Vec<_> = fixture
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|py| {
+            (
+                entry_key(
+                    py["desc"].as_str().unwrap(),
+                    py["namespace"].as_str().unwrap(),
+                    py["tag"].as_str().unwrap(),
+                ),
+                py["owner"].as_str().unwrap().to_string(),
+                py["defn"].as_str().unwrap().to_string(),
+                py["drop_stmt"].as_str().unwrap().to_string(),
+                py["tablespace"].as_str().map(String::from),
+            )
+        })
+        .filter(|(key, ..)| !deviations.contains(key))
+        .collect();
+    expected.sort();
+    let mut actual: Vec<_> = rust_tuples
+        .iter()
+        .filter(|(key, ..)| {
+            // exclude the corrected/recovered entries from the exact
+            // comparison; asserted separately below
+            !CORRECTED
+                .iter()
+                .any(|(d, n, t, _)| &entry_key(d, n, t) == key)
+                && !RECOVERED_COMMENTS
+                    .iter()
+                    .any(|(tag, _)| key == &entry_key("COMMENT", "test", tag))
+        })
+        .cloned()
+        .collect();
+    actual.sort();
+    assert_eq!(actual, expected, "non-deviant entries differ");
+
+    // the deviant entries must appear in their corrected forms
+    for (desc, namespace, tag, fragment) in CORRECTED {
+        let key = entry_key(desc, namespace, tag);
+        let defn = rust_tuples
+            .iter()
+            .find(|(k, ..)| k == &key)
+            .map(|(_, _, defn, ..)| defn.as_str())
+            .unwrap_or_else(|| {
+                panic!("missing corrected entry {key:?} in Rust archive")
+            });
+        assert!(
+            defn.contains(fragment),
+            "{key:?} defn missing {fragment:?}: {defn}"
+        );
+    }
+
+    // comments Python lost to the text search tag bug
+    for (tag, comment) in RECOVERED_COMMENTS {
+        let key = entry_key("COMMENT", "test", tag);
+        let defn = rust_tuples
+            .iter()
+            .find(|(k, ..)| k == &key)
+            .map(|(_, _, defn, ..)| defn.as_str())
+            .unwrap_or_else(|| panic!("missing recovered comment {key:?}"));
+        assert!(defn.contains(comment), "{key:?} missing comment text");
+    }
+
+    // 60 Python entries + 4 recovered text search comments
+    assert_eq!(dump.entries().len(), 64);
+}
+
+#[test]
+fn records_inventory_dependency_edges() {
+    let dump = build_archive();
+    let by_id: BTreeMap<i32, String> = dump
+        .entries()
+        .iter()
+        .map(|e| {
+            (
+                e.dump_id,
+                format!(
+                    "{}:{}",
+                    e.desc.as_str(),
+                    e.tag.as_deref().unwrap_or_default()
+                ),
+            )
+        })
+        .collect();
+    let mut edges: Vec<String> = dump
+        .entries()
+        .iter()
+        .filter(|e| {
+            !e.dependencies.is_empty()
+                && !matches!(
+                    e.desc,
+                    libpgdump::ObjectType::Comment
+                        | libpgdump::ObjectType::Index
+                )
+        })
+        .map(|e| {
+            let mut parents: Vec<&str> =
+                e.dependencies.iter().map(|d| by_id[d].as_str()).collect();
+            parents.sort();
+            format!(
+                "{}:{} -> {}",
+                e.desc.as_str(),
+                e.tag.as_deref().unwrap_or_default(),
+                parents.join(", ")
+            )
+        })
+        .collect();
+    edges.sort();
+    // the same 7 inventory edges the loader resolves (Python recorded
+    // no dependency edges at all; libpgdump's weighted toposort uses
+    // these to order the archive)
+    assert_eq!(
+        edges,
+        vec![
+            "AGGREGATE:test_agg -> \
+             FUNCTION:test_aggregate(integer, integer)",
+            "DOMAIN:bcp47_locale -> EXTENSION:citext",
+            "MATERIALIZED VIEW:user_addresses -> \
+             TABLE:addresses, TABLE:users",
+            "SERVER:localhost -> EXTENSION:postgres_fdw",
+            "TABLE:addresses -> TYPE:address_type",
+            "TABLE:users -> DOMAIN:bcp47_locale, DOMAIN:email_address, \
+             TYPE:user_state",
+            "VIEW:user_addresses -> TABLE:addresses, TABLE:users",
+        ]
+    );
+}

--- a/tests/fixtures/python-build-entries.json
+++ b/tests/fixtures/python-build-entries.json
@@ -1,0 +1,756 @@
+[
+ {
+  "dump_id": 1,
+  "desc": "ENCODING",
+  "namespace": "",
+  "tag": "ENCODING",
+  "owner": "",
+  "defn": "SET client_encoding = 'UTF-8';\n",
+  "drop_stmt": "",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 2,
+  "desc": "STDSTRINGS",
+  "namespace": "",
+  "tag": "STDSTRINGS",
+  "owner": "",
+  "defn": "SET standard_conforming_strings = 'on';\n",
+  "drop_stmt": "",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 3,
+  "desc": "SEARCHPATH",
+  "namespace": "",
+  "tag": "SEARCHPATH",
+  "owner": "",
+  "defn": "SELECT pg_catalog.set_config('search_path', '', false);\n",
+  "drop_stmt": "",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 44,
+  "desc": "GROUP",
+  "namespace": "",
+  "tag": "developers",
+  "owner": "postgres",
+  "defn": "CREATE GROUP developers INHERIT;\n",
+  "drop_stmt": "DROP GROUP IF EXISTS developers;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "None"
+ },
+ {
+  "dump_id": 45,
+  "desc": "ROLE",
+  "namespace": "",
+  "tag": "postgres",
+  "owner": "postgres",
+  "defn": "CREATE ROLE postgres BYPASSRLS CREATEDB CREATEROLE INHERIT LOGIN SUPERUSER;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "None"
+ },
+ {
+  "dump_id": 46,
+  "desc": "USER",
+  "namespace": "",
+  "tag": "fwd_user",
+  "owner": "postgres",
+  "defn": "CREATE USER fwd_user NOBYPASSRLS NOCREATEDB NOCREATEROLE INHERIT LOGIN NOSUPERUSER PASSWORD NULL;\n",
+  "drop_stmt": "DROP USER IF EXISTS fwd_user;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "None"
+ },
+ {
+  "dump_id": 9,
+  "desc": "SCHEMA",
+  "namespace": "",
+  "tag": "test",
+  "owner": "postgres",
+  "defn": "CREATE SCHEMA IF NOT EXISTS test;\n",
+  "drop_stmt": "DROP SCHEMA IF EXISTS test;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 4,
+  "desc": "EXTENSION",
+  "namespace": "public",
+  "tag": "citext",
+  "owner": "",
+  "defn": "CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA public;\n",
+  "drop_stmt": "DROP EXTENSION IF EXISTS citext;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 5,
+  "desc": "EXTENSION",
+  "namespace": "public",
+  "tag": "postgres_fdw",
+  "owner": "",
+  "defn": "CREATE EXTENSION IF NOT EXISTS postgres_fdw WITH SCHEMA public;\n",
+  "drop_stmt": "DROP EXTENSION IF EXISTS postgres_fdw;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 6,
+  "desc": "EXTENSION",
+  "namespace": "public",
+  "tag": "uuid-ossp",
+  "owner": "",
+  "defn": "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;\n",
+  "drop_stmt": "DROP EXTENSION IF EXISTS \"uuid-ossp\";\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 48,
+  "desc": "AGGREGATE",
+  "namespace": "test",
+  "tag": "test_agg",
+  "owner": "postgres",
+  "defn": "CREATE AGGREGATE test.test_agg (IN integer) (SFUNC = test.test_aggregate, STYPE = integer);\n",
+  "drop_stmt": "DROP AGGREGATE IF EXISTS test.test_agg (IN integer);\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 11,
+  "desc": "OPERATOR",
+  "namespace": "test",
+  "tag": "===",
+  "owner": "postgres",
+  "defn": "CREATE OPERATOR test.=== (PROCEDURE = area_equal_procedure, LEFTARG = box, RIGHTARG = box, COMMUTATOR = ===, NEGATOR = !==, RESTRICT = area_restriction_procedure, JOIN = area_join_procedure, HASHES, MERGES);\n",
+  "drop_stmt": "DROP OPERATOR IF EXISTS test.=== (box, box);\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 32,
+  "desc": "CAST",
+  "namespace": "test",
+  "tag": "(int4 AS timestamp)",
+  "owner": "postgres",
+  "defn": "CREATE CAST (int4 AS timestamp) WITH FUNCTION to_timestamp(int4) AS ASSIGNMENT;\n",
+  "drop_stmt": "DROP CAST IF EXISTS (int4 AS timestamp);\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 13,
+  "desc": "COLLATION",
+  "namespace": "test",
+  "tag": "french",
+  "owner": "postgres",
+  "defn": "CREATE COLLATION test.french (LOCALE = fr_FR.utf8);\n",
+  "drop_stmt": "DROP COLLATION IF EXISTS test.french;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 14,
+  "desc": "CONVERSION",
+  "namespace": "test",
+  "tag": "myconv",
+  "owner": "postgres",
+  "defn": "CREATE CONVERSION test.myconv FOR UTF8 TO LATIN1 FROM utf8_to_latin1;\n",
+  "drop_stmt": "DROP CONVERSION IF EXISTS test.myconv;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 8,
+  "desc": "PROCEDURAL LANGUAGE",
+  "namespace": "",
+  "tag": "plpython3u",
+  "owner": "postgres",
+  "defn": "CREATE OR REPLACE LANGUAGE plpython3u;\n",
+  "drop_stmt": "DROP LANGUAGE IF EXISTS plpython3u;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 7,
+  "desc": "FOREIGN DATA WRAPPER",
+  "namespace": "",
+  "tag": "file",
+  "owner": "postgres",
+  "defn": "CREATE FOREIGN DATA WRAPPER file HANDLER file_fdw_handler NO VALIDATOR;\n",
+  "drop_stmt": "DROP FOREIGN DATA WRAPPER IF EXISTS file;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 53,
+  "desc": "SERVER",
+  "namespace": "",
+  "tag": "localhost",
+  "owner": "postgres",
+  "defn": "CREATE SERVER localhost FOREIGN DATA WRAPPER postgres_fdw OPTIONS host 'localhost', port 5432, user 'fdw_user', dbname 'postgres';\n",
+  "drop_stmt": "DROP SERVER IF EXISTS localhost;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 19,
+  "desc": "DOMAIN",
+  "namespace": "test",
+  "tag": "email_address",
+  "owner": "postgres",
+  "defn": "CREATE DOMAIN test.email_address AS citext CONSTRAINT CHECK (value ~ '^[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$');\n",
+  "drop_stmt": "DROP DOMAIN IF EXISTS test.email_address;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 49,
+  "desc": "DOMAIN",
+  "namespace": "test",
+  "tag": "bcp47_locale",
+  "owner": "postgres",
+  "defn": "CREATE DOMAIN test.bcp47_locale AS text CONSTRAINT CHECK (value ~ '^[a-z]{2}-[A-Z]{2,3}$');\n",
+  "drop_stmt": "DROP DOMAIN IF EXISTS test.bcp47_locale;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 15,
+  "desc": "TYPE",
+  "namespace": "test",
+  "tag": "address_type",
+  "owner": "postgres",
+  "defn": "CREATE TYPE test.address_type AS ENUM ('billing', 'delivery');\n",
+  "drop_stmt": "DROP TYPE IF EXISTS test.address_type;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 16,
+  "desc": "TYPE",
+  "namespace": "test",
+  "tag": "user_state",
+  "owner": "postgres",
+  "defn": "CREATE TYPE test.user_state AS ENUM ('removed', 'suspended', 'unverified', 'verified');\n",
+  "drop_stmt": "DROP TYPE IF EXISTS test.user_state;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 17,
+  "desc": "TYPE",
+  "namespace": "test",
+  "tag": "compfoo",
+  "owner": "postgres",
+  "defn": "CREATE TYPE test.compfoo AS (f1 int, f2 text);\n",
+  "drop_stmt": "DROP TYPE IF EXISTS test.compfoo;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 18,
+  "desc": "TYPE",
+  "namespace": "test",
+  "tag": "float8_range",
+  "owner": "postgres",
+  "defn": "CREATE TYPE test.float8_range AS RANGE (SUBTYPE = float8, SUBTYPE_DIFF = float8mi);\n",
+  "drop_stmt": "DROP TYPE IF EXISTS test.float8_range;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 21,
+  "desc": "TABLESPACE",
+  "namespace": "",
+  "tag": "temp",
+  "owner": "postgres",
+  "defn": "CREATE TABLESPACE temp OWNER postgres LOCATION /tmp;\n",
+  "drop_stmt": "DROP TABLESPACE IF EXISTS temp;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 23,
+  "desc": "TABLE",
+  "namespace": "test",
+  "tag": "empty_table",
+  "owner": "postgres",
+  "defn": "CREATE TABLE test.empty_table ( id BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY, created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT 'CURRENT_TIMESTAMP', last_modified_at TIMESTAMP WITH TIME ZONE, value TEXT );\n",
+  "drop_stmt": "DROP TABLE IF EXISTS test.empty_table;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 27,
+  "desc": "SEQUENCE",
+  "namespace": "test",
+  "tag": "empty_table_id",
+  "owner": "postgres",
+  "defn": "CREATE SEQUENCE test.empty_table_id AS BIGINT INCREMENT BY 10 MAXVALUE 1000000 START WITH 100 CACHE 2 OWNED BY test.empty_table;\n",
+  "drop_stmt": "DROP SEQUENCE IF EXISTS test.empty_table_id;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 28,
+  "desc": "FUNCTION",
+  "namespace": "test",
+  "tag": "disable_alter_domain()",
+  "owner": "postgres",
+  "defn": "CREATE FUNCTION disable_alter_domain() RETURNS event_trigger LANGUAGE plpgsql AS $$\nBEGIN\n  IF tg_tag = 'ALTER DOMAIN' THEN\n    RAISE EXCEPTION '% is disabled', tg_tag;\n  END IF;\nEND;\n\n$$;\n",
+  "drop_stmt": "DROP FUNCTION IF EXISTS disable_alter_domain();\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 29,
+  "desc": "FUNCTION",
+  "namespace": "test",
+  "tag": "test_aggregate(integer, integer)",
+  "owner": "postgres",
+  "defn": "CREATE FUNCTION test_aggregate(integer, integer) RETURNS INTEGER LANGUAGE sql AS $$\nSELECT array_agg($1);\n\n$$;\n",
+  "drop_stmt": "DROP FUNCTION IF EXISTS test_aggregate(integer, integer);\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 30,
+  "desc": "FUNCTION",
+  "namespace": "test",
+  "tag": "utf8_to_latin1(integer, integer, cstring, internal, integer)",
+  "owner": "postgres",
+  "defn": "CREATE FUNCTION utf8_to_latin1(IN source_encoding_id INTEGER, IN destination_encoding_id INTEGER, IN source CSTRING, IN destination INTERNAL, IN source_length INTEGER) RETURNS TEXT LANGUAGE plpython3u AS $$\nreturn source.encode('UTF8').decode('LATIN-1')\n\n$$;\n",
+  "drop_stmt": "DROP FUNCTION IF EXISTS utf8_to_latin1(IN source_encoding_id INTEGER, IN destination_encoding_id INTEGER, IN source CSTRING, IN destination INTERNAL, IN source_length INTEGER);\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 34,
+  "desc": "TEXT SEARCH CONFIGURATION",
+  "namespace": "test",
+  "tag": "Copy of default things",
+  "owner": "postgres",
+  "defn": "CREATE TEXT SEARCH CONFIGURATION custom_english (['PARSER', '=', 'custom_default']);\n",
+  "drop_stmt": "DROP TEXT SEARCH CONFIGURATION IF EXISTS custom_english;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 35,
+  "desc": "TEXT SEARCH CONFIGURATION",
+  "namespace": "test",
+  "tag": "Copy of german config",
+  "owner": "postgres",
+  "defn": "CREATE TEXT SEARCH CONFIGURATION custom_german (['SOURCE', '=', 'german']);\n",
+  "drop_stmt": "DROP TEXT SEARCH CONFIGURATION IF EXISTS custom_german;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 36,
+  "desc": "TEXT SEARCH DICTIONARY",
+  "namespace": "test",
+  "tag": "",
+  "owner": "postgres",
+  "defn": "CREATE TEXT SEARCH DICTIONARY custom_simple (TEMPLATE = custom_snowball, language = 'english', stopwords = 'english');\n",
+  "drop_stmt": "DROP TEXT SEARCH DICTIONARY IF EXISTS custom_simple;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 37,
+  "desc": "TEXT SEARCH PARSER",
+  "namespace": "test",
+  "tag": "Simple copy of the default parser values",
+  "owner": "postgres",
+  "defn": "CREATE TEXT SEARCH PARSER custom_default (START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype, HEADLINE = prsd_headline);\n",
+  "drop_stmt": "DROP TEXT SEARCH PARSER IF EXISTS custom_default;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 38,
+  "desc": "TEXT SEARCH TEMPLATE",
+  "namespace": "test",
+  "tag": "Copied from the snowball template",
+  "owner": "postgres",
+  "defn": "CREATE TEXT SEARCH TEMPLATE custom_snowball (INIT = dsnowball_init, LEXIZE = dsnowball_lexize);\n",
+  "drop_stmt": "DROP TEXT SEARCH TEMPLATE IF EXISTS custom_snowball;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 42,
+  "desc": "SUBSCRIPTION",
+  "namespace": "",
+  "tag": "localhost_test",
+  "owner": "postgres",
+  "defn": "CREATE SUBSCRIPTION localhost_test CONNECTION host=localhost port=5432 dbname=logical_replication user=postgres PUBLICATION all_tables WITH copy_data = True, create_slot = True, enabled = True, synchronous_commit = 'on', connect = True;\n",
+  "drop_stmt": "DROP SUBSCRIPTION IF EXISTS localhost_test;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 47,
+  "desc": "USER MAPPING",
+  "namespace": "",
+  "tag": "postgres",
+  "owner": "postgres",
+  "defn": "CREATE USER MAPPING FOR postgres SERVER localhost OPTIONS (user 'fdw_user');\n",
+  "drop_stmt": "DROP USER MAPPING IF EXISTS FOR postgres SERVER localhost;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 51,
+  "desc": "TABLE",
+  "namespace": "test",
+  "tag": "addresses",
+  "owner": "postgres",
+  "defn": "CREATE TABLE test.addresses ( id UUID NOT NULL DEFAULT 'uuid_generate_v4()', created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT 'CURRENT_TIMESTAMP', last_modified_at TIMESTAMP WITH TIME ZONE, user_id UUID NOT NULL, address1 TEXT NOT NULL, address2 TEXT, address3 TEXT, locality TEXT NOT NULL, region TEXT, postal_code TEXT NOT NULL, country TEXT NOT NULL, FOREIGN KEY (user_id) REFERENCES test.users (id) ON_DELETE CASCADE ON_UPDATE CASCADE );\n",
+  "drop_stmt": "DROP TABLE IF EXISTS test.addresses;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 55,
+  "desc": "TABLE",
+  "namespace": "test",
+  "tag": "users",
+  "owner": "postgres",
+  "defn": "CREATE TABLE test.users ( id UUID NOT NULL DEFAULT 'uuid_generate_v4()', created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT 'CURRENT_TIMESTAMP', last_modified_at, TIMESTAMP WITH TIME ZONE,, state user_state NOT NULL DEFAULT 'unverified', email email_address NOT NULL, name TEXT NOT NULL, surname TEXT NOT NULL, display_name TEXT, locale bcp47_locale NOT NULL DEFAULT 'en-US', password_salt TEXT NOT NULL, password TEXT NOT NULL, signup_ip INET NOT NULL, icon oid );\n",
+  "drop_stmt": "DROP TABLE IF EXISTS test.users;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 58,
+  "desc": "VIEW",
+  "namespace": "test",
+  "tag": "user_addresses",
+  "owner": "postgres",
+  "defn": "CREATE VIEW test.user_addresses AS SELECT id,\n       created_at,\n       last_modified_at,\n       state,\n       email,\n       name,\n       surname,\n       display_name,\n       locale,\n       password_salt,\n       password,\n       signup_ip,\n       icon\n  FROM test.users\n WHERE id IN (SELECT DISTINCT id FROM test.addresses WHERE country = 'US';\n;\n",
+  "drop_stmt": "DROP VIEW IF EXISTS test.user_addresses;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Pre-Data"
+ },
+ {
+  "dump_id": 25,
+  "desc": "INDEX",
+  "namespace": "test",
+  "tag": "empty_table_created_at",
+  "owner": "postgres",
+  "defn": "CREATE INDEX test.empty_table_created_at ON test.empty_table ( created_at DESC NULLS LAST );\n",
+  "drop_stmt": "DROP INDEX IF EXISTS test.empty_table_created_at;\n",
+  "tablespace": null,
+  "dependencies": [
+   23
+  ],
+  "section": "Post-Data"
+ },
+ {
+  "dump_id": 57,
+  "desc": "INDEX",
+  "namespace": "test",
+  "tag": "users_unique_email",
+  "owner": "postgres",
+  "defn": "CREATE UNIQUE INDEX test.users_unique_email ON test.users ( email );\n",
+  "drop_stmt": "DROP INDEX IF EXISTS test.users_unique_email;\n",
+  "tablespace": null,
+  "dependencies": [
+   55
+  ],
+  "section": "Post-Data"
+ },
+ {
+  "dump_id": 39,
+  "desc": "EVENT TRIGGER",
+  "namespace": "",
+  "tag": "disable_alter_domain",
+  "owner": "postgres",
+  "defn": "CREATE EVENT TRIGGER disable_alter_domain ON ddl_command_start WHEN TAG IN (['ALTER DOMAIN']) EXECUTE FUNCTION test.disable_alter_domain();\n",
+  "drop_stmt": "DROP EVENT TRIGGER IF EXISTS disable_alter_domain;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Post-Data"
+ },
+ {
+  "dump_id": 40,
+  "desc": "PUBLICATION",
+  "namespace": "",
+  "tag": "test",
+  "owner": "postgres",
+  "defn": "CREATE PUBLICATION test FOR ALL TABLES;\n",
+  "drop_stmt": "DROP PUBLICATION IF EXISTS test;\n",
+  "tablespace": null,
+  "dependencies": [],
+  "section": "Post-Data"
+ },
+ {
+  "dump_id": 60,
+  "desc": "MATERIALIZED VIEW",
+  "namespace": "test",
+  "tag": "user_addresses",
+  "owner": "postgres",
+  "defn": "CREATE MATERIALIZED VIEW test.user_addresses (user_id, email, address1, address2, address3, locality, region, postal_code, country) TABLESPACE temp AS SELECT a.id AS user_id,\n       a.email,\n       b.address1,\n       b.address2,\n       b.address3,\n       b.locality,\n       b.region,\n       b.postal_code,\n       b.country\n  FROM test.users AS a\n  JOIN test.addresses AS b\n    ON b.user_id = a.id;\n;\n",
+  "drop_stmt": "DROP MATERIALIZED VIEW IF EXISTS test.user_addresses;\n",
+  "tablespace": "temp",
+  "dependencies": [],
+  "section": "Post-Data"
+ },
+ {
+  "dump_id": 10,
+  "desc": "COMMENT",
+  "namespace": "",
+  "tag": "test",
+  "owner": "postgres",
+  "defn": "COMMENT ON SCHEMA test IS $$Common test schema$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   9
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 12,
+  "desc": "COMMENT",
+  "namespace": "test",
+  "tag": "===",
+  "owner": "postgres",
+  "defn": "COMMENT ON OPERATOR test.=== IS $$Ripped directly from Postgres docs - should not work$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   11
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 20,
+  "desc": "COMMENT",
+  "namespace": "test",
+  "tag": "email_address",
+  "owner": "postgres",
+  "defn": "COMMENT ON DOMAIN test.email_address IS $$Validates an email address against a simplified regex$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   19
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 22,
+  "desc": "COMMENT",
+  "namespace": "",
+  "tag": "temp",
+  "owner": "postgres",
+  "defn": "COMMENT ON TABLESPACE temp IS $$It's temporary$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   21
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 24,
+  "desc": "COMMENT",
+  "namespace": "test",
+  "tag": "empty_table",
+  "owner": "postgres",
+  "defn": "COMMENT ON TABLE test.empty_table IS $$Simple table without much substance$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   23
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 26,
+  "desc": "COMMENT",
+  "namespace": "test",
+  "tag": "empty_table_created_at",
+  "owner": "postgres",
+  "defn": "COMMENT ON INDEX test.empty_table_created_at IS $$Index covering the created_at column$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   25
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 31,
+  "desc": "COMMENT",
+  "namespace": "test",
+  "tag": "utf8_to_latin1(integer, integer, cstring, internal, integer)",
+  "owner": "postgres",
+  "defn": "COMMENT ON FUNCTION test.utf8_to_latin1(integer, integer, cstring, internal, integer) IS $$Used for a conversion to convert from UTF-8 to Latin-1$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   30
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 33,
+  "desc": "COMMENT",
+  "namespace": "test",
+  "tag": "(int4 AS timestamp)",
+  "owner": "postgres",
+  "defn": "COMMENT ON CAST test.(int4 AS timestamp) IS $$Test cast for sure$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   32
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 41,
+  "desc": "COMMENT",
+  "namespace": "",
+  "tag": "test",
+  "owner": "postgres",
+  "defn": "COMMENT ON PUBLICATION test IS $$Test publication exposing all tables$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   40
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 43,
+  "desc": "COMMENT",
+  "namespace": "",
+  "tag": "localhost_test",
+  "owner": "postgres",
+  "defn": "COMMENT ON SUBSCRIPTION localhost_test IS $$Test logical replication subscription that requires a local database\nsetup with the name `logical_replication` and a publication named\n`all_tables`.\n$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   42
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 50,
+  "desc": "COMMENT",
+  "namespace": "test",
+  "tag": "bcp47_locale",
+  "owner": "postgres",
+  "defn": "COMMENT ON DOMAIN test.bcp47_locale IS $$Simplified locale check, doesn't fully conform to BCP-47$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   49
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 52,
+  "desc": "COMMENT",
+  "namespace": "test",
+  "tag": "addresses",
+  "owner": "postgres",
+  "defn": "COMMENT ON TABLE test.addresses IS $$Generic contact addresses table$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   51
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 54,
+  "desc": "COMMENT",
+  "namespace": "",
+  "tag": "localhost",
+  "owner": "postgres",
+  "defn": "COMMENT ON SERVER localhost IS $$Example FDW that conencts back to the same server on a different DB$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   53
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 56,
+  "desc": "COMMENT",
+  "namespace": "test",
+  "tag": "users",
+  "owner": "postgres",
+  "defn": "COMMENT ON TABLE test.users IS $$Sample user table$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   55
+  ],
+  "section": "None"
+ },
+ {
+  "dump_id": 59,
+  "desc": "COMMENT",
+  "namespace": "test",
+  "tag": "user_addresses",
+  "owner": "postgres",
+  "defn": "COMMENT ON VIEW test.user_addresses IS $$This is a test view$$;\n;\n",
+  "drop_stmt": ";\n",
+  "tablespace": null,
+  "dependencies": [
+   58
+  ],
+  "section": "None"
+ }
+]


### PR DESCRIPTION
## Summary

Ports dump.py (the largest Python module): per-object SQL renderers for all 27 object types, COMMENT entries, and archive emission through libpgdump.

- **Bug-for-bug faithful by default** so archives compare entry-by-entry against the Python implementation, with eight documented fixes where Python emitted unambiguously broken SQL (full list in the `src/build/mod.rs` module docs and `tests/build_parity.rs`): BYPASSRLS read from `create_db`, silently dropped primary keys, `ON_DELETE`/`ON_UPDATE`, Python list reprs interpolated into text search / event trigger clauses, text search entries tagged with their comment text, broken column COLLATE, SEND/SUBTYPE_OPCLASS read from the wrong fields.
- **No hand-rolled toposort.** Inventory dependency edges are recorded on the archive entries and ordering is delegated entirely to libpgdump's weighted pg_dump topological sort (run by `save()`). PLAN.md updated to drop the petgraph plan.
- ACL/grant emission intentionally absent — the Python build never emitted grants into the archive.
- `.gitignore`: anchor `/build/` + negate `!/src/build/` (a global `build/` ignore was silently excluding the new module).

## Phase 2 gates

- **Parity**: `tests/build_parity.rs` compares the built archive against `tests/fixtures/python-build-entries.json` (exported from a Python build of test-project). All 47 non-deviant entries match exactly; the 13 deviant entries are asserted in their corrected forms; 4 text search comments Python lost to its tag bug are verified present (64 entries total vs Python's 60).
- **Correctness**: `pg_restore` of both artifacts into Docker postgres:17 yields **byte-identical** `pg_dump --schema-only` output (modulo the random `\restrict` token), and the failed-statement sets differ by exactly the documented deviations.
- **Cross-validation**: the Rust archive loads cleanly in Python pgdumplib and `pg_restore -l`.

## Notes for review

- Several faithful-but-odd renderings remain on purpose (quoted column defaults, `OPTIONS` without parens on SERVER, Python-style `True`/`False` in parameter values, unqualified text search names). The Phase 3 round-trip gate against real pg_dump output is where rendering gets corrected wholesale; fixing them now would break the parity baseline.
- Upstream observation: libpgdump's `Dump::new()` prelude entries carry empty tags where pg_dump (and pgdumplib) use `ENCODING`/`STDSTRINGS`/`SEARCHPATH` — might be worth fixing in libpgdump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `build` command is now fully implemented and creates PostgreSQL-compatible archives from projects.

* **Chores**
  * Updated minimum Rust version requirement from 1.85 to 1.88.
  * Added libpgdump dependency for archive generation.

* **Tests**
  * Added integration tests to validate build output correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->