### PR TITLE
Fix post-cutover review config and Python oracle docs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,4 +2,5 @@ reviews:
   auto_review:
     enabled: true
     base_branches:
+      - main
       - rust-rewrite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,11 @@ cargo fmt            # Format (max_width 79, see rustfmt.toml)
 cargo clippy --all-targets -- -D warnings
 ```
 
-The Python implementation this replaces lives on `main`; reference it via:
+The Python implementation this replaces is preserved at the
+`python-final` tag; reference it via:
 
 ```bash
-git clone --depth 1 --branch main https://github.com/gmr/pglifecycle /tmp/pglifecycle-py
+git clone --depth 1 --branch python-final https://github.com/gmr/pglifecycle /tmp/pglifecycle-py
 ```
 
 It is the parity oracle until the round-trip gates in PLAN.md pass.

--- a/PLAN.md
+++ b/PLAN.md
@@ -30,10 +30,10 @@ selected pieces of [postgres-lsp](https://crates.io/crates/postgres-lsp-parse).
   phase gates below are the merge criteria for the PR that completes each
   phase.
 - The Python code is never present on the rewrite branch. Agents working on
-  the rewrite reference it via a shallow clone of `main`:
+  the rewrite reference it via a shallow clone of the `python-final` tag:
 
-  ```
-  git clone --depth 1 --branch main https://github.com/gmr/pglifecycle /tmp/pglifecycle-py
+  ```bash
+  git clone --depth 1 --branch python-final https://github.com/gmr/pglifecycle /tmp/pglifecycle-py
   ```
 
   The Python tool is the parity oracle (run from the clone via `uv run`)


### PR DESCRIPTION
## Summary
Addresses two CodeRabbit findings on the cutover PR #18 that only become real after main is overwritten with the Rust implementation.

## Problem
- `.coderabbit.yaml` restricted auto-review to PRs targeting `rust-rewrite`, so post-cutover PRs into `main` would receive no automatic review.
- CLAUDE.md and PLAN.md told contributors to clone `--branch main` for the Python parity oracle, which after the cutover points at the Rust rewrite instead of the Python implementation.

## Solution
- Add `main` to CodeRabbit `base_branches` (keeping `rust-rewrite` while PR #18 is open).
- Point the parity-oracle clone instructions at the preserved `python-final` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs to direct users to the Python implementation via the updated git tag and new clone instruction.

* **Chores**
  * Expanded auto-review branch coverage to include the main branch, widening review targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->