### PR TITLE
Bump tree-sitter-postgres to 1.2 for grammar fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,9 +1239,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-postgres"
-version = "1.1.6"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb97cfd489765a143311254db8216825009a222faa73210edc4c123f23a291ff"
+checksum = "f162cad52646c3f61a49a539486841d67f23fcb6ca5c01958403fc28b985e551"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = { version = "1.0.150", features = ["preserve_order"] }
 serde_norway = "0.9.42"
 simplelog = "0.12"
 tree-sitter = "0.26"
-tree-sitter-postgres = "1.1"
+tree-sitter-postgres = "1.2"
 
 [dev-dependencies]
 libpgdump = "2.1"

--- a/src/ddl/table.rs
+++ b/src/ddl/table.rs
@@ -503,12 +503,7 @@ mod tests {
         assert_eq!(index.unique, None);
     }
 
-    // tree-sitter-postgres 1.1.6 gap: index_elem_options requires
-    // collate + opclass + direction + nulls as a mandatory sequence,
-    // so bare `DESC` / `NULLS LAST` fail to parse. Needs an upstream
-    // grammar fix (each component optional, per gram.y).
     #[test]
-    #[ignore = "tree-sitter-postgres 1.1.6: index_elem_options not optional"]
     fn parses_index_options() {
         let statement = parse_one(
             "CREATE INDEX i ON t (created_at DESC NULLS LAST) \
@@ -607,11 +602,7 @@ mod tests {
         assert_eq!(constraint, TableConstraint::Check("value > 0".into()));
     }
 
-    // tree-sitter-postgres 1.1.6 gap: the quoted_identifier token
-    // exists but is not reachable from ColId/ColLabel, so any quoted
-    // identifier fails to parse. Needs an upstream grammar fix.
     #[test]
-    #[ignore = "tree-sitter-postgres 1.1.6: quoted_identifier not in ColId"]
     fn quoted_identifiers_unquote() {
         let statement =
             parse_one("CREATE TABLE \"Sch\"\"ema\".\"Tab le\" (id int);");


### PR DESCRIPTION
## Summary

tree-sitter-postgres 1.2.1 fixes the two grammar gaps that blocked DDL parsing:

- **Quoted identifiers** are now reachable from `ColId` — `CREATE TABLE "Foo" (...)` and the fixtures' `"uuid-ossp"` extension statements parse.
- **`index_elem_options`** components are individually optional — bare `DESC` / `NULLS LAST` in index columns parse.

This bumps the dependency to `1.2`, removes the two `#[ignore]` attributes on the tests that documented the gaps (`parses_index_options`, `quoted_identifiers_unquote`), and drops the accompanying gap comments.

## Verification

- `cargo test`: all pass, 0 ignored
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo run --example parse_dump -- fixtures.dump`: 15 parsed, 5 expected-unsupported, **0 errors** (previously 2 errors from the quoted extension name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL parser dependency to version 1.2.

* **Tests**
  * Enabled additional parser validation tests to strengthen test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->