### PR TITLE
Emit ACL entries in build and pass the Phase 3 round-trip gate

### DIFF
--- a/bin/round-trip
+++ b/bin/round-trip
@@ -19,7 +19,16 @@ export PGHOST PGPORT PGUSER
 SOURCE_DB=roundtrip_source
 RESTORED_DB=roundtrip_restored
 WORKDIR="$(mktemp -d)"
-trap 'rm -rf "$WORKDIR"' EXIT INT TERM
+
+cleanup() {
+    rm -rf "$WORKDIR"
+    psql -d postgres -q -c "DROP DATABASE IF EXISTS ${RESTORED_DB}" \
+        >/dev/null 2>&1 || true
+    psql -d postgres -q -c "DROP DATABASE IF EXISTS ${SOURCE_DB}" \
+        >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT INT TERM
 
 echo "==> Building pglifecycle"
 cargo build --quiet

--- a/bin/round-trip
+++ b/bin/round-trip
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Phase 3 round-trip gate (PLAN.md):
 #
 #   fixtures/schema.sql -> PostgreSQL -> pg_dump -Fc -> pull ->
@@ -9,7 +9,7 @@
 # compose.yaml container; override with PGHOST/PGPORT/PGUSER) and the
 # postgres client tools on PATH. All commands run via psql/pg_dump
 # against two scratch databases that are dropped and recreated.
-set -eu
+set -euo pipefail
 
 PGHOST="${PGHOST:-localhost}"
 PGPORT="${PGPORT:-5432}"
@@ -19,7 +19,7 @@ export PGHOST PGPORT PGUSER
 SOURCE_DB=roundtrip_source
 RESTORED_DB=roundtrip_restored
 WORKDIR="$(mktemp -d)"
-trap 'rm -rf "$WORKDIR"' EXIT
+trap 'rm -rf "$WORKDIR"' EXIT INT TERM
 
 echo "==> Building pglifecycle"
 cargo build --quiet

--- a/bin/round-trip
+++ b/bin/round-trip
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+# Phase 3 round-trip gate (PLAN.md):
+#
+#   fixtures/schema.sql -> PostgreSQL -> pg_dump -Fc -> pull ->
+#   load + validate -> build -> pg_restore -> pg_dump --schema-only
+#   of both databases -> diff is empty
+#
+# Requires a PostgreSQL superuser connection (defaults target the
+# compose.yaml container; override with PGHOST/PGPORT/PGUSER) and the
+# postgres client tools on PATH. All commands run via psql/pg_dump
+# against two scratch databases that are dropped and recreated.
+set -eu
+
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-postgres}"
+export PGHOST PGPORT PGUSER
+
+SOURCE_DB=roundtrip_source
+RESTORED_DB=roundtrip_restored
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "==> Building pglifecycle"
+cargo build --quiet
+
+echo "==> Creating ${SOURCE_DB} from fixtures/schema.sql"
+psql -d postgres -q -c "DROP DATABASE IF EXISTS ${SOURCE_DB}"
+psql -d postgres -q -c "CREATE DATABASE ${SOURCE_DB}"
+psql -d "${SOURCE_DB}" -q -v ON_ERROR_STOP=1 -f fixtures/schema.sql
+
+echo "==> pg_dump ${SOURCE_DB}"
+pg_dump -d "${SOURCE_DB}" -Fc --schema-only -f "${WORKDIR}/source.dump"
+
+echo "==> pull"
+./target/debug/pglifecycle pull --dump "${WORKDIR}/source.dump" \
+    "${WORKDIR}/project"
+
+echo "==> build (loads and validates the pulled project)"
+./target/debug/pglifecycle build "${WORKDIR}/project" \
+    "${WORKDIR}/build.dump"
+
+echo "==> pg_restore into ${RESTORED_DB}"
+psql -d postgres -q -c "DROP DATABASE IF EXISTS ${RESTORED_DB}"
+psql -d postgres -q -c "CREATE DATABASE ${RESTORED_DB}"
+pg_restore -d "${RESTORED_DB}" --no-owner --exit-on-error \
+    "${WORKDIR}/build.dump"
+
+echo "==> Comparing schema-only dumps"
+# the \restrict/\unrestrict psql guards carry a random per-dump token
+pg_dump -d "${SOURCE_DB}" --schema-only --no-owner \
+    | grep -v '^\\\(un\)\{0,1\}restrict ' > "${WORKDIR}/source.sql"
+pg_dump -d "${RESTORED_DB}" --schema-only --no-owner \
+    | grep -v '^\\\(un\)\{0,1\}restrict ' > "${WORKDIR}/restored.sql"
+if diff -u "${WORKDIR}/source.sql" "${WORKDIR}/restored.sql"; then
+    echo "Round-trip gate passed: schema diff is empty"
+else
+    echo "Round-trip gate FAILED: schemas differ" >&2
+    exit 1
+fi

--- a/src/build/acls.rs
+++ b/src/build/acls.rs
@@ -13,39 +13,40 @@ use std::collections::BTreeMap;
 use serde_json::{Map, Value};
 
 use crate::constants::ObjectType;
-use crate::models::{Acls, Definition};
+use crate::models::{Acls, Definition, Item};
 use crate::project::Project;
 use crate::utils::quote_ident;
 
 use super::Builder;
 
-/// `(Acls field, GRANT keyword, dependency object type)`
-const SECTIONS: &[(&str, &str, Option<ObjectType>)] = &[
-    ("columns", "TABLE", Some(ObjectType::Table)),
-    ("databases", "DATABASE", None),
-    ("domains", "DOMAIN", Some(ObjectType::Domain)),
+/// PostgreSQL grants on views and materialized views use the same
+/// TABLE/COLUMN syntax as tables, so relation ACLs may target any of
+/// the three
+const RELATIONS: &[ObjectType] = &[
+    ObjectType::Table,
+    ObjectType::View,
+    ObjectType::MaterializedView,
+];
+
+/// `(Acls field, GRANT keyword, dependency object types)`
+const SECTIONS: &[(&str, &str, &[ObjectType])] = &[
+    ("columns", "TABLE", RELATIONS),
+    ("databases", "DATABASE", &[]),
+    ("domains", "DOMAIN", &[ObjectType::Domain]),
     (
         "foreign_data_wrappers",
         "FOREIGN DATA WRAPPER",
-        Some(ObjectType::ForeignDataWrapper),
+        &[ObjectType::ForeignDataWrapper],
     ),
-    (
-        "foreign_servers",
-        "FOREIGN SERVER",
-        Some(ObjectType::Server),
-    ),
-    ("functions", "FUNCTION", Some(ObjectType::Function)),
-    (
-        "languages",
-        "LANGUAGE",
-        Some(ObjectType::ProceduralLanguage),
-    ),
-    ("large_objects", "LARGE OBJECT", None),
-    ("schemata", "SCHEMA", Some(ObjectType::Schema)),
-    ("sequences", "SEQUENCE", Some(ObjectType::Sequence)),
-    ("tables", "TABLE", Some(ObjectType::Table)),
-    ("tablespaces", "TABLESPACE", Some(ObjectType::Tablespace)),
-    ("types", "TYPE", Some(ObjectType::Type)),
+    ("foreign_servers", "FOREIGN SERVER", &[ObjectType::Server]),
+    ("functions", "FUNCTION", &[ObjectType::Function]),
+    ("languages", "LANGUAGE", &[ObjectType::ProceduralLanguage]),
+    ("large_objects", "LARGE OBJECT", &[]),
+    ("schemata", "SCHEMA", &[ObjectType::Schema]),
+    ("sequences", "SEQUENCE", &[ObjectType::Sequence]),
+    ("tables", "TABLE", RELATIONS),
+    ("tablespaces", "TABLESPACE", &[ObjectType::Tablespace]),
+    ("types", "TYPE", &[ObjectType::Type]),
 ];
 
 #[derive(Default)]
@@ -77,7 +78,7 @@ pub(super) fn dump_acls(
         }
     }
     for ((section, object), acl) in &objects {
-        let (key, keyword, dep_type) = SECTIONS[*section];
+        let (key, keyword, dep_types) = SECTIONS[*section];
         // column grants attach to their table's entry
         let target = match key {
             "columns" => match object.rsplit_once('.') {
@@ -99,8 +100,8 @@ pub(super) fn dump_acls(
         };
         let mut owner = builder.superuser.clone();
         let mut dependencies = Vec::new();
-        if let Some(dep_type) = dep_type {
-            match find_object(builder, project, dep_type, &target) {
+        if !dep_types.is_empty() {
+            match find_object(builder, project, dep_types, &target) {
                 Some((dump_id, item_owner)) => {
                     dependencies.push(dump_id);
                     if let Some(item_owner) = item_owner {
@@ -108,8 +109,7 @@ pub(super) fn dump_acls(
                     }
                 }
                 None => log::warn!(
-                    "ACL target {} {target} not found in the project",
-                    dep_type.as_str()
+                    "ACL target {keyword} {target} not found in the project"
                 ),
             }
         }
@@ -209,22 +209,48 @@ fn statement(
 fn find_object(
     builder: &Builder,
     project: &Project,
-    desc: ObjectType,
+    descs: &[ObjectType],
     object: &str,
 ) -> Option<(i32, Option<String>)> {
     let (schema, name) = match object.split_once('.') {
         Some((schema, name)) => (Some(schema), name),
         None => (None, object),
     };
-    // function objects are keyed `schema.name(args)`
-    let name = name.split('(').next().unwrap_or(name);
-    let item = project.inventory.iter().find(|item| {
-        item.desc == desc
-            && item.definition.name() == name
-            && (desc.is_schemaless() || item.definition.schema() == schema)
-    })?;
+    let item = if descs == [ObjectType::Function] {
+        find_function(project, schema, name)
+    } else {
+        project.inventory.iter().find(|item| {
+            descs.contains(&item.desc)
+                && item.definition.name() == name
+                && (item.desc.is_schemaless()
+                    || item.definition.schema() == schema)
+        })
+    }?;
     let dump_id = builder.dump_id_map.get(&item.id)?;
     Some((*dump_id, item.definition.owner().map(str::to_string)))
+}
+
+/// Function ACLs are keyed `schema.name(args)`: match the identity
+/// signature exactly, falling back to the bare name only when it is
+/// unambiguous, so overloads never bind to the wrong entry
+fn find_function<'a>(
+    project: &'a Project,
+    schema: Option<&str>,
+    name: &str,
+) -> Option<&'a Item> {
+    let functions = project.inventory.iter().filter(|item| {
+        item.desc == ObjectType::Function && item.definition.schema() == schema
+    });
+    if let Some(item) = functions.clone().find(|item| {
+        matches!(&item.definition, Definition::Function(f)
+            if f.identity() == name)
+    }) {
+        return Some(item);
+    }
+    let base = name.split('(').next().unwrap_or(name);
+    let mut matches = functions.filter(|item| item.definition.name() == base);
+    let item = matches.next()?;
+    matches.next().is_none().then_some(item)
 }
 
 fn section<'a>(acls: &'a Acls, key: &str) -> Option<&'a Map<String, Value>> {

--- a/src/build/acls.rs
+++ b/src/build/acls.rs
@@ -1,0 +1,341 @@
+//! ACL entry emission (new in the Rust implementation — the Python
+//! build loaded grants/revocations into models but never wrote them to
+//! the archive)
+//!
+//! Grants and revocations from role, user, and group definitions are
+//! grouped per target object and emitted as pg_dump-style ACL entries:
+//! tag `<KIND> <name>` (e.g. `SCHEMA test`, `TABLE users`), the owning
+//! object's namespace and owner, and a dependency edge on the object's
+//! entry so the topological sort restores ACLs after their objects.
+
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+
+use crate::constants::ObjectType;
+use crate::models::{Acls, Definition};
+use crate::project::Project;
+use crate::utils::quote_ident;
+
+use super::Builder;
+
+/// `(Acls field, GRANT keyword, dependency object type)`
+const SECTIONS: &[(&str, &str, Option<ObjectType>)] = &[
+    ("columns", "TABLE", Some(ObjectType::Table)),
+    ("databases", "DATABASE", None),
+    ("domains", "DOMAIN", Some(ObjectType::Domain)),
+    (
+        "foreign_data_wrappers",
+        "FOREIGN DATA WRAPPER",
+        Some(ObjectType::ForeignDataWrapper),
+    ),
+    (
+        "foreign_servers",
+        "FOREIGN SERVER",
+        Some(ObjectType::Server),
+    ),
+    ("functions", "FUNCTION", Some(ObjectType::Function)),
+    (
+        "languages",
+        "LANGUAGE",
+        Some(ObjectType::ProceduralLanguage),
+    ),
+    ("large_objects", "LARGE OBJECT", None),
+    ("schemata", "SCHEMA", Some(ObjectType::Schema)),
+    ("sequences", "SEQUENCE", Some(ObjectType::Sequence)),
+    ("tables", "TABLE", Some(ObjectType::Table)),
+    ("tablespaces", "TABLESPACE", Some(ObjectType::Tablespace)),
+    ("types", "TYPE", Some(ObjectType::Type)),
+];
+
+#[derive(Default)]
+struct ObjectAcl {
+    revokes: Vec<String>,
+    grants: Vec<String>,
+}
+
+pub(super) fn dump_acls(
+    builder: &mut Builder,
+    project: &Project,
+) -> Result<(), String> {
+    // (section index, object) → statements; BTreeMap keeps the output
+    // deterministic across runs
+    let mut objects: BTreeMap<(usize, String), ObjectAcl> = BTreeMap::new();
+    for item in &project.inventory {
+        let (grants, revocations) = match &item.definition {
+            Definition::Group(d) => (&d.grants, &d.revocations),
+            Definition::Role(d) => (&d.grants, &d.revocations),
+            Definition::User(d) => (&d.grants, &d.revocations),
+            _ => continue,
+        };
+        let role = item.definition.name();
+        if let Some(acls) = revocations {
+            collect(&mut objects, acls, &role, true);
+        }
+        if let Some(acls) = grants {
+            collect(&mut objects, acls, &role, false);
+        }
+    }
+    for ((section, object), acl) in &objects {
+        let (key, keyword, dep_type) = SECTIONS[*section];
+        // column grants attach to their table's entry
+        let target = match key {
+            "columns" => match object.rsplit_once('.') {
+                Some((table, _)) => table.to_string(),
+                None => object.clone(),
+            },
+            _ => object.clone(),
+        };
+        let (namespace, name) = match target.split_once('.') {
+            Some((schema, name)) => (schema, name),
+            None => ("", target.as_str()),
+        };
+        let tag = match key {
+            "columns" => format!(
+                "COLUMN {}",
+                object.split_once('.').map(|(_, n)| n).unwrap_or(object)
+            ),
+            _ => format!("{keyword} {name}"),
+        };
+        let mut owner = builder.superuser.clone();
+        let mut dependencies = Vec::new();
+        if let Some(dep_type) = dep_type {
+            match find_object(builder, project, dep_type, &target) {
+                Some((dump_id, item_owner)) => {
+                    dependencies.push(dump_id);
+                    if let Some(item_owner) = item_owner {
+                        owner = item_owner;
+                    }
+                }
+                None => log::warn!(
+                    "ACL target {} {target} not found in the project",
+                    dep_type.as_str()
+                ),
+            }
+        }
+        let mut statements = acl.revokes.clone();
+        statements.extend(acl.grants.iter().cloned());
+        let defn = format!("{}\n", statements.join("\n"));
+        builder
+            .dump
+            .add_entry(
+                libpgdump::ObjectType::Acl,
+                Some(namespace),
+                Some(&tag),
+                Some(&owner),
+                Some(&defn),
+                None,
+                None,
+                &dependencies,
+            )
+            .map_err(|e| format!("failed to add ACL {tag}: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Render one role's ACLs into the per-object statement map
+fn collect(
+    objects: &mut BTreeMap<(usize, String), ObjectAcl>,
+    acls: &Acls,
+    role: &str,
+    revoke: bool,
+) {
+    for (index, (key, keyword, _)) in SECTIONS.iter().enumerate() {
+        let Some(map) = section(acls, key) else {
+            continue;
+        };
+        for (object, privileges) in map {
+            let privileges: Vec<String> = privileges
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            if privileges.is_empty() {
+                continue;
+            }
+            let entry = objects.entry((index, object.clone())).or_default();
+            let statement =
+                statement(revoke, keyword, key, object, &privileges, role);
+            if revoke {
+                entry.revokes.push(statement);
+            } else {
+                entry.grants.push(statement);
+            }
+        }
+    }
+}
+
+/// One GRANT or REVOKE statement for a role on an object
+fn statement(
+    revoke: bool,
+    keyword: &str,
+    section: &str,
+    object: &str,
+    privileges: &[String],
+    role: &str,
+) -> String {
+    let (privileges, object) = match section {
+        // `schema.table.column` → `SELECT(column) ON TABLE schema.table`
+        "columns" => match object.rsplit_once('.') {
+            Some((table, column)) => (
+                privileges
+                    .iter()
+                    .map(|p| format!("{p}({})", quote_ident(column)))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                quote_object(table),
+            ),
+            None => (privileges.join(", "), quote_object(object)),
+        },
+        // function signatures carry their argument list verbatim
+        "functions" => (privileges.join(", "), object.to_string()),
+        _ => (privileges.join(", "), quote_object(object)),
+    };
+    if revoke {
+        format!(
+            "REVOKE {privileges} ON {keyword} {object} FROM {};",
+            quote_role(role)
+        )
+    } else {
+        format!(
+            "GRANT {privileges} ON {keyword} {object} TO {};",
+            quote_role(role)
+        )
+    }
+}
+
+/// Find the granted-on object's entry id and owner
+fn find_object(
+    builder: &Builder,
+    project: &Project,
+    desc: ObjectType,
+    object: &str,
+) -> Option<(i32, Option<String>)> {
+    let (schema, name) = match object.split_once('.') {
+        Some((schema, name)) => (Some(schema), name),
+        None => (None, object),
+    };
+    // function objects are keyed `schema.name(args)`
+    let name = name.split('(').next().unwrap_or(name);
+    let item = project.inventory.iter().find(|item| {
+        item.desc == desc
+            && item.definition.name() == name
+            && (desc.is_schemaless() || item.definition.schema() == schema)
+    })?;
+    let dump_id = builder.dump_id_map.get(&item.id)?;
+    Some((*dump_id, item.definition.owner().map(str::to_string)))
+}
+
+fn section<'a>(acls: &'a Acls, key: &str) -> Option<&'a Map<String, Value>> {
+    match key {
+        "columns" => acls.columns.as_ref(),
+        "databases" => acls.databases.as_ref(),
+        "domains" => acls.domains.as_ref(),
+        "foreign_data_wrappers" => acls.foreign_data_wrappers.as_ref(),
+        "foreign_servers" => acls.foreign_servers.as_ref(),
+        "functions" => acls.functions.as_ref(),
+        "languages" => acls.languages.as_ref(),
+        "large_objects" => acls.large_objects.as_ref(),
+        "schemata" => acls.schemata.as_ref(),
+        "sequences" => acls.sequences.as_ref(),
+        "tables" => acls.tables.as_ref(),
+        "tablespaces" => acls.tablespaces.as_ref(),
+        "types" => acls.types.as_ref(),
+        other => unreachable!("unknown ACL section {other}"),
+    }
+}
+
+/// Quote each part of a possibly-qualified object name
+fn quote_object(object: &str) -> String {
+    object
+        .split('.')
+        .map(quote_ident)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+/// PUBLIC is a keyword, not an identifier
+fn quote_role(role: &str) -> String {
+    if role.eq_ignore_ascii_case("public") {
+        String::from("PUBLIC")
+    } else {
+        quote_ident(role)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use serde_json::json;
+
+    use crate::models::{self, Item};
+
+    use super::*;
+
+    fn project_with_acls() -> Project {
+        let schema: models::Schema = serde_json::from_value(json!({
+            "name": "test", "owner": "owner_role",
+        }))
+        .unwrap();
+        let role: models::Role = serde_json::from_value(json!({
+            "name": "PUBLIC",
+            "create": false,
+            "grants": {"schemata": {"test": ["USAGE"]}},
+            "revocations": {"schemata": {"test": ["CREATE"]}},
+        }))
+        .unwrap();
+        Project {
+            name: String::from("acls"),
+            encoding: String::from("UTF8"),
+            stdstrings: true,
+            superuser: String::from("postgres"),
+            default_schema: String::from("public"),
+            path: std::path::PathBuf::new(),
+            inventory: vec![
+                Item {
+                    id: 0,
+                    desc: ObjectType::Schema,
+                    definition: Definition::Schema(schema),
+                    dependencies: BTreeSet::new(),
+                },
+                Item {
+                    id: 1,
+                    desc: ObjectType::Role,
+                    definition: Definition::Role(role),
+                    dependencies: BTreeSet::new(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn emits_acl_entries_with_dependencies() {
+        let project = project_with_acls();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("acls.dump");
+        crate::build::build(&project, &path).unwrap();
+        let dump = libpgdump::load(&path).unwrap();
+        let acl = dump
+            .entries()
+            .iter()
+            .find(|e| e.desc == libpgdump::ObjectType::Acl)
+            .expect("ACL entry");
+        assert_eq!(acl.tag.as_deref(), Some("SCHEMA test"));
+        assert_eq!(acl.owner.as_deref(), Some("owner_role"));
+        assert_eq!(
+            acl.defn.as_deref(),
+            Some(
+                "REVOKE CREATE ON SCHEMA test FROM PUBLIC;\n\
+                 GRANT USAGE ON SCHEMA test TO PUBLIC;\n"
+            )
+        );
+        let schema = dump
+            .entries()
+            .iter()
+            .find(|e| e.desc == libpgdump::ObjectType::Schema)
+            .expect("schema entry");
+        assert_eq!(acl.dependencies, vec![schema.dump_id]);
+    }
+}

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -20,6 +20,14 @@
 //! 7. Table column collations render `COLLATE x` (Python crashed)
 //! 8. Base/range type options render from their own fields (Python
 //!    read `receive` for SEND and `subtype` for SUBTYPE_OPCLASS)
+//! 9. String DEFAULT values that look like SQL expressions render raw
+//!    (Python quoted every string, e.g. `DEFAULT 'uuid_generate_v4()'`)
+//! 10. CREATE INDEX names render unqualified (Python emitted
+//!     `CREATE INDEX schema.name`, which PostgreSQL rejects)
+//! 11. Roles with `create: false` (e.g. PUBLIC) emit no entry (Python
+//!     emitted CREATE ROLE anyway)
+
+mod acls;
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -27,7 +35,7 @@ use std::path::Path;
 use serde_json::{Map, Value};
 
 use crate::models::{
-    Acls, Column, ConstraintColumns, Definition, Index, Item, RoleOptions,
+    Column, ConstraintColumns, Definition, Index, Item, RoleOptions,
     TablePartitionColumn, Trigger, ViewColumn,
 };
 use crate::project::Project;
@@ -49,6 +57,7 @@ pub fn build(project: &Project, destination: &Path) -> Result<(), String> {
     for item in &project.inventory {
         builder.dump_item(item)?;
     }
+    acls::dump_acls(&mut builder, project)?;
     // record inventory dependency edges on the entries so the weighted
     // pg_dump topological sort in libpgdump (run by save) can order
     // them; the Python implementation instead pre-ordered its adds with
@@ -206,7 +215,11 @@ impl Builder {
         parent_dump_id: i32,
         comment: &str,
     ) -> Result<(), String> {
-        let name = if namespace.is_empty() {
+        // extensions record the schema they install into as their
+        // namespace, but COMMENT ON EXTENSION takes an unqualified name
+        let name = if desc == "EXTENSION" {
+            quote_ident(tag)
+        } else if namespace.is_empty() {
             tag.to_string()
         } else {
             format!("{namespace}.{tag}")
@@ -451,7 +464,7 @@ impl Builder {
         }
         if let Some(default) = &d.default {
             create.push("DEFAULT".into());
-            create.push(postgres_value(&Value::String(default.clone())));
+            create.push(render_default(&Value::String(default.clone())));
         }
         if let Some(constraints) = &d.check_constraints {
             let mut rendered = Vec::new();
@@ -846,6 +859,11 @@ impl Builder {
         let Definition::Role(d) = &item.definition else {
             unreachable!()
         };
+        // create: false defines a role without creating it (e.g.
+        // PUBLIC); deviation 11 — Python emitted CREATE ROLE anyway
+        if d.create == Some(false) {
+            return Ok(());
+        }
         let mut create =
             vec!["CREATE".into(), "ROLE".into(), quote_ident(&d.name)];
         if let Some(options) = &d.options {
@@ -1103,7 +1121,10 @@ impl Builder {
         parent: &Item,
         table: &crate::models::Table,
     ) -> Result<(), String> {
-        let name = format!(
+        // index names cannot be schema-qualified in CREATE INDEX; the
+        // index lives in its table's schema (deviation 10 — Python
+        // emitted `CREATE INDEX schema.name`, which does not parse)
+        let qualified = format!(
             "{}.{}",
             quote_ident(&table.schema),
             quote_ident(&index.name)
@@ -1113,7 +1134,7 @@ impl Builder {
             create.push("UNIQUE".into());
         }
         create.push("INDEX".into());
-        create.push(name.clone());
+        create.push(quote_ident(&index.name));
         create.push("ON".into());
         if index.recurse == Some(false) {
             create.push("ONLY".into());
@@ -1174,7 +1195,7 @@ impl Builder {
             create.push("WHERE".into());
             create.push(where_clause.clone());
         }
-        let drop = vec!["DROP INDEX IF EXISTS".into(), name];
+        let drop = vec!["DROP INDEX IF EXISTS".into(), qualified];
         let parent_dump_id = self.dump_id_map[&parent.id];
         let dump_id = self.add_entry(
             "INDEX",
@@ -1748,6 +1769,25 @@ fn push_role_options(
     push_bool_option(sql, "SUPERUSER", options.superuser);
 }
 
+/// DEFAULT clause rendering: strings that look like SQL expressions
+/// (quoted literals, casts, function calls, keyword-like all-caps)
+/// pass through raw; everything else renders as a literal. Deviation
+/// 9: Python quoted every string, producing unrestorable SQL for
+/// expression defaults like `uuid_generate_v4()`.
+fn render_default(value: &Value) -> String {
+    if let Value::String(s) = value {
+        let expression = s.starts_with('\'')
+            || s.ends_with(')')
+            || s.contains("::")
+            || (!s.is_empty()
+                && s.chars().all(|c| c.is_ascii_uppercase() || c == '_'));
+        if expression {
+            return s.clone();
+        }
+    }
+    postgres_value(value)
+}
+
 fn render_table_column(column: &Column) -> String {
     let mut sql = vec![column.name.clone(), column.data_type.clone()];
     if let Some(collation) = &column.collation {
@@ -1763,7 +1803,7 @@ fn render_table_column(column: &Column) -> String {
     }
     if let Some(default) = &column.default {
         sql.push("DEFAULT".into());
-        sql.push(postgres_value(default));
+        sql.push(render_default(default));
     }
     if let Some(generated) = &column.generated {
         if let Some(expression) = &generated.expression {
@@ -1850,8 +1890,3 @@ fn render_parameters(parameters: &Map<String, Value>) -> String {
         .collect::<Vec<_>>()
         .join(", ")
 }
-
-// Acls intentionally unused for now: the Python build never emitted
-// grants/revocations into the archive; ACL entries arrive with the
-// pull/deploy work.
-const _: fn(&Acls) = |_| {};

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1770,17 +1770,31 @@ fn push_role_options(
 }
 
 /// DEFAULT clause rendering: strings that look like SQL expressions
-/// (quoted literals, casts, function calls, keyword-like all-caps)
-/// pass through raw; everything else renders as a literal. Deviation
-/// 9: Python quoted every string, producing unrestorable SQL for
-/// expression defaults like `uuid_generate_v4()`.
+/// (quoted literals, casts, function calls, parameterless keyword
+/// expressions like `CURRENT_TIMESTAMP`) pass through raw; everything
+/// else renders as a literal. Deviation 9: Python quoted every string,
+/// producing unrestorable SQL for expression defaults like
+/// `uuid_generate_v4()`.
 fn render_default(value: &Value) -> String {
     if let Value::String(s) = value {
+        const RAW_KEYWORDS: &[&str] = &[
+            "CURRENT_CATALOG",
+            "CURRENT_DATE",
+            "CURRENT_ROLE",
+            "CURRENT_SCHEMA",
+            "CURRENT_TIME",
+            "CURRENT_TIMESTAMP",
+            "CURRENT_USER",
+            "LOCALTIME",
+            "LOCALTIMESTAMP",
+            "NULL",
+            "SESSION_USER",
+            "USER",
+        ];
         let expression = s.starts_with('\'')
-            || s.ends_with(')')
+            || (s.contains('(') && s.ends_with(')'))
             || s.contains("::")
-            || (!s.is_empty()
-                && s.chars().all(|c| c.is_ascii_uppercase() || c == '_'));
+            || RAW_KEYWORDS.iter().any(|kw| s.eq_ignore_ascii_case(kw));
         if expression {
             return s.clone();
         }

--- a/src/models/function.rs
+++ b/src/models/function.rs
@@ -56,6 +56,33 @@ pub struct Function {
     pub comment: Option<String>,
 }
 
+impl Function {
+    /// The identity signature (`name(mode name type, ...)`) used to
+    /// match `COMMENT ON FUNCTION` and ACL targets; mirrors
+    /// `pg_get_function_identity_arguments` — defaults are omitted,
+    /// `IN` modes are implicit and OUT/TABLE parameters are excluded
+    pub fn identity(&self) -> String {
+        let args: Vec<String> = self
+            .parameters
+            .iter()
+            .flatten()
+            .filter(|p| p.mode != "OUT" && p.mode != "TABLE")
+            .map(|p| {
+                let mut parts: Vec<&str> = Vec::new();
+                if p.mode != "IN" {
+                    parts.push(&p.mode);
+                }
+                if let Some(name) = &p.name {
+                    parts.push(name);
+                }
+                parts.push(&p.data_type);
+                parts.join(" ")
+            })
+            .collect();
+        format!("{}({})", self.name, args.join(", "))
+    }
+}
+
 /// Represents a single parameter for a function
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -561,7 +561,7 @@ impl Assembly {
         if let Some(function) = self
             .functions
             .iter_mut()
-            .find(|f| f.schema == schema && function_identity(f) == name)
+            .find(|f| f.schema == schema && f.identity() == name)
         {
             function.comment = Some(comment.to_string());
             return true;
@@ -756,31 +756,6 @@ fn cancel_revokes(statements: Vec<Statement>) -> Vec<Statement> {
             _ => true,
         })
         .collect()
-}
-
-/// The identity signature (`name(mode name type, ...)`) used to match
-/// `COMMENT ON FUNCTION` targets; mirrors
-/// `pg_get_function_identity_arguments` — defaults are omitted, `IN`
-/// modes are implicit and OUT/TABLE parameters are excluded
-fn function_identity(function: &models::Function) -> String {
-    let args: Vec<String> = function
-        .parameters
-        .iter()
-        .flatten()
-        .filter(|p| p.mode != "OUT" && p.mode != "TABLE")
-        .map(|p| {
-            let mut parts: Vec<&str> = Vec::new();
-            if p.mode != "IN" {
-                parts.push(&p.mode);
-            }
-            if let Some(name) = &p.name {
-                parts.push(name);
-            }
-            parts.push(&p.data_type);
-            parts.join(" ")
-        })
-        .collect();
-    format!("{}({})", function.name, args.join(", "))
 }
 
 /// The quoted value from a `SET name = 'value';` entry definition

--- a/src/pull/writer.rs
+++ b/src/pull/writer.rs
@@ -35,7 +35,16 @@ pub fn write(assembly: &Assembly, args: &cli::Pull) -> Result<(), String> {
         )?;
     }
     for table in &assembly.tables {
-        writer.save(nested("tables", &table.schema, &table.name), table)?;
+        let mut value = serialize(table)?;
+        if let (Some(map), Some(dependencies)) =
+            (value.as_object_mut(), table_dependencies(table))
+        {
+            map.insert(String::from("dependencies"), dependencies);
+        }
+        writer.save_value(
+            nested("tables", &table.schema, &table.name),
+            &value,
+        )?;
     }
     for view in &assembly.views {
         writer.save(nested("views", &view.schema, &view.name), view)?;
@@ -249,6 +258,22 @@ impl Writer {
         std::fs::write(&path, yamlio::dump(value))
             .map_err(|e| format!("failed to write {}: {e}", path.display()))
     }
+}
+
+/// Foreign keys order table creation: emit a `dependencies` key so
+/// the build's topological sort restores referenced tables first
+fn table_dependencies(table: &models::Table) -> Option<Value> {
+    let this = format!("{}.{}", table.schema, table.name);
+    let mut references: Vec<String> = table
+        .foreign_keys
+        .iter()
+        .flatten()
+        .map(|fk| fk.references.name.clone())
+        .filter(|name| *name != this)
+        .collect();
+    references.sort();
+    references.dedup();
+    (!references.is_empty()).then(|| json!({"tables": references}))
 }
 
 /// `user.yml` does not allow the `login` option (login is implied)

--- a/tests/build_parity.rs
+++ b/tests/build_parity.rs
@@ -26,10 +26,14 @@ const DEVIATIONS: &[(&str, &str, &str)] = &[
     ("ENCODING", "", "ENCODING"),
     ("STDSTRINGS", "", "STDSTRINGS"),
     ("SEARCHPATH", "", "SEARCHPATH"),
-    // BYPASSRLS rendered from create_db in Python
+    // Python emitted CREATE ROLE for create: false roles (and
+    // rendered BYPASSRLS from create_db); the Rust build skips them
     ("ROLE", "", "postgres"),
     // Python interpolated a Python list repr into WHEN TAG IN
     ("EVENT TRIGGER", "", "disable_alter_domain"),
+    // Python emitted CREATE INDEX schema.name, which does not parse
+    ("INDEX", "test", "empty_table_created_at"),
+    ("INDEX", "test", "users_unique_email"),
     // Python's loader dropped primary keys and rendered ON_DELETE /
     // ON_UPDATE
     ("TABLE", "test", "addresses"),
@@ -67,12 +71,23 @@ const CORRECTED: &[(&str, &str, &str, &str)] = &[
         "SET standard_conforming_strings = 'on';\n",
     ),
     ("SEARCHPATH", "", "", "SELECT pg_catalog.set_config"),
-    ("ROLE", "", "postgres", "NOBYPASSRLS CREATEDB"),
     (
         "EVENT TRIGGER",
         "",
         "disable_alter_domain",
         "WHEN TAG IN ('ALTER DOMAIN')",
+    ),
+    (
+        "INDEX",
+        "test",
+        "empty_table_created_at",
+        "CREATE INDEX empty_table_created_at ON test.empty_table",
+    ),
+    (
+        "INDEX",
+        "test",
+        "users_unique_email",
+        "CREATE UNIQUE INDEX users_unique_email ON test.users",
     ),
     (
         "TABLE",
@@ -87,6 +102,10 @@ const CORRECTED: &[(&str, &str, &str, &str)] = &[
         "value TEXT, PRIMARY KEY (id) )",
     ),
     ("TABLE", "test", "users", "icon oid, PRIMARY KEY (id) )"),
+    // expression defaults render raw (Python quoted them)
+    ("TABLE", "test", "users", "DEFAULT uuid_generate_v4()"),
+    ("TABLE", "test", "users", "DEFAULT CURRENT_TIMESTAMP"),
+    ("TABLE", "test", "users", "DEFAULT 'en-US'"),
     (
         "TEXT SEARCH CONFIGURATION",
         "test",
@@ -194,10 +213,12 @@ fn matches_python_build_output() {
         .iter()
         .filter(|(key, ..)| {
             // exclude the corrected/recovered entries from the exact
-            // comparison; asserted separately below
-            !CORRECTED
-                .iter()
-                .any(|(d, n, t, _)| &entry_key(d, n, t) == key)
+            // comparison; asserted separately below. ACL entries are
+            // new in the Rust build (Python never emitted them)
+            key.0 != "ACL"
+                && !CORRECTED
+                    .iter()
+                    .any(|(d, n, t, _)| &entry_key(d, n, t) == key)
                 && !RECOVERED_COMMENTS
                     .iter()
                     .any(|(tag, _)| key == &entry_key("COMMENT", "test", tag))
@@ -234,7 +255,21 @@ fn matches_python_build_output() {
         assert!(defn.contains(comment), "{key:?} missing comment text");
     }
 
-    // 60 Python entries + 4 recovered text search comments
+    // the developers group's grant emits an ACL entry, which the
+    // Python build never did
+    let acl = rust_tuples
+        .iter()
+        .find(|(key, ..)| key.0 == "ACL")
+        .expect("missing ACL entry");
+    assert_eq!(acl.0, entry_key("ACL", "public", "TABLE empty_table"));
+    assert_eq!(
+        acl.2,
+        "GRANT SELECT, INSERT, DELETE, UPDATE ON TABLE \
+         public.empty_table TO developers;\n"
+    );
+
+    // 60 Python entries + 4 recovered text search comments + 1 ACL
+    // - 1 create: false role
     assert_eq!(dump.entries().len(), 64);
 }
 


### PR DESCRIPTION
## Summary

Closes the **Phase 3 round-trip gate** from PLAN.md:

```
fixtures/schema.sql → PostgreSQL → pg_dump -Fc → pull →
load + validate → build → pg_restore → re-dump → empty schema diff
```

`bin/round-trip` automates the gate (defaults target the compose.yaml container; override with `PGHOST`/`PGPORT`/`PGUSER`). It passes repeatedly against the PostgreSQL 17 container. Per the Phase 2 precedent, the Docker-dependent gate runs locally and is not wired into CI.

### ACL emission (new capability)

`src/build/acls.rs`: grants/revocations from role, user, and group definitions emit pg_dump-style ACL entries — grouped per target object, tagged `<KIND> <name>` (`SCHEMA test`, `TABLE users`), carrying the owning object's namespace/owner, and with a dependency edge on the object's entry so the toposort restores ACLs after their objects. The Python build never emitted ACLs (the `Acls` model was parked behind a `const _:` placeholder).

### Restore-correctness fixes (documented deviations 9–11)

Running the gate surfaced these; each is recorded in the build module doc and the parity test:

- **Deviation 9** — string `DEFAULT` values that look like SQL expressions (quoted literals, casts, function calls, keyword-like all-caps) render raw. Python quoted every string: `DEFAULT 'uuid_generate_v4()'` is unrestorable.
- **Deviation 10** — `CREATE INDEX` names render unqualified. Python emitted `CREATE INDEX schema.name`, which PostgreSQL rejects.
- **Deviation 11** — roles with `create: false` (PUBLIC) emit no entry. Python emitted `CREATE ROLE` anyway, which fails or pollutes the cluster on restore.
- `COMMENT ON EXTENSION` renders an unqualified, quoted name (`"uuid-ossp"`).
- `pull` now writes a `dependencies` key on tables derived from their foreign keys, so inline FK constraints restore after their referenced tables.

### Testing

- New unit test for ACL emission (entry shape, owner, REVOKE-before-GRANT ordering, dependency edge).
- `tests/build_parity.rs` updated: ACL entries excluded from the Python exact-match (Python emitted none) and asserted separately; index/default deviations registered with corrected-fragment assertions; entry count 64 (60 Python + 4 recovered comments + 1 ACL − 1 `create: false` role).
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, all 7 test suites green; `bin/round-trip` passes twice consecutively (no leaked cluster state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL ACL support: emits GRANT/REVOKE entries
  * Table dependency tracking included in schema outputs

* **Improvements**
  * SQL rendering updated to better match PostgreSQL conventions
  * Improved handling/identification of overloaded functions for comment matching

* **Tests**
  * New round-trip validation script and updated parity tests to cover ACLs and build/output differences
<!-- end of auto-generated comment: release notes by coderabbit.ai -->