### PR TITLE
Add release tooling and refresh docs for the Rust cutover (Phase 4)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,6 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
-      - 'pglifecycle/**'
       - '.github/workflows/docs.yaml'
   workflow_dispatch:
 
@@ -35,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs mkdocs-material "mkdocstrings[python]"
+          pip install mkdocs mkdocs-material
 
       - name: Build documentation
         run: mkdocs build --strict

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,30 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: crates.io
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Obtain crates.io token
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout homebrew tap
         uses: actions/checkout@v5
         with:
-          repository: gmr/homebrew-gmr
+          repository: gmr/homebrew-postgres
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Update formula

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,107 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (Linux aarch64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (native)
+        if: matrix.target != 'aarch64-unknown-linux-gnu'
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build (cross)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Package binary
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../pglifecycle-${{ matrix.target }}.tar.gz pglifecycle
+          cd ../../..
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: pglifecycle-${{ matrix.target }}.tar.gz
+
+  update-homebrew:
+    name: Update Homebrew formula
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get release version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download release assets and compute checksums
+        id: checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for target in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
+            url="https://github.com/gmr/pglifecycle/releases/download/${GITHUB_REF_NAME}/pglifecycle-${target}.tar.gz"
+            curl -fsSL -o "pglifecycle-${target}.tar.gz" "$url"
+            sha=$(sha256sum "pglifecycle-${target}.tar.gz" | cut -d' ' -f1)
+            key=$(echo "${target}" | tr '-' '_')
+            echo "${key}=${sha}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Checkout homebrew tap
+        uses: actions/checkout@v5
+        with:
+          repository: gmr/homebrew-pglifecycle
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Update formula
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA_AARCH64_APPLE: ${{ steps.checksums.outputs.aarch64_apple_darwin }}
+          SHA_X86_64_APPLE: ${{ steps.checksums.outputs.x86_64_apple_darwin }}
+          SHA_AARCH64_LINUX: ${{ steps.checksums.outputs.aarch64_unknown_linux_gnu }}
+          SHA_X86_64_LINUX: ${{ steps.checksums.outputs.x86_64_unknown_linux_gnu }}
+        run: |
+          sed -i "s/version \".*\"/version \"${VERSION}\"/" Formula/pglifecycle.rb
+          sed -i "s|download/v[^/]*/|download/v${VERSION}/|g" Formula/pglifecycle.rb
+          sed -i "/aarch64-apple-darwin/{n;s/sha256 \".*\"/sha256 \"${SHA_AARCH64_APPLE}\"/;}" Formula/pglifecycle.rb
+          sed -i "/x86_64-apple-darwin/{n;s/sha256 \".*\"/sha256 \"${SHA_X86_64_APPLE}\"/;}" Formula/pglifecycle.rb
+          sed -i "/aarch64-unknown-linux-gnu/{n;s/sha256 \".*\"/sha256 \"${SHA_AARCH64_LINUX}\"/;}" Formula/pglifecycle.rb
+          sed -i "/x86_64-unknown-linux-gnu/{n;s/sha256 \".*\"/sha256 \"${SHA_X86_64_LINUX}\"/;}" Formula/pglifecycle.rb
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/pglifecycle.rb
+          git commit -m "Update pglifecycle to ${{ steps.version.outputs.version }}"
+          git push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout homebrew tap
         uses: actions/checkout@v5
         with:
-          repository: gmr/homebrew-pglifecycle
+          repository: gmr/homebrew-gmr
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Update formula

--- a/README.md
+++ b/README.md
@@ -19,11 +19,25 @@ databases:
 
 ## Installation
 
-### Homebrew
+### Homebrew (macOS / Linux)
 
 ```bash
-brew install gmr/gmr/pglifecycle
+brew tap gmr/postgres
+brew install pglifecycle
 ```
+
+> [!NOTE]
+> Homebrew 6.0 added [tap trust](https://docs.brew.sh/Tap-Trust), and some
+> versions fail to install third-party taps inside the build sandbox (the
+> error mentions `build.rb ... exited with 1`). If you hit this, trust the
+> formula first:
+>
+> ```bash
+> brew trust --formula gmr/postgres/pglifecycle
+> ```
+>
+> or, as a temporary workaround, set `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` for
+> the install.
 
 ### Cargo
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ databases:
 ### Homebrew
 
 ```bash
-brew install gmr/pglifecycle/pglifecycle
+brew install gmr/gmr/pglifecycle
 ```
 
 ### Cargo

--- a/README.md
+++ b/README.md
@@ -2,13 +2,48 @@
 
 A PostgreSQL schema management tool
 
-[![Version](https://img.shields.io/pypi/v/pglifecycle.svg?)](https://pypi.python.org/pypi/pglifecycle)
+[![Crates.io](https://img.shields.io/crates/v/pglifecycle.svg)](https://crates.io/crates/pglifecycle)
 [![Testing](https://github.com/gmr/pglifecycle/workflows/Testing/badge.svg?)](https://github.com/gmr/pglifecycle/actions?workflow=Testing)
-[![Coverage](https://codecov.io/gh/gmr/pglifecycle/branch/main/graph/badge.svg)](https://codecov.io/github/gmr/pglifecycle?branch=main)
-[![License](https://img.shields.io/pypi/l/pglifecycle.svg?)](https://github.com/gmr/pglifecycle/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/gmr/pglifecycle.svg)](https://github.com/gmr/pglifecycle/blob/main/LICENSE)
+
+pglifecycle keeps your database schema in a version-controlled project
+of YAML files — one file per database object, validated against a
+JSON-Schema contract — and moves schema between the repository and live
+databases:
+
+- **`pull`** reads a live database (or a `pg_dump` archive) and writes
+  the project directory
+- **`build`** turns the project into a `pg_restore`-compatible custom
+  format archive
+- **`create`** scaffolds an empty project
 
 ## Installation
 
+### Homebrew
+
 ```bash
-pip install pglifecycle
+brew install gmr/pglifecycle/pglifecycle
 ```
+
+### Cargo
+
+```bash
+cargo install pglifecycle
+```
+
+Prebuilt binaries for Linux and macOS (x86_64 and aarch64) are attached
+to each [release](https://github.com/gmr/pglifecycle/releases).
+
+## Usage
+
+```bash
+# pull an existing database into a new project
+pglifecycle pull -h localhost -d mydb my-project/
+
+# build the project into a restorable archive
+pglifecycle build my-project/ mydb.dump
+pg_restore -d mydb_copy mydb.dump
+```
+
+See the [documentation](https://gmr.github.io/pglifecycle/) for the
+full command reference and project format.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,81 @@
+# Commands
+
+All commands share the logging options `-L/--log-file FILE`,
+`-v/--verbose`, and `--debug`.
+
+## create
+
+Create a skeleton project.
+
+```bash
+pglifecycle create [OPTIONS] DEST
+```
+
+| Option | Description |
+| --- | --- |
+| `--encoding ENCODING` | Database encoding (default `UTF-8`) |
+| `--force` | Write to `DEST` even if it already exists |
+| `--name NAME` | Override the default project name |
+| `--no-gitkeep` | Do not create `.gitkeep` files in empty directories |
+| `--no-stdstrings` | Turn off standard conforming strings |
+| `--superuser NAME` | Superuser name (default `postgres`) |
+
+## build
+
+Generate a `pg_restore`-compatible archive from a project. The project
+is loaded and validated against the JSON-Schema contract before the
+archive is written; entries are ordered with pg_dump's weighted
+topological sort.
+
+```bash
+pglifecycle build PROJECT DEST
+```
+
+## pull
+
+Create a project from a live database or an existing dump. Entry DDL is
+parsed into structured YAML (columns, constraints, indexes, and ACLs as
+data), view queries and function bodies are formatted, and child
+objects are merged into their owners.
+
+```bash
+pglifecycle pull [OPTIONS] DEST
+```
+
+| Option | Description |
+| --- | --- |
+| `-D, --dump FILE` | Use an existing `pg_dump -Fc` file instead of connecting |
+| `-r, --extract-roles` | Extract roles and users via `pg_dumpall --roles-only` |
+| `-i, --ignore FILE` | File listing project paths to skip writing |
+| `--force` | Write to `DEST` even if it already exists |
+| `--gitkeep` | Create `.gitkeep` files in empty directories |
+| `--remove-empty-dirs` | Remove empty directories after generation |
+| `--save-remaining` | Save unprocessed dump entries to `remaining.yaml` |
+
+Connection options mirror the PostgreSQL client tools and honor the
+standard `PGHOST`, `PGPORT`, `PGUSER`, and `PGDATABASE` environment
+variables:
+
+| Option | Description |
+| --- | --- |
+| `-d, --dbname NAME` | Database name to connect to |
+| `-h, --host HOST` | Server host or socket directory (default `localhost`) |
+| `-p, --port PORT` | Server port (default `5432`) |
+| `-U, --username NAME` | Username to operate as |
+| `-w, --no-password` | Never prompt for a password |
+| `-W, --password` | Force a password prompt |
+| `--role NAME` | Role to assume when connecting |
+
+DDL options:
+
+| Option | Description |
+| --- | --- |
+| `-x, --no-privileges` | Do not include GRANT/REVOKE |
+| `--no-security-labels` | Do not include security label assignments |
+| `--no-tablespaces` | Do not include tablespace assignments |
+
+Roles are classified when written: a role with a password or
+`VALID UNTIL` becomes a file in `users/`; everything else lands in
+`roles/`. Roles that appear only as ACL grantees (such as `PUBLIC`)
+are written with `create: false` so `build` defines but never creates
+them.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ data, not opaque SQL.
 ### Homebrew
 
 ```bash
-brew install gmr/pglifecycle/pglifecycle
+brew install gmr/gmr/pglifecycle
 ```
 
 ### Cargo

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,61 @@
 # pglifecycle
 
-A PostgreSQL schema management tool
+A PostgreSQL schema management tool.
+
+pglifecycle keeps your database schema in a version-controlled project
+of YAML files — one file per database object — and moves schema between
+the repository and live databases:
+
+- **`pull`** reads a live database (or a `pg_dump` archive) and writes
+  the project directory.
+- **`build`** turns the project into a `pg_restore`-compatible custom
+  format archive.
+- **`create`** scaffolds an empty project.
+
+The project format is validated against JSON-Schema definitions for
+every PostgreSQL object type, so the repository is the contract: tables,
+columns, constraints, indexes, functions, ACLs, and roles are structured
+data, not opaque SQL.
 
 ## Installation
 
-```bash
-pip install pglifecycle
-```
-
-## Usage
+### Homebrew
 
 ```bash
-pglifecycle --help
+brew install gmr/pglifecycle/pglifecycle
 ```
+
+### Cargo
+
+```bash
+cargo install pglifecycle
+```
+
+### Release binaries
+
+Prebuilt binaries for Linux and macOS (x86_64 and aarch64) are attached
+to each [GitHub release](https://github.com/gmr/pglifecycle/releases).
+
+## Quick start
+
+Pull an existing database into a new project:
+
+```bash
+pglifecycle pull -h localhost -d mydb my-project/
+```
+
+Build the project into a restorable archive:
+
+```bash
+pglifecycle build my-project/ mydb.dump
+pg_restore -d mydb_copy mydb.dump
+```
+
+Or start from scratch:
+
+```bash
+pglifecycle create my-project/
+```
+
+See [Commands](commands.md) for the full reference and
+[Project Format](project-format.md) for the directory layout.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,11 +19,23 @@ data, not opaque SQL.
 
 ## Installation
 
-### Homebrew
+### Homebrew (macOS / Linux)
+
+pglifecycle is published in the shared [gmr/postgres
+tap](https://github.com/gmr/homebrew-postgres):
 
 ```bash
-brew install gmr/gmr/pglifecycle
+brew tap gmr/postgres
+brew install pglifecycle
 ```
+
+!!! note
+    Homebrew 6.0 added [tap trust](https://docs.brew.sh/Tap-Trust), and
+    some versions fail to install third-party taps inside the build
+    sandbox (the error mentions `build.rb ... exited with 1`). If you
+    hit this, trust the formula first with
+    `brew trust --formula gmr/postgres/pglifecycle`, or set
+    `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` for the install.
 
 ### Cargo
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -4,7 +4,7 @@ A pglifecycle project is a directory of YAML files, one file per
 database object, validated against the JSON-Schema definitions in
 [`schemata/`](https://github.com/gmr/pglifecycle/tree/main/schemata).
 
-```
+```text
 my-project/
 ├── project.yaml          # name, encoding, extensions, languages
 ├── schemata/             # one file per schema

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -1,0 +1,76 @@
+# Project Format
+
+A pglifecycle project is a directory of YAML files, one file per
+database object, validated against the JSON-Schema definitions in
+[`schemata/`](https://github.com/gmr/pglifecycle/tree/main/schemata).
+
+```
+my-project/
+├── project.yaml          # name, encoding, extensions, languages
+├── schemata/             # one file per schema
+│   └── test.yaml
+├── tables/               # <schema>/<table>.yaml
+│   └── test/
+│       └── users.yaml
+├── views/                # <schema>/<view>.yaml
+├── materialized_views/
+├── functions/            # <schema>/<function>.yaml
+├── sequences/
+├── domains/
+├── types/                # one container file per schema
+├── roles/                # <role>.yaml
+├── users/
+├── groups/
+└── ...                   # aggregates, casts, collations, conversions,
+                          # event_triggers, operators, publications,
+                          # servers, subscriptions, tablespaces,
+                          # text_search, user_mappings, dml
+```
+
+Objects are structured data, not SQL. A table file, for example:
+
+```yaml
+---
+name: users
+schema: test
+owner: postgres
+columns:
+  - name: id
+    data_type: uuid
+    nullable: false
+    default: uuid_generate_v4()
+  - name: email
+    data_type: test.email_address
+    nullable: false
+indexes:
+  - name: users_unique_email
+    unique: true
+    method: btree
+    columns:
+      - name: email
+primary_key:
+  - id
+```
+
+## Conventions
+
+- The file location implies `schema` and `name`; both may be omitted
+  from the file body and are injected on load.
+- A `dependencies` key (e.g. `dependencies: {tables: [test.users]}`)
+  records relationships the topological sort cannot infer, such as
+  foreign-key ordering between tables.
+- ACL grants and revocations live on the grantee's role, user, or
+  group file under `grants:`/`revocations:`, keyed by object:
+
+```yaml
+---
+name: PUBLIC
+create: false
+grants:
+  schemata:
+    test:
+      - USAGE
+```
+
+- `create: false` defines a role without creating it — used for
+  built-in pseudo-roles like `PUBLIC`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,10 +4,6 @@ site_url: https://gmr.github.io/pglifecycle/
 repo_url: https://github.com/gmr/pglifecycle
 repo_name: gmr/pglifecycle
 
-exclude_docs: |
-  *.rst
-  conf.py
-
 theme:
   name: material
   palette:
@@ -36,17 +32,6 @@ theme:
 
 plugins:
   - search
-  - mkdocstrings:
-      handlers:
-        python:
-          paths: [.]
-          options:
-            docstring_style: google
-            show_source: true
-            show_root_heading: true
-            show_root_toc_entry: true
-            heading_level: 2
-            members_order: source
 
 markdown_extensions:
   - admonition
@@ -62,3 +47,5 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Commands: commands.md
+  - Project Format: project-format.md


### PR DESCRIPTION
## Summary

Phase 4 prep: everything pgfmt has, ported for pglifecycle.

### Release tooling (from pgfmt)

- **`release.yaml`** — on each GitHub release: binaries for `x86_64`/`aarch64` Linux (aarch64 via `cross`) and macOS, uploaded as `pglifecycle-<target>.tar.gz`, then an automatic formula bump in the new [gmr/homebrew-pglifecycle](https://github.com/gmr/homebrew-pglifecycle) tap.
- **`publish.yaml`** — `cargo publish` to crates.io on release via trusted publishing (needs the `crates.io` environment configured like pgfmt's).

### Docs (mkdocs kept)

- `docs/index.md` rewritten for the Rust tool (brew/cargo/binary install, quick start), new `docs/commands.md` (full CLI reference) and `docs/project-format.md` (layout, conventions, ACL/role placement).
- `mkdocs.yml`: dropped the Python-only `mkdocstrings` plugin; docs workflow no longer triggers on `pglifecycle/**` and no longer installs mkdocstrings. `mkdocs build --strict` passes.
- README: Rust install instructions; crates.io badge replaces PyPI/codecov.

### Done outside this PR

- **gmr/homebrew-pglifecycle** created and seeded with a placeholder formula (version `0.0.0`, zeroed checksums) that the release workflow rewrites on the first tagged release.
- **`python-final`** tag pushed at main's HEAD, per the PLAN.md cutover step.

### Action needed (secrets, can't be automated)

- `HOMEBREW_TAP_TOKEN` repo secret (PAT with write access to gmr/homebrew-pglifecycle), same as pgfmt's.
- `crates.io` environment for trusted publishing, same as pgfmt's.

Once this merges, the next step is the cutover PR: `rust-rewrite` → `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated multi-platform release packaging and publishing, plus automatic Homebrew formula updates and crate publication.

* **Documentation**
  * New comprehensive CLI commands guide and Project Format documentation.
  * Rewritten landing README with installation, quick-start examples, and improved navigation.

* **Chores**
  * Updated CI/CD and docs deployment workflows to streamline releases and documentation builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->