### PR TITLE
Phase 3: ddl module — object, view, function, and trigger families

### DIFF
--- a/examples/parse_dump.rs
+++ b/examples/parse_dump.rs
@@ -1,0 +1,50 @@
+//! Development helper: parse every DDL entry in a pg_dump archive with
+//! the ddl module and report what is supported, unsupported, or fails.
+//!
+//!     cargo run --example parse_dump -- /path/to/archive.dump
+
+use pglifecycle::ddl;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: parse_dump <archive>");
+    let dump = libpgdump::load(&path).expect("failed to load archive");
+    let mut parser = ddl::Parser::new().expect("parser init failed");
+    let (mut parsed, mut unsupported, mut errors) = (0, 0, 0);
+    for entry in dump.entries() {
+        let Some(defn) = entry.defn.as_deref() else {
+            continue;
+        };
+        if defn.trim().is_empty() || defn.starts_with("SET ") {
+            continue;
+        }
+        match parser.parse(defn) {
+            Ok(statements) => {
+                for statement in statements {
+                    if let ddl::Statement::Unsupported(kind) = statement {
+                        unsupported += 1;
+                        println!(
+                            "UNSUPPORTED {kind}: {} {}.{}",
+                            entry.desc.as_str(),
+                            entry.namespace.as_deref().unwrap_or_default(),
+                            entry.tag.as_deref().unwrap_or_default(),
+                        );
+                    } else {
+                        parsed += 1;
+                    }
+                }
+            }
+            Err(error) => {
+                errors += 1;
+                println!(
+                    "ERROR for {} {}.{}: {error}",
+                    entry.desc.as_str(),
+                    entry.namespace.as_deref().unwrap_or_default(),
+                    entry.tag.as_deref().unwrap_or_default(),
+                );
+            }
+        }
+    }
+    println!("parsed: {parsed}, unsupported: {unsupported}, errors: {errors}");
+}

--- a/examples/parse_dump.rs
+++ b/examples/parse_dump.rs
@@ -16,7 +16,10 @@ fn main() {
         let Some(defn) = entry.defn.as_deref() else {
             continue;
         };
-        if defn.trim().is_empty() || defn.starts_with("SET ") {
+        let trimmed = defn.trim();
+        if trimmed.is_empty()
+            || trimmed.to_ascii_uppercase().starts_with("SET ")
+        {
             continue;
         }
         match parser.parse(defn) {

--- a/src/ddl/function.rs
+++ b/src/ddl/function.rs
@@ -1,0 +1,220 @@
+//! Functions and procedures (CreateFunctionStmt)
+
+use tree_sitter::Node;
+
+use crate::ddl::object::{string_value, unstring};
+use crate::ddl::{NodeExt, Statement, any_name, unquote};
+use crate::models::{Function, FunctionParameter};
+
+/// CREATE [OR REPLACE] FUNCTION/PROCEDURE → Function
+pub(crate) fn create_function(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let name = node
+        .child_of_kind("func_name")
+        .map(|n| any_name(&n, src))
+        .ok_or_else(|| String::from("CREATE FUNCTION without a name"))?;
+    let mut function = Function {
+        name: name.name,
+        schema: name.schema.unwrap_or_default(),
+        owner: String::new(),
+        sql: None,
+        parameters: None,
+        returns: node
+            .child_of_kind("func_return")
+            .map(|n| n.text(src).to_string()),
+        language: None,
+        transform_types: None,
+        window: None,
+        immutable: None,
+        stable: None,
+        volatile: None,
+        leak_proof: None,
+        called_on_null_input: None,
+        strict: None,
+        security: None,
+        parallel: None,
+        cost: None,
+        rows: None,
+        support: None,
+        configuration: None,
+        definition: None,
+        object_file: None,
+        link_symbol: None,
+        comment: None,
+    };
+    let parameters: Vec<FunctionParameter> = node
+        .find_all("func_arg_with_default")
+        .iter()
+        .map(|arg| parameter(arg, src))
+        .collect();
+    if !parameters.is_empty() {
+        function.parameters = Some(parameters);
+    }
+    for option in node.find_all("createfunc_opt_item") {
+        if option.has("kw_language") {
+            function.language = option
+                .child_of_kind("NonReservedWord_or_Sconst")
+                .map(|n| unquote(n.text(src)));
+        } else if option.has("kw_as") {
+            if let Some(body) = option.find("Sconst") {
+                function.definition = Some(string_value(&body, src));
+            }
+        } else if option.has("kw_window") {
+            function.window = Some(true);
+        } else if let Some(common) =
+            option.child_of_kind("common_func_opt_item")
+        {
+            apply_common_option(&mut function, &common, src);
+        }
+    }
+    Ok(Statement::CreateFunction(Box::new(function)))
+}
+
+fn apply_common_option(function: &mut Function, node: &Node, src: &str) {
+    if node.has("kw_immutable") {
+        function.immutable = Some(true);
+    } else if node.has("kw_stable") {
+        function.stable = Some(true);
+    } else if node.has("kw_volatile") {
+        function.volatile = Some(true);
+    } else if node.has("kw_leakproof") {
+        function.leak_proof = Some(!node.has("kw_not"));
+    } else if node.has("kw_strict") {
+        function.strict = Some(true);
+    } else if node.has("kw_called") {
+        function.called_on_null_input = Some(true);
+    } else if node.has("kw_null") && node.has("kw_returns") {
+        function.called_on_null_input = Some(false);
+    } else if node.has("kw_security") {
+        function.security = Some(
+            if node.has("kw_definer") {
+                "DEFINER"
+            } else {
+                "INVOKER"
+            }
+            .to_string(),
+        );
+    } else if node.has("kw_parallel") {
+        function.parallel = node
+            .child_of_kind("ColId")
+            .map(|n| n.text(src).to_uppercase());
+    } else if node.has("kw_cost") {
+        function.cost = node
+            .find("NumericOnly")
+            .and_then(|n| n.text(src).parse().ok());
+    } else if node.has("kw_rows") {
+        function.rows = node
+            .find("NumericOnly")
+            .and_then(|n| n.text(src).parse().ok());
+    } else if node.has("kw_support") {
+        function.support = node
+            .child_of_kind("any_name")
+            .map(|n| n.text(src).to_string());
+    } else if node.has("kw_set")
+        && let Some(config) = node.find("set_rest_more")
+    {
+        let text = config.text(src);
+        if let Some((name, value)) = split_set(text) {
+            function
+                .configuration
+                .get_or_insert_default()
+                .insert(name, serde_json::Value::String(value));
+        }
+    }
+}
+
+/// `name TO value` / `name = value` from a SET clause body
+fn split_set(text: &str) -> Option<(String, String)> {
+    let (name, value) = text
+        .split_once(" TO ")
+        .or_else(|| text.split_once(" to "))
+        .or_else(|| text.split_once('='))?;
+    Some((name.trim().to_string(), unstring(value.trim())))
+}
+
+fn parameter(node: &Node, src: &str) -> FunctionParameter {
+    let mode = node
+        .find("arg_class")
+        .map(|n| n.text(src).to_uppercase())
+        .unwrap_or_else(|| String::from("IN"));
+    FunctionParameter {
+        mode,
+        data_type: node
+            .find("func_type")
+            .map(|n| n.text(src).to_string())
+            .unwrap_or_default(),
+        name: node.find("param_name").map(|n| unquote(n.text(src))),
+        default: node
+            .child_of_kind("a_expr")
+            .map(|n| serde_json::Value::String(n.text(src).to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::ddl::Parser;
+
+    fn parse_one(sql: &str) -> Statement {
+        let mut parser = Parser::new().unwrap();
+        let mut statements = parser.parse(sql).unwrap();
+        assert_eq!(statements.len(), 1, "expected one statement");
+        statements.remove(0)
+    }
+
+    #[test]
+    fn parses_create_function() {
+        let Statement::CreateFunction(function) = parse_one(
+            "CREATE FUNCTION test.fn(a integer, b text DEFAULT 'x') \
+             RETURNS text\n    LANGUAGE sql STABLE\n    AS $$ SELECT b \
+             $$;",
+        ) else {
+            panic!("expected CreateFunction")
+        };
+        assert_eq!(function.schema, "test");
+        assert_eq!(function.name, "fn");
+        assert_eq!(function.returns, Some("text".into()));
+        assert_eq!(function.language, Some("sql".into()));
+        assert_eq!(function.stable, Some(true));
+        assert_eq!(function.definition, Some(" SELECT b ".into()));
+        let parameters = function.parameters.unwrap();
+        assert_eq!(parameters.len(), 2);
+        assert_eq!(parameters[0].mode, "IN");
+        assert_eq!(parameters[0].name, Some("a".into()));
+        assert_eq!(parameters[0].data_type, "integer");
+        assert_eq!(parameters[1].default, Some(json!("'x'")));
+    }
+
+    #[test]
+    fn parses_function_options() {
+        let Statement::CreateFunction(function) = parse_one(
+            "CREATE FUNCTION f(OUT result integer) RETURNS integer \
+             LANGUAGE plpgsql SECURITY DEFINER STRICT COST 100 \
+             AS $_$BEGIN END$_$;",
+        ) else {
+            panic!("expected CreateFunction")
+        };
+        assert_eq!(function.security, Some("DEFINER".into()));
+        assert_eq!(function.strict, Some(true));
+        assert_eq!(function.cost, Some(100));
+        assert_eq!(function.definition, Some("BEGIN END".into()));
+        let parameters = function.parameters.unwrap();
+        assert_eq!(parameters[0].mode, "OUT");
+    }
+
+    #[test]
+    fn parses_unqualified_function() {
+        let Statement::CreateFunction(function) = parse_one(
+            "CREATE FUNCTION uppercase(value text) RETURNS text \
+             LANGUAGE sql AS $$ SELECT upper(value) $$;",
+        ) else {
+            panic!("expected CreateFunction")
+        };
+        assert_eq!(function.schema, "");
+        assert_eq!(function.name, "uppercase");
+    }
+}

--- a/src/ddl/mod.rs
+++ b/src/ddl/mod.rs
@@ -157,7 +157,14 @@ pub(crate) fn any_name(node: &Node, src: &str) -> QualifiedName {
         parts.push(unquote(attr.text(src)));
     }
     match parts.len() {
-        0 => QualifiedName::default(),
+        0 => {
+            log::warn!(
+                "No name parts found in {} node: {:?}",
+                node.kind(),
+                truncate(node.text(src), 64)
+            );
+            QualifiedName::default()
+        }
         1 => QualifiedName {
             schema: None,
             name: parts.remove(0),

--- a/src/ddl/mod.rs
+++ b/src/ddl/mod.rs
@@ -6,7 +6,11 @@
 //! `ConstraintElem`, ...) and carry no named fields — extraction walks
 //! the tree by kind via the [`NodeExt`] helpers.
 
+mod function;
+mod object;
 mod table;
+mod trigger;
+mod view;
 
 use tree_sitter::Node;
 
@@ -26,6 +30,26 @@ pub enum Statement {
         table: QualifiedName,
         name: Option<String>,
         constraint: TableConstraint,
+    },
+    CreateSchema(models::Schema),
+    CreateDomain(models::Domain),
+    CreateType(Box<models::Type>),
+    CreateSequence(models::Sequence),
+    /// ALTER SEQUENCE — only the options present in the statement are
+    /// set; the assembly merges them into the owning sequence
+    AlterSequence(models::Sequence),
+    CreateView(models::View),
+    CreateMaterializedView(models::MaterializedView),
+    CreateFunction(Box<models::Function>),
+    CreateTrigger {
+        table: QualifiedName,
+        trigger: models::Trigger,
+    },
+    /// COMMENT ON `on` `target` IS `comment`
+    Comment {
+        on: String,
+        target: QualifiedName,
+        comment: String,
     },
     /// Parsed successfully but not (yet) a supported statement type
     Unsupported(String),
@@ -97,11 +121,58 @@ fn dispatch(node: &Node, src: &str) -> Result<Vec<Statement>, String> {
         "CreateStmt" => Ok(vec![table::create_table(node, src)?]),
         "IndexStmt" => Ok(vec![table::create_index(node, src)?]),
         "AlterTableStmt" => table::alter_table(node, src),
+        "CreateSchemaStmt" => Ok(vec![object::create_schema(node, src)?]),
+        "CreateDomainStmt" => Ok(vec![object::create_domain(node, src)?]),
+        "DefineStmt" if node.has("kw_type") => {
+            Ok(vec![object::create_type(node, src)?])
+        }
+        "CreateSeqStmt" | "AlterSeqStmt" => {
+            Ok(vec![object::create_sequence(node, src)?])
+        }
+        "ViewStmt" => Ok(vec![view::create_view(node, src)?]),
+        "CreateMatViewStmt" => {
+            Ok(vec![view::create_materialized_view(node, src)?])
+        }
+        "CreateFunctionStmt" => {
+            Ok(vec![function::create_function(node, src)?])
+        }
+        "CreateTrigStmt" => Ok(vec![trigger::create_trigger(node, src)?]),
+        "CommentStmt" => Ok(vec![object::comment(node, src)?]),
         other => Ok(vec![Statement::Unsupported(other.to_string())]),
     }
 }
 
-fn truncate(value: &str, len: usize) -> &str {
+/// Extract a possibly-qualified name from an `any_name` / `func_name`
+/// node (ColId head + attrs); multi-part names keep everything before
+/// the final part as the schema
+pub(crate) fn any_name(node: &Node, src: &str) -> QualifiedName {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(head) = node
+        .child_of_kind("ColId")
+        .or_else(|| node.child_of_kind("type_function_name"))
+    {
+        parts.push(unquote(head.text(src)));
+    }
+    for attr in node.find_all("attr_name") {
+        parts.push(unquote(attr.text(src)));
+    }
+    match parts.len() {
+        0 => QualifiedName::default(),
+        1 => QualifiedName {
+            schema: None,
+            name: parts.remove(0),
+        },
+        _ => {
+            let name = parts.pop().unwrap_or_default();
+            QualifiedName {
+                schema: Some(parts.join(".")),
+                name,
+            }
+        }
+    }
+}
+
+pub(crate) fn truncate(value: &str, len: usize) -> &str {
     match value.char_indices().nth(len) {
         Some((offset, _)) => &value[..offset],
         None => value,

--- a/src/ddl/object.rs
+++ b/src/ddl/object.rs
@@ -1,0 +1,539 @@
+//! Schemas, domains, types, sequences, and comments
+
+use tree_sitter::Node;
+
+use crate::ddl::{
+    NodeExt, QualifiedName, Statement, any_name, truncate, unquote,
+};
+use crate::models::{
+    Domain, DomainConstraint, Schema, Sequence, Type, TypeColumn,
+};
+
+/// CREATE SCHEMA → Schema
+pub(crate) fn create_schema(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let name = node
+        .child_of_kind("ColId")
+        .map(|n| unquote(n.text(src)))
+        .or_else(|| node.find("OptSchemaName").map(|n| unquote(n.text(src))))
+        .ok_or_else(|| String::from("CREATE SCHEMA without a name"))?;
+    let authorization = node.find("RoleSpec").map(|n| unquote(n.text(src)));
+    Ok(Statement::CreateSchema(Schema {
+        name,
+        owner: String::new(),
+        authorization,
+        comment: None,
+    }))
+}
+
+/// CREATE DOMAIN → Domain
+pub(crate) fn create_domain(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let name = node
+        .child_of_kind("any_name")
+        .map(|n| any_name(&n, src))
+        .ok_or_else(|| String::from("CREATE DOMAIN without a name"))?;
+    let mut domain = Domain {
+        name: name.name,
+        schema: name.schema.unwrap_or_default(),
+        owner: String::new(),
+        sql: None,
+        data_type: node
+            .child_of_kind("Typename")
+            .map(|n| n.text(src).to_string()),
+        collation: None,
+        default: None,
+        check_constraints: None,
+        comment: None,
+    };
+    for constraint in node.find_all("ColConstraint") {
+        let name = constraint
+            .child_of_kind("name")
+            .map(|n| unquote(n.text(src)));
+        let Some(elem) = constraint.child_of_kind("ColConstraintElem") else {
+            if constraint.has("kw_collate")
+                && let Some(collation) = constraint.child_of_kind("any_name")
+            {
+                domain.collation = Some(collation.text(src).to_string());
+            }
+            continue;
+        };
+        if elem.has("kw_check") {
+            if let Some(expr) = elem.find("a_expr") {
+                domain.check_constraints.get_or_insert_default().push(
+                    DomainConstraint {
+                        name,
+                        nullable: None,
+                        expression: Some(expr.text(src).to_string()),
+                    },
+                );
+            }
+        } else if elem.has("kw_not") && elem.has("kw_null") {
+            domain.check_constraints.get_or_insert_default().push(
+                DomainConstraint {
+                    name,
+                    nullable: Some(false),
+                    expression: None,
+                },
+            );
+        } else if elem.has("kw_default")
+            && let Some(expr) = elem.child_of_kind("b_expr")
+        {
+            domain.default = Some(expr.text(src).to_string());
+        }
+    }
+    Ok(Statement::CreateDomain(domain))
+}
+
+/// CREATE TYPE (DefineStmt): enum, composite, range, and base forms
+pub(crate) fn create_type(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let name = node
+        .child_of_kind("any_name")
+        .map(|n| any_name(&n, src))
+        .ok_or_else(|| String::from("CREATE TYPE without a name"))?;
+    let mut value = Type {
+        name: name.name,
+        schema: name.schema.unwrap_or_default(),
+        owner: String::new(),
+        sql: None,
+        type_kind: None,
+        input: None,
+        output: None,
+        receive: None,
+        send: None,
+        typmod_in: None,
+        typmod_out: None,
+        analyze: None,
+        internal_length: None,
+        passed_by_value: None,
+        alignment: None,
+        storage: None,
+        like_type: None,
+        category: None,
+        preferred: None,
+        default: None,
+        element: None,
+        delimiter: None,
+        collatable: None,
+        columns: None,
+        enum_values: None,
+        subtype: None,
+        subtype_opclass: None,
+        collation: None,
+        canonical: None,
+        subtype_diff: None,
+        comment: None,
+    };
+    if node.has("kw_enum") {
+        value.type_kind = Some(String::from("enum"));
+        value.enum_values = Some(
+            node.find_all("Sconst")
+                .iter()
+                .map(|n| string_value(n, src))
+                .collect(),
+        );
+    } else if node.has("kw_range") {
+        value.type_kind = Some(String::from("range"));
+        for elem in node.find_all("def_elem") {
+            let key = elem
+                .child_of_kind("ColLabel")
+                .map(|n| n.text(src).to_lowercase())
+                .unwrap_or_default();
+            let arg = elem
+                .child_of_kind("def_arg")
+                .map(|n| n.text(src).to_string())
+                .unwrap_or_default();
+            match key.as_str() {
+                "subtype" => value.subtype = Some(arg),
+                "subtype_opclass" => value.subtype_opclass = Some(arg),
+                "collation" => value.collation = Some(arg),
+                "canonical" => value.canonical = Some(arg),
+                "subtype_diff" => value.subtype_diff = Some(arg),
+                _ => {
+                    log::warn!(
+                        "Unsupported range type option {key:?} for {}",
+                        value.name
+                    );
+                }
+            }
+        }
+    } else if node.has("OptTableFuncElementList") {
+        value.type_kind = Some(String::from("composite"));
+        value.columns = Some(
+            node.find_all("TableFuncElement")
+                .iter()
+                .map(|element| TypeColumn {
+                    name: element
+                        .child_of_kind("ColId")
+                        .map(|n| unquote(n.text(src)))
+                        .unwrap_or_default(),
+                    data_type: element
+                        .child_of_kind("Typename")
+                        .map(|n| n.text(src).to_string())
+                        .unwrap_or_default(),
+                    collation: element
+                        .find("opt_collate_clause")
+                        .and_then(|n| n.child_of_kind("any_name"))
+                        .map(|n| n.text(src).to_string()),
+                })
+                .collect(),
+        );
+    } else if node.has("definition") {
+        value.type_kind = Some(String::from("base"));
+        for elem in node.find_all("def_elem") {
+            let key = elem
+                .child_of_kind("ColLabel")
+                .map(|n| n.text(src).to_lowercase())
+                .unwrap_or_default();
+            let arg = elem
+                .child_of_kind("def_arg")
+                .map(|n| n.text(src).to_string())
+                .unwrap_or_default();
+            match key.as_str() {
+                "input" => value.input = Some(arg),
+                "output" => value.output = Some(arg),
+                "receive" => value.receive = Some(arg),
+                "send" => value.send = Some(arg),
+                "typmod_in" => value.typmod_in = Some(arg),
+                "typmod_out" => value.typmod_out = Some(arg),
+                "analyze" => value.analyze = Some(arg),
+                "internallength" => {
+                    value.internal_length =
+                        Some(serde_json::Value::String(arg));
+                }
+                "passedbyvalue" => value.passed_by_value = Some(true),
+                "alignment" => value.alignment = Some(arg),
+                "storage" => value.storage = Some(arg),
+                "like" => value.like_type = Some(arg),
+                "category" => value.category = Some(unstring(&arg)),
+                "preferred" => {
+                    value.preferred = Some(serde_json::Value::String(arg));
+                }
+                "default" => {
+                    value.default = Some(serde_json::Value::String(arg));
+                }
+                "element" => value.element = Some(arg),
+                "delimiter" => value.delimiter = Some(unstring(&arg)),
+                "collatable" => value.collatable = Some(true),
+                _ => {
+                    log::warn!(
+                        "Unsupported base type option {key:?} for {}",
+                        value.name
+                    );
+                }
+            }
+        }
+    } else {
+        // shell type: CREATE TYPE name;
+        value.type_kind = None;
+    }
+    Ok(Statement::CreateType(Box::new(value)))
+}
+
+/// CREATE SEQUENCE → Sequence; ALTER SEQUENCE ... OWNED BY also maps
+/// here so the assembly can merge it into the owning sequence
+pub(crate) fn create_sequence(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let name = node
+        .find("qualified_name")
+        .ok_or_else(|| String::from("CREATE SEQUENCE without a name"))?;
+    let name = crate::ddl::qualified_name(&name, src)?;
+    let mut sequence = Sequence {
+        name: name.name,
+        schema: name.schema.unwrap_or_default(),
+        owner: String::new(),
+        sql: None,
+        data_type: None,
+        increment_by: None,
+        min_value: None,
+        max_value: None,
+        start_with: None,
+        cache: None,
+        cycle: None,
+        owned_by: None,
+        comment: None,
+    };
+    apply_seq_options(&mut sequence, node, src);
+    if node.kind() == "AlterSeqStmt" {
+        return Ok(Statement::AlterSequence(sequence));
+    }
+    Ok(Statement::CreateSequence(sequence))
+}
+
+fn apply_seq_options(sequence: &mut Sequence, node: &Node, src: &str) {
+    for elem in node.find_all("SeqOptElem") {
+        let number = elem
+            .find("NumericOnly")
+            .and_then(|n| n.text(src).parse::<i64>().ok());
+        if elem.has("kw_start") {
+            sequence.start_with = number;
+        } else if elem.has("kw_increment") {
+            sequence.increment_by = number;
+        } else if elem.has("kw_minvalue") {
+            sequence.min_value = number;
+        } else if elem.has("kw_maxvalue") {
+            sequence.max_value = number;
+        } else if elem.has("kw_cache") {
+            sequence.cache = number;
+        } else if elem.has("kw_cycle") {
+            sequence.cycle = Some(!elem.has("kw_no"));
+        } else if elem.has("kw_owned") {
+            sequence.owned_by = elem
+                .child_of_kind("any_name")
+                .map(|n| n.text(src).to_string());
+        } else if elem.has("kw_as") {
+            sequence.data_type = elem
+                .child_of_kind("SimpleTypename")
+                .or_else(|| elem.find("SimpleTypename"))
+                .map(|n| n.text(src).to_string());
+        }
+    }
+}
+
+/// COMMENT ON <type> <name> IS '...'
+pub(crate) fn comment(node: &Node, src: &str) -> Result<Statement, String> {
+    let text = node
+        .child_of_kind("comment_text")
+        .and_then(|n| n.find("Sconst"))
+        .map(|n| string_value(&n, src))
+        .ok_or_else(|| {
+            format!("COMMENT without text: {}", truncate(node.text(src), 80))
+        })?;
+    // the object type is the keyword sequence between ON and the name
+    let mut object_type = Vec::new();
+    let mut target: Option<QualifiedName> = None;
+    let mut cursor = node.walk();
+    let mut past_on = false;
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "kw_on" => past_on = true,
+            "kw_is" => break,
+            kind if kind.starts_with("kw_") && past_on => {
+                object_type
+                    .push(kind.trim_start_matches("kw_").to_uppercase());
+            }
+            "any_name" => target = Some(any_name(&child, src)),
+            "qualified_name" => {
+                target = Some(crate::ddl::qualified_name(&child, src)?);
+            }
+            "Typename" => {
+                let text = child.text(src);
+                target = Some(split_dotted(text));
+            }
+            "name" | "ColId" => {
+                target = Some(QualifiedName {
+                    schema: None,
+                    name: unquote(child.text(src)),
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(Statement::Comment {
+        on: object_type.join(" "),
+        target: target.unwrap_or_default(),
+        comment: text,
+    })
+}
+
+/// `a.b.c` → schema `a.b`, name `c` (COLUMN comments use three parts)
+fn split_dotted(value: &str) -> QualifiedName {
+    match value.rsplit_once('.') {
+        Some((head, tail)) => QualifiedName {
+            schema: Some(unquote(head)),
+            name: unquote(tail),
+        },
+        None => QualifiedName {
+            schema: None,
+            name: unquote(value),
+        },
+    }
+}
+
+/// The value of a string constant node (single quotes or dollar
+/// quoting stripped, escapes collapsed)
+pub(crate) fn string_value(node: &Node, src: &str) -> String {
+    let text = node.text(src);
+    unstring(text)
+}
+
+pub(crate) fn unstring(text: &str) -> String {
+    if text.len() >= 2 && text.starts_with('\'') && text.ends_with('\'') {
+        return text[1..text.len() - 1].replace("''", "'");
+    }
+    if text.starts_with('$')
+        && let Some(end) = text[1..].find('$')
+    {
+        let tag = &text[..end + 2];
+        if text.len() >= tag.len() * 2 && text.ends_with(tag) {
+            return text[tag.len()..text.len() - tag.len()].to_string();
+        }
+    }
+    text.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ddl::Parser;
+    use crate::ddl::Statement;
+
+    fn parse_one(sql: &str) -> Statement {
+        let mut parser = Parser::new().unwrap();
+        let mut statements = parser.parse(sql).unwrap();
+        assert_eq!(statements.len(), 1, "expected one statement");
+        statements.remove(0)
+    }
+
+    #[test]
+    fn parses_create_schema() {
+        let Statement::CreateSchema(schema) = parse_one("CREATE SCHEMA test;")
+        else {
+            panic!("expected CreateSchema")
+        };
+        assert_eq!(schema.name, "test");
+    }
+
+    #[test]
+    fn parses_create_domain() {
+        let Statement::CreateDomain(domain) = parse_one(
+            "CREATE DOMAIN test.bcp47_locale AS text\n\
+             \tCONSTRAINT bcp47_locale_check CHECK \
+             ((VALUE ~ '^[a-z]{2}-[A-Z]{2,3}$'::text));",
+        ) else {
+            panic!("expected CreateDomain")
+        };
+        assert_eq!(domain.schema, "test");
+        assert_eq!(domain.name, "bcp47_locale");
+        assert_eq!(domain.data_type, Some("text".into()));
+        let constraints = domain.check_constraints.unwrap();
+        assert_eq!(constraints.len(), 1);
+        assert_eq!(constraints[0].name, Some("bcp47_locale_check".into()));
+        assert_eq!(
+            constraints[0].expression,
+            Some("(VALUE ~ '^[a-z]{2}-[A-Z]{2,3}$'::text)".into())
+        );
+    }
+
+    #[test]
+    fn parses_enum_type() {
+        let Statement::CreateType(value) = parse_one(
+            "CREATE TYPE test.user_state AS ENUM ('unverified', \
+             'verified', 'suspended');",
+        ) else {
+            panic!("expected CreateType")
+        };
+        assert_eq!(value.type_kind, Some("enum".into()));
+        assert_eq!(
+            value.enum_values,
+            Some(vec![
+                "unverified".into(),
+                "verified".into(),
+                "suspended".into()
+            ])
+        );
+    }
+
+    #[test]
+    fn parses_composite_type() {
+        let Statement::CreateType(value) =
+            parse_one("CREATE TYPE test.compfoo AS (f1 integer, f2 text);")
+        else {
+            panic!("expected CreateType")
+        };
+        assert_eq!(value.type_kind, Some("composite".into()));
+        let columns = value.columns.unwrap();
+        assert_eq!(columns.len(), 2);
+        assert_eq!(columns[0].name, "f1");
+        assert_eq!(columns[0].data_type, "integer");
+        assert_eq!(columns[1].data_type, "text");
+    }
+
+    #[test]
+    fn parses_range_type() {
+        let Statement::CreateType(value) = parse_one(
+            "CREATE TYPE test.float8_range AS RANGE (subtype = float8, \
+             subtype_diff = float8mi);",
+        ) else {
+            panic!("expected CreateType")
+        };
+        assert_eq!(value.type_kind, Some("range".into()));
+        assert_eq!(value.subtype, Some("float8".into()));
+        assert_eq!(value.subtype_diff, Some("float8mi".into()));
+    }
+
+    #[test]
+    fn parses_create_sequence() {
+        let Statement::CreateSequence(sequence) = parse_one(
+            "CREATE SEQUENCE test.seq AS bigint START WITH 100 \
+             INCREMENT BY 10 MAXVALUE 1000000 CACHE 2 NO CYCLE;",
+        ) else {
+            panic!("expected CreateSequence")
+        };
+        assert_eq!(sequence.schema, "test");
+        assert_eq!(sequence.name, "seq");
+        assert_eq!(sequence.data_type, Some("bigint".into()));
+        assert_eq!(sequence.start_with, Some(100));
+        assert_eq!(sequence.increment_by, Some(10));
+        assert_eq!(sequence.max_value, Some(1000000));
+        assert_eq!(sequence.cache, Some(2));
+        assert_eq!(sequence.cycle, Some(false));
+    }
+
+    #[test]
+    fn parses_alter_sequence_owned_by() {
+        let Statement::AlterSequence(sequence) =
+            parse_one("ALTER SEQUENCE test.seq OWNED BY test.empty_table.id;")
+        else {
+            panic!("expected AlterSequence")
+        };
+        assert_eq!(sequence.name, "seq");
+        assert_eq!(sequence.owned_by, Some("test.empty_table.id".into()));
+    }
+
+    #[test]
+    fn parses_comments() {
+        let Statement::Comment {
+            on,
+            target,
+            comment,
+        } = parse_one(
+            "COMMENT ON DOMAIN test.bcp47_locale IS 'Simplified locale \
+             check, doesn''t conform';",
+        )
+        else {
+            panic!("expected Comment")
+        };
+        assert_eq!(on, "DOMAIN");
+        assert_eq!(target.to_string(), "test.bcp47_locale");
+        assert_eq!(comment, "Simplified locale check, doesn't conform");
+    }
+
+    #[test]
+    fn parses_column_comments() {
+        let Statement::Comment { on, target, .. } =
+            parse_one("COMMENT ON COLUMN test.users.id IS 'The user ID';")
+        else {
+            panic!("expected Comment")
+        };
+        assert_eq!(on, "COLUMN");
+        assert_eq!(target.schema, Some("test.users".into()));
+        assert_eq!(target.name, "id");
+    }
+
+    #[test]
+    fn unstrings_dollar_quotes() {
+        assert_eq!(unstring("$$body$$"), "body");
+        assert_eq!(unstring("$_$ BEGIN END $_$"), " BEGIN END ");
+        assert_eq!(unstring("'it''s'"), "it's");
+    }
+}

--- a/src/ddl/object.rs
+++ b/src/ddl/object.rs
@@ -221,7 +221,11 @@ pub(crate) fn create_type(
                 }
                 "element" => value.element = Some(arg),
                 "delimiter" => value.delimiter = Some(unstring(&arg)),
-                "collatable" => value.collatable = Some(true),
+                "collatable" => {
+                    value.collatable = Some(
+                        arg.is_empty() || arg.eq_ignore_ascii_case("true"),
+                    );
+                }
                 _ => {
                     log::warn!(
                         "Unsupported base type option {key:?} for {}",

--- a/src/ddl/table.rs
+++ b/src/ddl/table.rs
@@ -624,7 +624,7 @@ mod tests {
 
     #[test]
     fn other_statements_are_unsupported() {
-        let statement = parse_one("CREATE VIEW v AS SELECT 1;");
+        let statement = parse_one("GRANT USAGE ON SCHEMA test TO PUBLIC;");
         assert!(matches!(statement, Statement::Unsupported(_)));
     }
 }

--- a/src/ddl/trigger.rs
+++ b/src/ddl/trigger.rs
@@ -1,0 +1,135 @@
+//! Triggers (CreateTrigStmt)
+
+use tree_sitter::Node;
+
+use crate::ddl::object::string_value;
+use crate::ddl::{NodeExt, Statement, qualified_name, unquote};
+use crate::models::Trigger;
+
+/// CREATE TRIGGER → (table, Trigger)
+pub(crate) fn create_trigger(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let table = node
+        .find("qualified_name")
+        .ok_or_else(|| String::from("CREATE TRIGGER without a relation"))?;
+    let table = qualified_name(&table, src)?;
+    let name = node
+        .child_of_kind("name")
+        .map(|n| unquote(n.text(src)))
+        .ok_or_else(|| String::from("CREATE TRIGGER without a name"))?;
+    let when = node.child_of_kind("TriggerActionTime").map(|n| {
+        if n.has("kw_before") {
+            "BEFORE"
+        } else if n.has("kw_after") {
+            "AFTER"
+        } else {
+            "INSTEAD OF"
+        }
+        .to_string()
+    });
+    let events: Vec<String> = node
+        .find_all("TriggerOneEvent")
+        .iter()
+        .map(|event| {
+            if event.has("kw_insert") {
+                "INSERT".to_string()
+            } else if event.has("kw_delete") {
+                "DELETE".to_string()
+            } else if event.has("kw_truncate") {
+                "TRUNCATE".to_string()
+            } else if let Some(columns) = event.child_of_kind("columnList") {
+                format!("UPDATE OF {}", columns.text(src))
+            } else {
+                "UPDATE".to_string()
+            }
+        })
+        .collect();
+    let for_each = node.child_of_kind("TriggerForSpec").map(|n| {
+        if n.has("kw_row") { "ROW" } else { "STATEMENT" }.to_string()
+    });
+    let condition = node
+        .child_of_kind("TriggerWhen")
+        .and_then(|n| n.child_of_kind("a_expr"))
+        .map(|n| n.text(src).to_string());
+    let function = node
+        .child_of_kind("func_name")
+        .map(|n| n.text(src).to_string());
+    let arguments: Vec<serde_json::Value> = node
+        .find_all("TriggerFuncArg")
+        .iter()
+        .map(|arg| {
+            if let Some(string) = arg.find("Sconst") {
+                serde_json::Value::String(string_value(&string, src))
+            } else if let Ok(number) = arg.text(src).parse::<i64>() {
+                serde_json::Value::Number(number.into())
+            } else {
+                serde_json::Value::String(arg.text(src).to_string())
+            }
+        })
+        .collect();
+    Ok(Statement::CreateTrigger {
+        table,
+        trigger: Trigger {
+            sql: None,
+            name: Some(name),
+            when,
+            events: (!events.is_empty()).then_some(events),
+            for_each,
+            condition,
+            function: function.map(|f| format!("{f}()")),
+            arguments: (!arguments.is_empty()).then_some(arguments),
+            comment: None,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::ddl::Parser;
+
+    fn parse_one(sql: &str) -> Statement {
+        let mut parser = Parser::new().unwrap();
+        let mut statements = parser.parse(sql).unwrap();
+        assert_eq!(statements.len(), 1, "expected one statement");
+        statements.remove(0)
+    }
+
+    #[test]
+    fn parses_create_trigger() {
+        let Statement::CreateTrigger { table, trigger } = parse_one(
+            "CREATE TRIGGER audit BEFORE INSERT OR UPDATE ON test.users \
+             FOR EACH ROW EXECUTE FUNCTION test.audit_row();",
+        ) else {
+            panic!("expected CreateTrigger")
+        };
+        assert_eq!(table.to_string(), "test.users");
+        assert_eq!(trigger.name, Some("audit".into()));
+        assert_eq!(trigger.when, Some("BEFORE".into()));
+        assert_eq!(
+            trigger.events,
+            Some(vec!["INSERT".into(), "UPDATE".into()])
+        );
+        assert_eq!(trigger.for_each, Some("ROW".into()));
+        assert_eq!(trigger.function, Some("test.audit_row()".into()));
+    }
+
+    #[test]
+    fn parses_trigger_condition_and_arguments() {
+        let Statement::CreateTrigger { trigger, .. } = parse_one(
+            "CREATE TRIGGER t AFTER DELETE ON x FOR EACH STATEMENT \
+             WHEN (OLD.id IS NOT NULL) \
+             EXECUTE FUNCTION f(1, 'two');",
+        ) else {
+            panic!("expected CreateTrigger")
+        };
+        assert_eq!(trigger.when, Some("AFTER".into()));
+        assert_eq!(trigger.for_each, Some("STATEMENT".into()));
+        assert_eq!(trigger.condition, Some("OLD.id IS NOT NULL".into()));
+        assert_eq!(trigger.arguments, Some(vec![json!(1), json!("two")]));
+    }
+}

--- a/src/ddl/view.rs
+++ b/src/ddl/view.rs
@@ -1,0 +1,147 @@
+//! Views and materialized views
+
+use tree_sitter::Node;
+
+use crate::ddl::{NodeExt, Statement, qualified_name, unquote};
+use crate::models::{MaterializedView, View, ViewColumn};
+
+/// CREATE [OR REPLACE] VIEW → View
+pub(crate) fn create_view(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let name = node
+        .find("qualified_name")
+        .ok_or_else(|| String::from("CREATE VIEW without a name"))?;
+    let name = qualified_name(&name, src)?;
+    let columns = view_columns(node, src);
+    let query = node
+        .child_of_kind("SelectStmt")
+        .map(|n| n.text(src).to_string());
+    Ok(Statement::CreateView(View {
+        name: name.name,
+        schema: name.schema.unwrap_or_default(),
+        owner: String::new(),
+        sql: None,
+        recursive: node.has("kw_recursive").then_some(true),
+        columns,
+        check_option: node.find("opt_check_option").map(|n| {
+            if n.has("kw_local") {
+                "LOCAL"
+            } else {
+                "CASCADED"
+            }
+            .to_string()
+        }),
+        security_barrier: None,
+        query,
+        comment: None,
+    }))
+}
+
+/// CREATE MATERIALIZED VIEW → MaterializedView
+pub(crate) fn create_materialized_view(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let name = node
+        .find("create_mv_target")
+        .and_then(|n| n.find("qualified_name"))
+        .ok_or_else(|| {
+            String::from("CREATE MATERIALIZED VIEW without a name")
+        })?;
+    let name = qualified_name(&name, src)?;
+    let query = node
+        .child_of_kind("SelectStmt")
+        .map(|n| n.text(src).to_string());
+    let columns = view_columns(node, src);
+    Ok(Statement::CreateMaterializedView(MaterializedView {
+        name: name.name,
+        schema: name.schema.unwrap_or_default(),
+        owner: String::new(),
+        sql: None,
+        columns,
+        table_access_method: node
+            .find("table_access_method_clause")
+            .and_then(|n| n.find("name"))
+            .map(|n| unquote(n.text(src))),
+        storage_parameters: None,
+        tablespace: node
+            .find("OptTableSpace")
+            .and_then(|n| n.find("name"))
+            .map(|n| unquote(n.text(src))),
+        query,
+        comment: None,
+    }))
+}
+
+/// The optional parenthesized column-name list before AS
+fn view_columns(node: &Node, src: &str) -> Option<Vec<ViewColumn>> {
+    let list = node.child_of_kind("opt_column_list").or_else(|| {
+        node.find("create_mv_target")
+            .and_then(|n| n.child_of_kind("opt_column_list"))
+    })?;
+    let columns: Vec<ViewColumn> = list
+        .find_all("columnElem")
+        .iter()
+        .map(|c| ViewColumn::Name(unquote(c.text(src))))
+        .collect();
+    (!columns.is_empty()).then_some(columns)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ddl::Parser;
+
+    fn parse_one(sql: &str) -> Statement {
+        let mut parser = Parser::new().unwrap();
+        let mut statements = parser.parse(sql).unwrap();
+        assert_eq!(statements.len(), 1, "expected one statement");
+        statements.remove(0)
+    }
+
+    #[test]
+    fn parses_create_view() {
+        let Statement::CreateView(view) = parse_one(
+            "CREATE VIEW test.us_users AS\n SELECT id,\n    email\n   \
+             FROM test.users\n  WHERE (country = 'US'::text);",
+        ) else {
+            panic!("expected CreateView")
+        };
+        assert_eq!(view.schema, "test");
+        assert_eq!(view.name, "us_users");
+        let query = view.query.unwrap();
+        assert!(query.starts_with("SELECT id,"));
+        assert!(query.ends_with("WHERE (country = 'US'::text)"));
+    }
+
+    #[test]
+    fn parses_view_columns() {
+        let Statement::CreateView(view) =
+            parse_one("CREATE VIEW v (a, b) AS SELECT 1, 2;")
+        else {
+            panic!("expected CreateView")
+        };
+        assert_eq!(
+            view.columns,
+            Some(vec![
+                ViewColumn::Name("a".into()),
+                ViewColumn::Name("b".into())
+            ])
+        );
+    }
+
+    #[test]
+    fn parses_materialized_view() {
+        let Statement::CreateMaterializedView(view) = parse_one(
+            "CREATE MATERIALIZED VIEW test.mv AS\n SELECT id FROM \
+             test.users\n  WITH NO DATA;",
+        ) else {
+            panic!("expected CreateMaterializedView")
+        };
+        assert_eq!(view.schema, "test");
+        assert_eq!(view.name, "mv");
+        assert_eq!(view.query, Some("SELECT id FROM test.users".into()));
+    }
+}


### PR DESCRIPTION
## Summary

Second ddl-module PR: the remaining object-DDL statement families.

- **object.rs**: CREATE SCHEMA, CREATE DOMAIN (named constraints, NOT NULL, DEFAULT, COLLATE), CREATE TYPE via `DefineStmt` (enum/composite/range/base), CREATE/ALTER SEQUENCE (all options; `OWNED BY` surfaces as `AlterSequence` for the assembly to merge), COMMENT ON (object type + target + text, with single-quote and dollar-quote unescaping)
- **view.rs**: CREATE VIEW (recursive, column lists, check option), CREATE MATERIALIZED VIEW (access method, tablespace)
- **function.rs**: CREATE FUNCTION/PROCEDURE (parameter modes/defaults, returns, language, volatility, strictness, security, parallel, cost/rows, SET configuration, dollar-quoted bodies)
- **trigger.rs**: CREATE TRIGGER (timing, events incl. UPDATE OF, FOR EACH, WHEN, function + arguments)
- **examples/parse_dump.rs**: dev helper that runs the ddl module over every entry of an archive and reports supported/unsupported/error counts

## Validation against the real fixtures dump

All 14 object-DDL entries in a pg_dump of `fixtures/schema.sql` parse into models. Remaining entries are expected: SEARCHPATH/DATABASE/EXTENSION are handled from entry metadata by the assembly, GRANT is the next family (ACL/roles PR).

## ⚠️ Upstream dependency now load-bearing

The two parse failures on the fixtures dump are both the known **quoted-identifier grammar gap** (`CREATE EXTENSION "uuid-ossp"` and its `COMMENT ON`). That tree-sitter-postgres fix is now required before the pull-assembly PR can pass the round-trip gate — not just for real-world dumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parse CREATE FUNCTION / CREATE PROCEDURE
  * Parse CREATE and MATERIALIZED VIEW
  * Parse CREATE TRIGGER
  * Parse CREATE SCHEMA, DOMAIN, TYPE, SEQUENCE, and ALTER SEQUENCE
  * Parse COMMENT ON ...
  * Add a CLI example to parse PostgreSQL dump archives
<!-- end of auto-generated comment: release notes by coderabbit.ai -->