### PR TITLE
Phase 3: ddl module — table statement family

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,8 @@ dependencies = [
  "serde_norway",
  "simplelog",
  "tempfile",
+ "tree-sitter",
+ "tree-sitter-postgres",
 ]
 
 [[package]]
@@ -1097,6 +1099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1215,36 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-postgres"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb97cfd489765a143311254db8216825009a222faa73210edc4c123f23a291ff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150", features = ["preserve_order"] }
 serde_norway = "0.9.42"
 simplelog = "0.12"
+tree-sitter = "0.26"
+tree-sitter-postgres = "1.1"
 
 [dev-dependencies]
 libpgdump = "2.1"

--- a/PLAN.md
+++ b/PLAN.md
@@ -8,8 +8,9 @@ selected pieces of [postgres-lsp](https://crates.io/crates/postgres-lsp-parse).
 
 ## Goals
 
-- Functional parity with the Python tool: `create`, `build`, and `generate`
-  commands operating on the same YAML project layout.
+- Functional parity with the Python tool: `create`, `build`, and `pull`
+  (which replaces the Python `generate`; see Phase 3) commands operating
+  on the same YAML project layout.
 - Two new capabilities beyond parity (see New Capabilities below):
   database-to-repo updates of an existing project (`pull`), and
   repo-to-database schema synchronization (`deploy`).

--- a/PLAN.md
+++ b/PLAN.md
@@ -225,17 +225,27 @@ ships something testable against the Python implementation.
 
 ### Phase 3 — `pull` (bootstrap mode; replaces `generate`)
 - Parse `pg_dump -Fc` with libpgdump, classify entries, extract structure
-  from DDL via the `ddl` module, write the YAML project. Use libpgfmt
-  (AWeber style) for view queries and function bodies. Port `--extract-roles`
-  (pg_dumpall subprocess) and the ignore/remaining-yaml options. The
-  command ships as `pull` (see New Capabilities); semantics in this phase
-  match Python `generate --extract` exactly.
-- This ports `generate_dump.py` + `generate_project.py` + `tokenizer.py` —
-  the bulk of the remaining work.
+  from DDL via the `ddl` module, and write the YAML project **in the
+  structured format** (the test-project/ shape: columns, constraints,
+  indexes as data — not raw SQL). Use libpgfmt (AWeber style) for view
+  queries and function bodies. Port `--extract-roles` (pg_dumpall
+  subprocess) and the ignore/remaining-yaml options. The command ships as
+  `pull` (see New Capabilities).
+- **Decision (2026-06-11):** the Python `generate` emitted sql-passthrough
+  YAML (raw DDL in `sql:` keys, children as nested sql entries). That
+  output violates the schemata contract (`additionalProperties: false`)
+  and cannot be loaded by `project.load` in either implementation — the
+  Python round-trip never worked end-to-end, and `generate` on main
+  crashes outright (`_mark_remaining_processed` lives on the wrong
+  class). Output parity with Python `generate` is therefore dropped as a
+  gate; the structured format honors the schemata contract and gives
+  Phases 5–6 the model-level data the `diff` module requires.
+- This replaces `generate_project.py` + `tokenizer.py`; lands as several
+  PRs (the `ddl` module per statement family, then pgdump.rs + the pull
+  assembly).
 - **Gate (round-trip):** `fixtures/schema.sql` → Docker pg → `pg_dump` →
-  Rust `generate` → Rust `build` → `pg_restore` → re-dump → schema diff is
-  empty. Also: Rust `generate` output vs Python `generate` output on the
-  same dump (semantic YAML diff).
+  Rust `pull` → load + validate against the schemata → Rust `build` →
+  `pg_restore` → re-dump → schema diff is empty.
 
 ### Phase 4 — Cutover
 - Port docs (mkdocs → keep, or switch to README + docs.rs), release

--- a/src/ddl/mod.rs
+++ b/src/ddl/mod.rs
@@ -86,18 +86,18 @@ impl Parser {
             let Some(node) = stmt.named_child(0) else {
                 continue;
             };
-            statements.push(dispatch(&node, sql)?);
+            statements.extend(dispatch(&node, sql)?);
         }
         Ok(statements)
     }
 }
 
-fn dispatch(node: &Node, src: &str) -> Result<Statement, String> {
+fn dispatch(node: &Node, src: &str) -> Result<Vec<Statement>, String> {
     match node.kind() {
-        "CreateStmt" => table::create_table(node, src),
-        "IndexStmt" => table::create_index(node, src),
+        "CreateStmt" => Ok(vec![table::create_table(node, src)?]),
+        "IndexStmt" => Ok(vec![table::create_index(node, src)?]),
         "AlterTableStmt" => table::alter_table(node, src),
-        other => Ok(Statement::Unsupported(other.to_string())),
+        other => Ok(vec![Statement::Unsupported(other.to_string())]),
     }
 }
 
@@ -174,12 +174,20 @@ fn collect<'tree>(
 }
 
 /// Extract (schema, name) from a `qualified_name` node
-pub(crate) fn qualified_name(node: &Node, src: &str) -> QualifiedName {
+pub(crate) fn qualified_name(
+    node: &Node,
+    src: &str,
+) -> Result<QualifiedName, String> {
     let head = node
         .child_of_kind("ColId")
         .map(|n| unquote(n.text(src)))
-        .unwrap_or_default();
-    match node.find("attr_name") {
+        .ok_or_else(|| {
+            format!(
+                "qualified_name missing ColId: {}",
+                truncate(node.text(src), 80)
+            )
+        })?;
+    Ok(match node.find("attr_name") {
         Some(attr) => QualifiedName {
             schema: Some(head),
             name: unquote(attr.text(src)),
@@ -188,7 +196,7 @@ pub(crate) fn qualified_name(node: &Node, src: &str) -> QualifiedName {
             schema: None,
             name: head,
         },
-    }
+    })
 }
 
 /// Strip identifier quoting: `"Name"` → `Name`, `""` escapes collapse

--- a/src/ddl/mod.rs
+++ b/src/ddl/mod.rs
@@ -1,0 +1,201 @@
+//! DDL parsing: tree-sitter-postgres CST → models (replaces
+//! tokenizer.py)
+//!
+//! The grammar is generated from PostgreSQL's gram.y, so node kinds
+//! mirror grammar productions (`CreateStmt`, `columnDef`,
+//! `ConstraintElem`, ...) and carry no named fields — extraction walks
+//! the tree by kind via the [`NodeExt`] helpers.
+
+mod table;
+
+use tree_sitter::Node;
+
+use crate::models;
+
+/// A single parsed DDL statement, mapped onto the project models
+#[derive(Clone, Debug, PartialEq)]
+pub enum Statement {
+    CreateTable(Box<models::Table>),
+    /// CREATE INDEX — `table` is the qualified relation name
+    CreateIndex {
+        table: QualifiedName,
+        index: models::Index,
+    },
+    /// ALTER TABLE ... ADD CONSTRAINT
+    AddConstraint {
+        table: QualifiedName,
+        name: Option<String>,
+        constraint: TableConstraint,
+    },
+    /// Parsed successfully but not (yet) a supported statement type
+    Unsupported(String),
+}
+
+/// A table constraint from inline DDL or ALTER TABLE ... ADD
+#[derive(Clone, Debug, PartialEq)]
+pub enum TableConstraint {
+    PrimaryKey(models::ConstraintColumns),
+    Unique(models::ConstraintColumns),
+    Check(String),
+    ForeignKey(models::ForeignKey),
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct QualifiedName {
+    pub schema: Option<String>,
+    pub name: String,
+}
+
+impl std::fmt::Display for QualifiedName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.schema {
+            Some(schema) => write!(f, "{schema}.{}", self.name),
+            None => f.write_str(&self.name),
+        }
+    }
+}
+
+pub struct Parser {
+    inner: tree_sitter::Parser,
+}
+
+impl Parser {
+    pub fn new() -> Result<Self, String> {
+        let mut inner = tree_sitter::Parser::new();
+        inner
+            .set_language(&tree_sitter_postgres::LANGUAGE.into())
+            .map_err(|e| format!("failed to load postgres grammar: {e}"))?;
+        Ok(Self { inner })
+    }
+
+    /// Parse a blob of one or more SQL statements
+    pub fn parse(&mut self, sql: &str) -> Result<Vec<Statement>, String> {
+        let tree = self
+            .inner
+            .parse(sql, None)
+            .ok_or_else(|| String::from("tree-sitter returned no tree"))?;
+        let root = tree.root_node();
+        if root.has_error() {
+            return Err(format!(
+                "syntax error parsing: {}",
+                truncate(sql, 120)
+            ));
+        }
+        let mut statements = Vec::new();
+        for stmt in root.find_all("stmt") {
+            let Some(node) = stmt.named_child(0) else {
+                continue;
+            };
+            statements.push(dispatch(&node, sql)?);
+        }
+        Ok(statements)
+    }
+}
+
+fn dispatch(node: &Node, src: &str) -> Result<Statement, String> {
+    match node.kind() {
+        "CreateStmt" => table::create_table(node, src),
+        "IndexStmt" => table::create_index(node, src),
+        "AlterTableStmt" => table::alter_table(node, src),
+        other => Ok(Statement::Unsupported(other.to_string())),
+    }
+}
+
+fn truncate(value: &str, len: usize) -> &str {
+    match value.char_indices().nth(len) {
+        Some((offset, _)) => &value[..offset],
+        None => value,
+    }
+}
+
+/// Walk-by-kind helpers for the fieldless CST
+pub(crate) trait NodeExt<'tree> {
+    /// The first descendant of `kind`, depth-first
+    fn find(&self, kind: &str) -> Option<Node<'tree>>;
+    /// All descendants of `kind`, not descending into matches (so
+    /// left-recursive list productions flatten naturally)
+    fn find_all(&self, kind: &str) -> Vec<Node<'tree>>;
+    /// The first direct child of `kind`
+    fn child_of_kind(&self, kind: &str) -> Option<Node<'tree>>;
+    /// Whether any descendant of `kind` exists
+    fn has(&self, kind: &str) -> bool {
+        self.find(kind).is_some()
+    }
+    /// The source text for this node
+    fn text<'src>(&self, src: &'src str) -> &'src str;
+}
+
+impl<'tree> NodeExt<'tree> for Node<'tree> {
+    fn find(&self, kind: &str) -> Option<Node<'tree>> {
+        let mut cursor = self.walk();
+        for child in self.children(&mut cursor) {
+            if child.kind() == kind {
+                return Some(child);
+            }
+        }
+        let mut cursor = self.walk();
+        for child in self.children(&mut cursor) {
+            if let Some(found) = child.find(kind) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn find_all(&self, kind: &str) -> Vec<Node<'tree>> {
+        let mut results = Vec::new();
+        collect(self, kind, &mut results);
+        results
+    }
+
+    fn child_of_kind(&self, kind: &str) -> Option<Node<'tree>> {
+        let mut cursor = self.walk();
+        self.children(&mut cursor).find(|c| c.kind() == kind)
+    }
+
+    fn text<'src>(&self, src: &'src str) -> &'src str {
+        &src[self.start_byte()..self.end_byte()]
+    }
+}
+
+fn collect<'tree>(
+    node: &Node<'tree>,
+    kind: &str,
+    results: &mut Vec<Node<'tree>>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == kind {
+            results.push(child);
+        } else {
+            collect(&child, kind, results);
+        }
+    }
+}
+
+/// Extract (schema, name) from a `qualified_name` node
+pub(crate) fn qualified_name(node: &Node, src: &str) -> QualifiedName {
+    let head = node
+        .child_of_kind("ColId")
+        .map(|n| unquote(n.text(src)))
+        .unwrap_or_default();
+    match node.find("attr_name") {
+        Some(attr) => QualifiedName {
+            schema: Some(head),
+            name: unquote(attr.text(src)),
+        },
+        None => QualifiedName {
+            schema: None,
+            name: head,
+        },
+    }
+}
+
+/// Strip identifier quoting: `"Name"` → `Name`, `""` escapes collapse
+pub(crate) fn unquote(value: &str) -> String {
+    if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+        value[1..value.len() - 1].replace("\"\"", "\"")
+    } else {
+        value.to_string()
+    }
+}

--- a/src/ddl/table.rs
+++ b/src/ddl/table.rs
@@ -17,8 +17,8 @@ pub(crate) fn create_table(
 ) -> Result<Statement, String> {
     let name = node
         .find("qualified_name")
-        .map(|n| qualified_name(&n, src))
         .ok_or_else(|| String::from("CREATE TABLE without a name"))?;
+    let name = qualified_name(&name, src)?;
     let mut table = Table {
         name: name.name,
         schema: name.schema.unwrap_or_default(),
@@ -133,8 +133,8 @@ pub(crate) fn create_index(
     let table = node
         .find("relation_expr")
         .and_then(|n| n.find("qualified_name"))
-        .map(|n| qualified_name(&n, src))
         .ok_or_else(|| String::from("CREATE INDEX without a relation"))?;
+    let table = qualified_name(&table, src)?;
     let name = node
         .child_of_kind("opt_single_name")
         .map(|n| unquote(n.text(src)))
@@ -206,16 +206,18 @@ fn direction(node: &Node) -> Option<String> {
         .map(|n| if n.has("kw_desc") { "DESC" } else { "ASC" }.to_string())
 }
 
-/// ALTER TABLE ... ADD CONSTRAINT (other forms → Unsupported)
+/// ALTER TABLE ... ADD CONSTRAINT, one statement per command
+/// (other forms → Unsupported)
 pub(crate) fn alter_table(
     node: &Node,
     src: &str,
-) -> Result<Statement, String> {
+) -> Result<Vec<Statement>, String> {
     let table = node
         .find("relation_expr")
         .and_then(|n| n.find("qualified_name"))
-        .map(|n| qualified_name(&n, src))
         .ok_or_else(|| String::from("ALTER TABLE without a relation"))?;
+    let table = qualified_name(&table, src)?;
+    let mut statements = Vec::new();
     for cmd in node.find_all("alter_table_cmd") {
         if !cmd.has("kw_add") {
             continue;
@@ -224,16 +226,19 @@ pub(crate) fn alter_table(
             continue;
         };
         let (name, parsed) = table_constraint(&constraint, src)?;
-        return Ok(Statement::AddConstraint {
-            table,
+        statements.push(Statement::AddConstraint {
+            table: table.clone(),
             name,
             constraint: parsed,
         });
     }
-    Ok(Statement::Unsupported(format!(
-        "ALTER TABLE {table}: {}",
-        crate::ddl::truncate(node.text(src), 80)
-    )))
+    if statements.is_empty() {
+        statements.push(Statement::Unsupported(format!(
+            "ALTER TABLE {table}: {}",
+            crate::ddl::truncate(node.text(src), 80)
+        )));
+    }
+    Ok(statements)
 }
 
 /// Parse a TableConstraint node into (name, constraint)
@@ -310,8 +315,8 @@ fn foreign_key(
     let columns = column_list(elem, src);
     let references = elem
         .find("qualified_name")
-        .map(|n| qualified_name(&n, src))
         .ok_or_else(|| String::from("FOREIGN KEY without a reference"))?;
+    let references = qualified_name(&references, src)?;
     let ref_columns: Vec<String> = elem
         .child_of_kind("opt_column_and_period_list")
         .map(|n| {
@@ -565,6 +570,26 @@ mod tests {
         assert_eq!(fk.references.columns, vec!["id"]);
         assert_eq!(fk.on_delete, Some("CASCADE".into()));
         assert_eq!(fk.on_update, Some("CASCADE".into()));
+    }
+
+    #[test]
+    fn parses_alter_table_multiple_constraints() {
+        let mut parser = Parser::new().unwrap();
+        let statements = parser
+            .parse(
+                "ALTER TABLE t ADD CONSTRAINT positive CHECK (value > 0), \
+                 ADD CONSTRAINT t_value_key UNIQUE (value);",
+            )
+            .unwrap();
+        assert_eq!(statements.len(), 2);
+        let Statement::AddConstraint { name, .. } = &statements[0] else {
+            panic!("expected AddConstraint, got {:?}", statements[0])
+        };
+        assert_eq!(name.as_deref(), Some("positive"));
+        let Statement::AddConstraint { name, .. } = &statements[1] else {
+            panic!("expected AddConstraint, got {:?}", statements[1])
+        };
+        assert_eq!(name.as_deref(), Some("t_value_key"));
     }
 
     #[test]

--- a/src/ddl/table.rs
+++ b/src/ddl/table.rs
@@ -1,0 +1,605 @@
+//! CreateStmt / IndexStmt / AlterTableStmt → table models
+
+use tree_sitter::Node;
+
+use crate::ddl::{
+    NodeExt, Statement, TableConstraint, qualified_name, unquote,
+};
+use crate::models::{
+    CheckConstraint, Column, ColumnGenerated, ConstraintColumns, ForeignKey,
+    ForeignKeyReference, Index, IndexColumn, Table,
+};
+
+/// CREATE TABLE → Table (columns + inline constraints)
+pub(crate) fn create_table(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let name = node
+        .find("qualified_name")
+        .map(|n| qualified_name(&n, src))
+        .ok_or_else(|| String::from("CREATE TABLE without a name"))?;
+    let mut table = Table {
+        name: name.name,
+        schema: name.schema.unwrap_or_default(),
+        owner: String::new(),
+        sql: None,
+        unlogged: node.has("kw_unlogged").then_some(true),
+        from_type: None,
+        parents: None,
+        like_table: None,
+        columns: None,
+        indexes: None,
+        primary_key: None,
+        check_constraints: None,
+        unique_constraints: None,
+        foreign_keys: None,
+        triggers: None,
+        partition: None,
+        partitions: None,
+        access_method: None,
+        storage_parameters: None,
+        tablespace: None,
+        index_tablespace: None,
+        comment: None,
+    };
+    let mut columns = Vec::new();
+    for element in node.find_all("TableElement") {
+        if let Some(column_def) = element.child_of_kind("columnDef") {
+            columns.push(column(&column_def, src));
+        } else if let Some(constraint) =
+            element.child_of_kind("TableConstraint")
+        {
+            let (name, parsed) = table_constraint(&constraint, src)?;
+            apply_constraint(&mut table, name, parsed);
+        }
+    }
+    if !columns.is_empty() {
+        table.columns = Some(columns);
+    }
+    Ok(Statement::CreateTable(Box::new(table)))
+}
+
+fn column(node: &Node, src: &str) -> Column {
+    let name = node
+        .child_of_kind("ColId")
+        .map(|n| unquote(n.text(src)))
+        .unwrap_or_default();
+    let data_type = node
+        .child_of_kind("Typename")
+        .map(|n| n.text(src).to_string())
+        .unwrap_or_default();
+    let mut column = Column {
+        name,
+        data_type,
+        nullable: None,
+        default: None,
+        collation: None,
+        check_constraint: None,
+        generated: None,
+        comment: None,
+    };
+    for constraint in node.find_all("ColConstraintElem") {
+        if constraint.has("kw_default") {
+            if let Some(expr) = constraint.child_of_kind("b_expr") {
+                column.default =
+                    Some(serde_json::Value::String(expr.text(src).into()));
+            }
+        } else if constraint.has("kw_not") && constraint.has("kw_null") {
+            column.nullable = Some(false);
+        } else if constraint.has("kw_check") {
+            if let Some(expr) = constraint.find("a_expr") {
+                column.check_constraint = Some(expr.text(src).to_string());
+            }
+        } else if constraint.has("kw_identity") {
+            column.generated = Some(ColumnGenerated {
+                expression: None,
+                sequence: None,
+                sequence_behavior: Some(
+                    if constraint.has("kw_always") {
+                        "ALWAYS"
+                    } else {
+                        "BY DEFAULT"
+                    }
+                    .to_string(),
+                ),
+            });
+        } else if constraint.has("kw_generated")
+            && let Some(expr) = constraint.find("a_expr")
+        {
+            column.generated = Some(ColumnGenerated {
+                expression: Some(expr.text(src).to_string()),
+                sequence: None,
+                sequence_behavior: None,
+            });
+        }
+    }
+    // COLLATE lives in the column qualifier list alongside constraints
+    for qual in node.find_all("ColConstraint") {
+        if qual.has("kw_collate")
+            && let Some(name) = qual.child_of_kind("any_name")
+        {
+            column.collation = Some(name.text(src).to_string());
+        }
+    }
+    column
+}
+
+/// CREATE INDEX → (table, Index)
+pub(crate) fn create_index(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let table = node
+        .find("relation_expr")
+        .and_then(|n| n.find("qualified_name"))
+        .map(|n| qualified_name(&n, src))
+        .ok_or_else(|| String::from("CREATE INDEX without a relation"))?;
+    let name = node
+        .child_of_kind("opt_single_name")
+        .map(|n| unquote(n.text(src)))
+        .unwrap_or_default();
+    let columns: Vec<IndexColumn> = node
+        .find_all("index_elem")
+        .iter()
+        .map(|elem| index_column(elem, src))
+        .collect();
+    let index = Index {
+        name,
+        sql: None,
+        unique: node.has("opt_unique").then_some(true),
+        recurse: None,
+        parent: None,
+        method: node
+            .child_of_kind("access_method_clause")
+            .and_then(|n| n.child_of_kind("name"))
+            .map(|n| unquote(n.text(src))),
+        columns: (!columns.is_empty()).then_some(columns),
+        include: node.find("opt_c_include").map(|n| {
+            n.find_all("columnElem")
+                .iter()
+                .map(|c| unquote(c.text(src)))
+                .collect()
+        }),
+        where_clause: node
+            .child_of_kind("where_clause")
+            .and_then(|n| n.find("a_expr"))
+            .map(|n| n.text(src).to_string()),
+        storage_parameters: None,
+        tablespace: node
+            .child_of_kind("OptTableSpace")
+            .and_then(|n| n.find("name"))
+            .map(|n| unquote(n.text(src))),
+        comment: None,
+    };
+    Ok(Statement::CreateIndex { table, index })
+}
+
+fn index_column(node: &Node, src: &str) -> IndexColumn {
+    let name = node.child_of_kind("ColId").map(|n| unquote(n.text(src)));
+    let expression = if name.is_none() {
+        node.child_of_kind("func_expr_windowless")
+            .or_else(|| node.child_of_kind("a_expr"))
+            .map(|n| n.text(src).to_string())
+    } else {
+        None
+    };
+    IndexColumn {
+        name,
+        expression,
+        collation: node
+            .find("opt_collate")
+            .and_then(|n| n.find("any_name"))
+            .map(|n| n.text(src).to_string()),
+        opclass: node
+            .find("opt_qualified_name")
+            .map(|n| n.text(src).to_string()),
+        direction: direction(node),
+        null_placement: node.find("opt_nulls_order").map(|n| {
+            if n.has("kw_first") { "FIRST" } else { "LAST" }.to_string()
+        }),
+    }
+}
+
+fn direction(node: &Node) -> Option<String> {
+    node.find("opt_asc_desc")
+        .map(|n| if n.has("kw_desc") { "DESC" } else { "ASC" }.to_string())
+}
+
+/// ALTER TABLE ... ADD CONSTRAINT (other forms → Unsupported)
+pub(crate) fn alter_table(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let table = node
+        .find("relation_expr")
+        .and_then(|n| n.find("qualified_name"))
+        .map(|n| qualified_name(&n, src))
+        .ok_or_else(|| String::from("ALTER TABLE without a relation"))?;
+    for cmd in node.find_all("alter_table_cmd") {
+        if !cmd.has("kw_add") {
+            continue;
+        }
+        let Some(constraint) = cmd.find("TableConstraint") else {
+            continue;
+        };
+        let (name, parsed) = table_constraint(&constraint, src)?;
+        return Ok(Statement::AddConstraint {
+            table,
+            name,
+            constraint: parsed,
+        });
+    }
+    Ok(Statement::Unsupported(format!(
+        "ALTER TABLE {table}: {}",
+        crate::ddl::truncate(node.text(src), 80)
+    )))
+}
+
+/// Parse a TableConstraint node into (name, constraint)
+fn table_constraint(
+    node: &Node,
+    src: &str,
+) -> Result<(Option<String>, TableConstraint), String> {
+    let name = node.child_of_kind("name").map(|n| unquote(n.text(src)));
+    let elem = node
+        .child_of_kind("ConstraintElem")
+        .ok_or_else(|| String::from("constraint without ConstraintElem"))?;
+    let constraint = if elem.has("kw_foreign") {
+        TableConstraint::ForeignKey(foreign_key(
+            &elem,
+            src,
+            name.clone().unwrap_or_default(),
+        )?)
+    } else if elem.has("kw_primary") {
+        TableConstraint::PrimaryKey(constraint_columns(&elem, src))
+    } else if elem.has("kw_unique") {
+        TableConstraint::Unique(constraint_columns(&elem, src))
+    } else if elem.has("kw_check") {
+        let expression = elem
+            .find("a_expr")
+            .map(|n| n.text(src).to_string())
+            .ok_or_else(|| String::from("CHECK without an expression"))?;
+        TableConstraint::Check(expression)
+    } else {
+        return Err(format!(
+            "unsupported constraint: {}",
+            crate::ddl::truncate(elem.text(src), 80)
+        ));
+    };
+    Ok((name, constraint))
+}
+
+fn constraint_columns(elem: &Node, src: &str) -> ConstraintColumns {
+    let columns = column_list(elem, src);
+    let include: Vec<String> = elem
+        .find("opt_c_include")
+        .map(|n| {
+            n.find_all("columnElem")
+                .iter()
+                .map(|c| unquote(c.text(src)))
+                .collect()
+        })
+        .unwrap_or_default();
+    if include.is_empty() {
+        ConstraintColumns::Columns(columns)
+    } else {
+        ConstraintColumns::Detailed {
+            columns,
+            include: Some(include),
+        }
+    }
+}
+
+fn column_list(node: &Node, src: &str) -> Vec<String> {
+    node.child_of_kind("columnList")
+        .map(|list| {
+            list.find_all("columnElem")
+                .iter()
+                .map(|c| unquote(c.text(src)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn foreign_key(
+    elem: &Node,
+    src: &str,
+    name: String,
+) -> Result<ForeignKey, String> {
+    let columns = column_list(elem, src);
+    let references = elem
+        .find("qualified_name")
+        .map(|n| qualified_name(&n, src))
+        .ok_or_else(|| String::from("FOREIGN KEY without a reference"))?;
+    let ref_columns: Vec<String> = elem
+        .child_of_kind("opt_column_and_period_list")
+        .map(|n| {
+            n.find_all("columnElem")
+                .iter()
+                .map(|c| unquote(c.text(src)))
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut on_delete = None;
+    let mut on_update = None;
+    if let Some(actions) = elem.child_of_kind("key_actions") {
+        if let Some(delete) = actions.child_of_kind("key_delete") {
+            on_delete = delete
+                .child_of_kind("key_action")
+                .map(|n| n.text(src).to_uppercase());
+        }
+        if let Some(update) = actions.child_of_kind("key_update") {
+            on_update = update
+                .child_of_kind("key_action")
+                .map(|n| n.text(src).to_uppercase());
+        }
+    }
+    Ok(ForeignKey {
+        name,
+        columns,
+        references: ForeignKeyReference {
+            name: references.to_string(),
+            columns: ref_columns,
+        },
+        match_type: elem.find("key_match").map(|n| {
+            if n.has("kw_full") {
+                "FULL"
+            } else if n.has("kw_partial") {
+                "PARTIAL"
+            } else {
+                "SIMPLE"
+            }
+            .to_string()
+        }),
+        on_delete,
+        on_update,
+        deferrable: None,
+        initially_deferred: None,
+    })
+}
+
+/// Merge a parsed constraint into a table model
+pub(crate) fn apply_constraint(
+    table: &mut Table,
+    name: Option<String>,
+    constraint: TableConstraint,
+) {
+    match constraint {
+        TableConstraint::PrimaryKey(columns) => {
+            table.primary_key = Some(columns);
+        }
+        TableConstraint::Unique(columns) => {
+            table
+                .unique_constraints
+                .get_or_insert_default()
+                .push(columns);
+        }
+        TableConstraint::Check(expression) => {
+            table.check_constraints.get_or_insert_default().push(
+                CheckConstraint {
+                    name: name.unwrap_or_default(),
+                    expression,
+                },
+            );
+        }
+        TableConstraint::ForeignKey(fk) => {
+            table.foreign_keys.get_or_insert_default().push(fk);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::ddl::Parser;
+
+    fn parse_one(sql: &str) -> Statement {
+        let mut parser = Parser::new().unwrap();
+        let mut statements = parser.parse(sql).unwrap();
+        assert_eq!(statements.len(), 1, "expected one statement");
+        statements.remove(0)
+    }
+
+    #[test]
+    fn parses_create_table() {
+        let statement = parse_one(
+            "CREATE TABLE test.users (\n\
+             id uuid DEFAULT public.uuid_generate_v4() NOT NULL,\n\
+             state test.user_state DEFAULT 'unverified'::test.user_state \
+             NOT NULL,\n\
+             email test.email_address NOT NULL,\n\
+             icon oid\n\
+             );",
+        );
+        let Statement::CreateTable(table) = statement else {
+            panic!("expected CreateTable, got {statement:?}")
+        };
+        assert_eq!(table.schema, "test");
+        assert_eq!(table.name, "users");
+        let columns = table.columns.unwrap();
+        assert_eq!(columns.len(), 4);
+        assert_eq!(columns[0].name, "id");
+        assert_eq!(columns[0].data_type, "uuid");
+        assert_eq!(
+            columns[0].default,
+            Some(json!("public.uuid_generate_v4()"))
+        );
+        assert_eq!(columns[0].nullable, Some(false));
+        assert_eq!(
+            columns[1].default,
+            Some(json!("'unverified'::test.user_state"))
+        );
+        assert_eq!(columns[3].name, "icon");
+        assert_eq!(columns[3].nullable, None);
+        assert_eq!(columns[3].default, None);
+    }
+
+    #[test]
+    fn parses_identity_and_inline_constraints() {
+        let statement = parse_one(
+            "CREATE TABLE test.t (\n\
+             id bigint GENERATED ALWAYS AS IDENTITY,\n\
+             total numeric CHECK (total > 0),\n\
+             CONSTRAINT t_pkey PRIMARY KEY (id),\n\
+             UNIQUE (total)\n\
+             );",
+        );
+        let Statement::CreateTable(table) = statement else {
+            panic!("expected CreateTable")
+        };
+        let columns = table.columns.unwrap();
+        assert_eq!(
+            columns[0].generated,
+            Some(ColumnGenerated {
+                expression: None,
+                sequence: None,
+                sequence_behavior: Some("ALWAYS".into()),
+            })
+        );
+        assert_eq!(columns[1].check_constraint, Some("total > 0".into()));
+        assert_eq!(
+            table.primary_key,
+            Some(ConstraintColumns::Columns(vec!["id".into()]))
+        );
+        assert_eq!(
+            table.unique_constraints,
+            Some(vec![ConstraintColumns::Columns(vec!["total".into()])])
+        );
+    }
+
+    #[test]
+    fn parses_create_index() {
+        let statement = parse_one(
+            "CREATE UNIQUE INDEX users_unique_email ON test.users \
+             USING btree (email);",
+        );
+        let Statement::CreateIndex { table, index } = statement else {
+            panic!("expected CreateIndex")
+        };
+        assert_eq!(table.to_string(), "test.users");
+        assert_eq!(index.name, "users_unique_email");
+        assert_eq!(index.unique, Some(true));
+        assert_eq!(index.method, Some("btree".into()));
+        let columns = index.columns.unwrap();
+        assert_eq!(columns.len(), 1);
+        assert_eq!(columns[0].name, Some("email".into()));
+    }
+
+    #[test]
+    fn parses_partial_index() {
+        let statement = parse_one("CREATE INDEX i ON t (c) WHERE d IS NULL;");
+        let Statement::CreateIndex { index, .. } = statement else {
+            panic!("expected CreateIndex")
+        };
+        assert_eq!(index.where_clause, Some("d IS NULL".into()));
+        assert_eq!(index.unique, None);
+    }
+
+    // tree-sitter-postgres 1.1.6 gap: index_elem_options requires
+    // collate + opclass + direction + nulls as a mandatory sequence,
+    // so bare `DESC` / `NULLS LAST` fail to parse. Needs an upstream
+    // grammar fix (each component optional, per gram.y).
+    #[test]
+    #[ignore = "tree-sitter-postgres 1.1.6: index_elem_options not optional"]
+    fn parses_index_options() {
+        let statement = parse_one(
+            "CREATE INDEX i ON t (created_at DESC NULLS LAST) \
+             WHERE deleted_at IS NULL;",
+        );
+        let Statement::CreateIndex { index, .. } = statement else {
+            panic!("expected CreateIndex")
+        };
+        let columns = index.columns.unwrap();
+        assert_eq!(columns[0].direction, Some("DESC".into()));
+        assert_eq!(columns[0].null_placement, Some("LAST".into()));
+        assert_eq!(index.where_clause, Some("deleted_at IS NULL".into()));
+    }
+
+    #[test]
+    fn parses_alter_table_primary_key() {
+        let statement = parse_one(
+            "ALTER TABLE ONLY test.users\n    \
+             ADD CONSTRAINT users_pkey PRIMARY KEY (id);",
+        );
+        let Statement::AddConstraint {
+            table,
+            name,
+            constraint,
+        } = statement
+        else {
+            panic!("expected AddConstraint, got {statement:?}")
+        };
+        assert_eq!(table.to_string(), "test.users");
+        assert_eq!(name, Some("users_pkey".into()));
+        assert_eq!(
+            constraint,
+            TableConstraint::PrimaryKey(ConstraintColumns::Columns(vec![
+                "id".into()
+            ]))
+        );
+    }
+
+    #[test]
+    fn parses_alter_table_foreign_key() {
+        let statement = parse_one(
+            "ALTER TABLE ONLY test.addresses\n    \
+             ADD CONSTRAINT addresses_user_id_fkey FOREIGN KEY (user_id) \
+             REFERENCES test.users(id) ON UPDATE CASCADE \
+             ON DELETE CASCADE;",
+        );
+        let Statement::AddConstraint {
+            name, constraint, ..
+        } = statement
+        else {
+            panic!("expected AddConstraint")
+        };
+        assert_eq!(name, Some("addresses_user_id_fkey".into()));
+        let TableConstraint::ForeignKey(fk) = constraint else {
+            panic!("expected ForeignKey")
+        };
+        assert_eq!(fk.columns, vec!["user_id"]);
+        assert_eq!(fk.references.name, "test.users");
+        assert_eq!(fk.references.columns, vec!["id"]);
+        assert_eq!(fk.on_delete, Some("CASCADE".into()));
+        assert_eq!(fk.on_update, Some("CASCADE".into()));
+    }
+
+    #[test]
+    fn parses_alter_table_check_constraint() {
+        let statement = parse_one(
+            "ALTER TABLE t ADD CONSTRAINT positive CHECK (value > 0);",
+        );
+        let Statement::AddConstraint {
+            name, constraint, ..
+        } = statement
+        else {
+            panic!("expected AddConstraint")
+        };
+        assert_eq!(name, Some("positive".into()));
+        assert_eq!(constraint, TableConstraint::Check("value > 0".into()));
+    }
+
+    // tree-sitter-postgres 1.1.6 gap: the quoted_identifier token
+    // exists but is not reachable from ColId/ColLabel, so any quoted
+    // identifier fails to parse. Needs an upstream grammar fix.
+    #[test]
+    #[ignore = "tree-sitter-postgres 1.1.6: quoted_identifier not in ColId"]
+    fn quoted_identifiers_unquote() {
+        let statement =
+            parse_one("CREATE TABLE \"Sch\"\"ema\".\"Tab le\" (id int);");
+        let Statement::CreateTable(table) = statement else {
+            panic!("expected CreateTable")
+        };
+        assert_eq!(table.schema, "Sch\"ema");
+        assert_eq!(table.name, "Tab le");
+    }
+
+    #[test]
+    fn other_statements_are_unsupported() {
+        let statement = parse_one("CREATE VIEW v AS SELECT 1;");
+        assert!(matches!(statement, Statement::Unsupported(_)));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod build;
 pub mod cli;
 pub mod constants;
+pub mod ddl;
 pub mod models;
 pub mod project;
 pub mod skeleton;


### PR DESCRIPTION
## Summary

First of the Phase 3 PRs: the `ddl` module parses dump-entry DDL with tree-sitter-postgres into the structured models.

- `ddl::Parser` + `NodeExt` walk-by-kind helpers for the fieldless CST (`find_all` flattens the left-recursive list productions)
- **Table family**: `CreateStmt` → `Table` (columns with types, NOT NULL, defaults, CHECK, GENERATED/IDENTITY, COLLATE, inline constraints), `IndexStmt` → `Index` (unique/method/columns/include/where/tablespace), `AlterTableStmt ADD CONSTRAINT` → primary key / unique / check / foreign key
- 10 corpus-style tests per statement shape

## Architectural decision (PLAN.md updated)

`pull` will emit the **structured format** (the test-project shape), not Python's sql-passthrough. Investigation findings, recorded in PLAN.md:
- Python `generate` on main **crashes outright** (`_mark_remaining_processed` is defined on `Structure` but called on `Generate`)
- Its sql-passthrough output **violates the schemata contract** (`additionalProperties: false` rejects `constraints`/`comments`/`acls` keys)
- That output **cannot be loaded back** by `project.load` in either implementation — the Python round-trip never worked end-to-end

Output parity with Python `generate` is therefore dropped as a gate; the fixtures round-trip gate (pull → load+validate → build → restore → re-dump → empty diff) stands and the structured format is what Phases 5–6 (`diff`/`deploy`) need.

## Upstream grammar gaps (tree-sitter-postgres 1.1.6)

Two gaps found, marked as `#[ignore]` tests pending upstream fixes (per PLAN.md's fix-upstream policy):
1. **Quoted identifiers fail everywhere** — the `quoted_identifier` token exists in the grammar but is not reachable from `ColId`/`ColLabel`
2. **Index column options** — `index_elem_options` requires `collate + opclass + direction + nulls` as a mandatory sequence, so bare `DESC` / `NULLS LAST` fail

Neither affects the fixtures round-trip gate. Both will need grammar fixes + a release before real-world dumps parse reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated PostgreSQL DDL parsing for comprehensive schema analysis, extracting tables, indexes, and constraints for structured workflows
* **Documentation**
  * Updated the project plan to revise Phase 3 goals and correctness gate to target a structured YAML round-trip and schema-validation workflow
* **Chores**
  * Added parser-related dependency support for improved SQL parsing capabilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->