### PR TITLE
Add pull --update and --prune

### DIFF
--- a/bin/round-trip
+++ b/bin/round-trip
@@ -45,6 +45,16 @@ echo "==> pull"
 ./target/debug/pglifecycle pull --dump "${WORKDIR}/source.dump" \
     "${WORKDIR}/project"
 
+echo "==> pull --update from the same dump (no-op gate)"
+cp -R "${WORKDIR}/project" "${WORKDIR}/project-before"
+./target/debug/pglifecycle pull --update --dump "${WORKDIR}/source.dump" \
+    "${WORKDIR}/project"
+if ! diff -r "${WORKDIR}/project-before" "${WORKDIR}/project"; then
+    echo "Update gate FAILED: pull --update from an unchanged dump" \
+        "modified the project" >&2
+    exit 1
+fi
+
 echo "==> build (loads and validates the pulled project)"
 ./target/debug/pglifecycle build "${WORKDIR}/project" \
     "${WORKDIR}/build.dump"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,6 +48,8 @@ pglifecycle pull [OPTIONS] DEST
 | `-r, --extract-roles` | Extract roles and users via `pg_dumpall --roles-only` |
 | `-i, --ignore FILE` | File listing project paths to skip writing |
 | `--force` | Write to `DEST` even if it already exists |
+| `--update` | Merge into an existing project, rewriting only changed files |
+| `--prune` | With `--update`, delete files whose objects left the database |
 | `--gitkeep` | Create `.gitkeep` files in empty directories |
 | `--remove-empty-dirs` | Remove empty directories after generation |
 | `--save-remaining` | Save unprocessed dump entries to `remaining.yaml` |
@@ -73,6 +75,18 @@ DDL options:
 | `-x, --no-privileges` | Do not include GRANT/REVOKE |
 | `--no-security-labels` | Do not include security label assignments |
 | `--no-tablespaces` | Do not include tablespace assignments |
+
+With `--update`, `DEST` must be an existing project (it must contain
+`project.yaml`). The pull is rendered as usual but only files whose
+content actually changed are written, so `git diff` afterwards shows
+exactly what changed in the database. Files for objects that no longer
+exist in the database are reported as warnings and left in place;
+`--prune` deletes them instead (confined to the directories `pull`
+manages — `dml/` and other project content is never touched). Paths
+listed in the `--ignore` file are neither rewritten nor pruned. Note
+that overloaded function files are numbered in dump order
+(`name.yaml`, `name_1.yaml`, …), so adding or removing an overload can
+renumber a sibling's file.
 
 Roles are classified when written: a role with a password or
 `VALID UNTIL` becomes a file in `users/`; everything else lands in

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,15 @@ pub struct Pull {
     #[arg(long)]
     pub force: bool,
 
+    /// Merge into an existing project, rewriting only changed files
+    #[arg(long, conflicts_with = "force")]
+    pub update: bool,
+
+    /// With --update, delete project files whose objects no longer
+    /// exist in the database
+    #[arg(long, requires = "update")]
+    pub prune: bool,
+
     /// Create a .gitkeep file in empty directories
     #[arg(long, conflicts_with = "remove_empty_dirs")]
     pub gitkeep: bool,

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -6,6 +6,7 @@
 //! module into models and child entries (indexes, constraints,
 //! triggers, comments, ACLs, OWNED BY) are merged into their owners.
 
+mod update;
 mod writer;
 
 use std::collections::BTreeMap;
@@ -18,7 +19,15 @@ use crate::models;
 use crate::{cli, pgdump};
 
 pub fn pull(args: &cli::Pull) -> Result<(), String> {
-    if args.destination.exists() && !args.force {
+    if args.update {
+        if !args.destination.join("project.yaml").exists() {
+            return Err(format!(
+                "--update requires an existing project; {} has no \
+                 project.yaml",
+                args.destination.display()
+            ));
+        }
+    } else if args.destination.exists() && !args.force {
         return Err(format!("{} already exists", args.destination.display()));
     }
     if args.no_owner {
@@ -68,7 +77,12 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
         assembly.ingest_roles(&text)?;
     }
     assembly.format_sql();
-    writer::write(&assembly, args)
+    let files = writer::render(&assembly, args)?;
+    if args.update {
+        update::merge(&files, args)
+    } else {
+        writer::write_bootstrap(&files, args)
+    }
 }
 
 /// A dump entry that was not assembled into the project models

--- a/src/pull/update.rs
+++ b/src/pull/update.rs
@@ -1,0 +1,167 @@
+//! `pull --update`: merge the rendered file set into an existing
+//! project, writing only files whose content changed so `git diff`
+//! shows exactly what changed in the database. Files for objects no
+//! longer in the database are warned about, or removed with `--prune`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use crate::cli;
+use crate::pull::writer;
+use crate::yamlio;
+
+/// The directories `pull` writes object files into; staleness (and
+/// `--prune`) is confined to these — `dml/` and the other project
+/// directories are never touched
+const MANAGED_DIRS: &[&str] = &[
+    "domains",
+    "functions",
+    "materialized_views",
+    "roles",
+    "schemata",
+    "sequences",
+    "tables",
+    "types",
+    "users",
+    "views",
+];
+
+pub fn merge(
+    files: &BTreeMap<PathBuf, String>,
+    args: &cli::Pull,
+) -> Result<(), String> {
+    let root = &args.destination;
+    log::info!("Updating project at {}", root.display());
+    let ignore = writer::read_ignore(args.ignore.as_deref())?;
+    let mut written = 0usize;
+    for (relative, content) in files {
+        let path = root.join(relative);
+        if let Ok(existing) = std::fs::read_to_string(&path)
+            && existing == *content
+        {
+            continue;
+        }
+        let verb = if path.exists() {
+            "Updating"
+        } else {
+            "Creating"
+        };
+        log::info!("{verb} {}", relative.display());
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                format!("failed to create {}: {e}", parent.display())
+            })?;
+        }
+        std::fs::write(&path, content)
+            .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+        written += 1;
+    }
+    let stale = stale_files(root, files, &ignore)?;
+    if args.prune {
+        for relative in &stale {
+            log::info!("Removing {}", relative.display());
+            let path = root.join(relative);
+            std::fs::remove_file(&path).map_err(|e| {
+                format!("failed to remove {}: {e}", path.display())
+            })?;
+        }
+        remove_emptied_directories(root)?;
+    } else {
+        for relative in &stale {
+            log::warn!(
+                "{} has no matching database object; re-run with --prune \
+                 to remove it",
+                relative.display()
+            );
+        }
+    }
+    log::info!(
+        "Update complete: {written} file(s) written, {} stale",
+        stale.len()
+    );
+    Ok(())
+}
+
+/// YAML files on disk under the managed directories that the render
+/// did not produce and the ignore file does not cover
+fn stale_files(
+    root: &Path,
+    files: &BTreeMap<PathBuf, String>,
+    ignore: &BTreeSet<String>,
+) -> Result<Vec<PathBuf>, String> {
+    let mut stale = Vec::new();
+    for dir in MANAGED_DIRS {
+        let top = root.join(dir);
+        if !top.is_dir() {
+            continue;
+        }
+        let mut pending = vec![top];
+        while let Some(dir) = pending.pop() {
+            for entry in std::fs::read_dir(&dir).map_err(|e| {
+                format!("failed to read {}: {e}", dir.display())
+            })? {
+                let entry =
+                    entry.map_err(|e| format!("failed to read entry: {e}"))?;
+                let path = entry.path();
+                if path.is_dir() {
+                    pending.push(path);
+                    continue;
+                }
+                if !yamlio::is_yaml(&path) {
+                    continue;
+                }
+                let relative = path
+                    .strip_prefix(root)
+                    .expect("walked path under root")
+                    .to_path_buf();
+                if files.contains_key(&relative)
+                    || ignore.contains(&relative.to_string_lossy().to_string())
+                {
+                    continue;
+                }
+                stale.push(relative);
+            }
+        }
+    }
+    stale.sort();
+    Ok(stale)
+}
+
+/// After pruning, drop directories left empty below the managed
+/// top-level directories (the top-level layout itself is preserved)
+fn remove_emptied_directories(root: &Path) -> Result<(), String> {
+    for dir in MANAGED_DIRS {
+        let top = root.join(dir);
+        if !top.is_dir() {
+            continue;
+        }
+        let mut directories = Vec::new();
+        let mut pending = vec![top];
+        while let Some(dir) = pending.pop() {
+            for entry in std::fs::read_dir(&dir).map_err(|e| {
+                format!("failed to read {}: {e}", dir.display())
+            })? {
+                let entry =
+                    entry.map_err(|e| format!("failed to read entry: {e}"))?;
+                let path = entry.path();
+                if path.is_dir() {
+                    directories.push(path.clone());
+                    pending.push(path);
+                }
+            }
+        }
+        directories.sort_by_key(|d| std::cmp::Reverse(d.components().count()));
+        for dir in directories {
+            let empty = std::fs::read_dir(&dir)
+                .map_err(|e| format!("failed to read {}: {e}", dir.display()))?
+                .next()
+                .is_none();
+            if empty {
+                std::fs::remove_dir(&dir).map_err(|e| {
+                    format!("failed to remove {}: {e}", dir.display())
+                })?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/pull/update.rs
+++ b/src/pull/update.rs
@@ -82,14 +82,26 @@ pub fn merge(
     Ok(())
 }
 
-/// YAML files on disk under the managed directories that the render
-/// did not produce and the ignore file does not cover
+/// The root-level file `--save-remaining` emits; managed for
+/// staleness like the directories above
+const REMAINING_FILE: &str = "remaining.yaml";
+
+/// YAML files on disk under the managed directories (plus the
+/// root-level `remaining.yaml`) that the render did not produce and
+/// the ignore file does not cover
 fn stale_files(
     root: &Path,
     files: &BTreeMap<PathBuf, String>,
     ignore: &BTreeSet<String>,
 ) -> Result<Vec<PathBuf>, String> {
     let mut stale = Vec::new();
+    let remaining = PathBuf::from(REMAINING_FILE);
+    if root.join(&remaining).is_file()
+        && !files.contains_key(&remaining)
+        && !ignore.contains(REMAINING_FILE)
+    {
+        stale.push(remaining);
+    }
     for dir in MANAGED_DIRS {
         let top = root.join(dir);
         if !top.is_dir() {
@@ -103,7 +115,13 @@ fn stale_files(
                 let entry =
                     entry.map_err(|e| format!("failed to read entry: {e}"))?;
                 let path = entry.path();
-                if path.is_dir() {
+                let file_type = entry.file_type().map_err(|e| {
+                    format!("failed to read type for {}: {e}", path.display())
+                })?;
+                if file_type.is_symlink() {
+                    continue;
+                }
+                if file_type.is_dir() {
                     pending.push(path);
                     continue;
                 }
@@ -144,7 +162,13 @@ fn remove_emptied_directories(root: &Path) -> Result<(), String> {
                 let entry =
                     entry.map_err(|e| format!("failed to read entry: {e}"))?;
                 let path = entry.path();
-                if path.is_dir() {
+                let file_type = entry.file_type().map_err(|e| {
+                    format!("failed to read type for {}: {e}", path.display())
+                })?;
+                if file_type.is_symlink() {
+                    continue;
+                }
+                if file_type.is_dir() {
                     directories.push(path.clone());
                     pending.push(path);
                 }

--- a/src/pull/writer.rs
+++ b/src/pull/writer.rs
@@ -1,7 +1,7 @@
 //! YAML project emission for `pull` (ports the storage half of
 //! generate_project.py / storage.py)
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value, json};
@@ -10,13 +10,16 @@ use crate::constants::PROJECT_DIRS;
 use crate::pull::{Assembly, RoleState};
 use crate::{cli, models, yamlio};
 
-pub fn write(assembly: &Assembly, args: &cli::Pull) -> Result<(), String> {
-    log::info!("Writing project to {}", args.destination.display());
-    let writer = Writer {
-        root: args.destination.clone(),
+/// Render the project files for an assembly as `relative path →
+/// YAML text`, honoring the `--ignore` file
+pub fn render(
+    assembly: &Assembly,
+    args: &cli::Pull,
+) -> Result<BTreeMap<PathBuf, String>, String> {
+    let mut writer = Writer {
         ignore: read_ignore(args.ignore.as_deref())?,
+        files: BTreeMap::new(),
     };
-    writer.create_directories(args.gitkeep)?;
     writer.write_project_file(assembly)?;
     for schema in &assembly.schemas {
         writer.save(
@@ -76,6 +79,27 @@ pub fn write(assembly: &Assembly, args: &cli::Pull) -> Result<(), String> {
             &Value::Array(entries),
         )?;
     }
+    Ok(writer.files)
+}
+
+/// Write the full rendered file set into a new project tree (bootstrap
+/// mode)
+pub fn write_bootstrap(
+    files: &BTreeMap<PathBuf, String>,
+    args: &cli::Pull,
+) -> Result<(), String> {
+    log::info!("Writing project to {}", args.destination.display());
+    create_directories(&args.destination, args.gitkeep)?;
+    for (relative, content) in files {
+        let path = args.destination.join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                format!("failed to create {}: {e}", parent.display())
+            })?;
+        }
+        std::fs::write(&path, content)
+            .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+    }
     if args.gitkeep {
         remove_unneeded_gitkeeps(&args.destination)?;
     }
@@ -86,28 +110,31 @@ pub fn write(assembly: &Assembly, args: &cli::Pull) -> Result<(), String> {
 }
 
 struct Writer {
-    root: PathBuf,
     ignore: BTreeSet<String>,
+    files: BTreeMap<PathBuf, String>,
+}
+
+fn create_directories(root: &Path, gitkeep: bool) -> Result<(), String> {
+    for dir in PROJECT_DIRS {
+        let path = root.join(dir);
+        std::fs::create_dir_all(&path).map_err(|e| {
+            format!("failed to create {}: {e}", path.display())
+        })?;
+        if gitkeep {
+            let path = path.join(".gitkeep");
+            std::fs::write(&path, "").map_err(|e| {
+                format!("failed to create {}: {e}", path.display())
+            })?;
+        }
+    }
+    Ok(())
 }
 
 impl Writer {
-    fn create_directories(&self, gitkeep: bool) -> Result<(), String> {
-        for dir in PROJECT_DIRS {
-            let path = self.root.join(dir);
-            std::fs::create_dir_all(&path).map_err(|e| {
-                format!("failed to create {}: {e}", path.display())
-            })?;
-            if gitkeep {
-                let path = path.join(".gitkeep");
-                std::fs::write(&path, "").map_err(|e| {
-                    format!("failed to create {}: {e}", path.display())
-                })?;
-            }
-        }
-        Ok(())
-    }
-
-    fn write_project_file(&self, assembly: &Assembly) -> Result<(), String> {
+    fn write_project_file(
+        &mut self,
+        assembly: &Assembly,
+    ) -> Result<(), String> {
         let mut project = Map::new();
         project.insert(
             String::from("name"),
@@ -140,7 +167,7 @@ impl Writer {
 
     /// Function files are named by function; overloads get a numeric
     /// suffix (generate_project.py _function_filename, simplified)
-    fn write_functions(&self, assembly: &Assembly) -> Result<(), String> {
+    fn write_functions(&mut self, assembly: &Assembly) -> Result<(), String> {
         let mut used: BTreeSet<(String, String)> = BTreeSet::new();
         for function in &assembly.functions {
             let mut filename = function.name.clone();
@@ -159,7 +186,7 @@ impl Writer {
     }
 
     /// Types are written as per-schema container files (types.yml)
-    fn write_types(&self, assembly: &Assembly) -> Result<(), String> {
+    fn write_types(&mut self, assembly: &Assembly) -> Result<(), String> {
         let mut schemas: Vec<&str> =
             assembly.types.iter().map(|t| t.schema.as_str()).collect();
         schemas.sort_unstable();
@@ -182,7 +209,7 @@ impl Writer {
     /// Classify accumulated role state into user and role files; a
     /// password or expiry makes a user (pg_dumpall does not
     /// distinguish groups)
-    fn write_roles(&self, assembly: &Assembly) -> Result<(), String> {
+    fn write_roles(&mut self, assembly: &Assembly) -> Result<(), String> {
         for (name, state) in &assembly.roles {
             if !state.settings.is_empty() {
                 // role.yml declares settings as an array of objects but
@@ -231,7 +258,7 @@ impl Writer {
     }
 
     fn save<T: serde::Serialize>(
-        &self,
+        &mut self,
         relative: PathBuf,
         value: &T,
     ) -> Result<(), String> {
@@ -240,7 +267,7 @@ impl Writer {
     }
 
     fn save_value(
-        &self,
+        &mut self,
         relative: PathBuf,
         value: &Value,
     ) -> Result<(), String> {
@@ -249,14 +276,8 @@ impl Writer {
             log::debug!("Skipping ignored file {key}");
             return Ok(());
         }
-        let path = self.root.join(&relative);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                format!("failed to create {}: {e}", parent.display())
-            })?;
-        }
-        std::fs::write(&path, yamlio::dump(value))
-            .map_err(|e| format!("failed to write {}: {e}", path.display()))
+        self.files.insert(relative, yamlio::dump(value));
+        Ok(())
     }
 }
 
@@ -294,7 +315,9 @@ fn nested(directory: &str, schema: &str, name: &str) -> PathBuf {
         .join(format!("{name}.yaml"))
 }
 
-fn read_ignore(path: Option<&Path>) -> Result<BTreeSet<String>, String> {
+pub(crate) fn read_ignore(
+    path: Option<&Path>,
+) -> Result<BTreeSet<String>, String> {
     let Some(path) = path else {
         return Ok(BTreeSet::new());
     };

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -28,6 +28,16 @@ fn add(
 
 /// A miniature of the fixtures database dump
 fn fixture_archive(path: &std::path::Path) {
+    build_archive(path, false);
+}
+
+/// The fixtures dump after a migration: a column added to users, the
+/// function body changed, and the view dropped
+fn mutated_archive(path: &std::path::Path) {
+    build_archive(path, true);
+}
+
+fn build_archive(path: &std::path::Path, mutated: bool) {
     let mut dump = libpgdump::new("fixtures", "UTF8", "18.0").unwrap();
     add(
         &mut dump,
@@ -74,18 +84,23 @@ fn fixture_archive(path: &std::path::Path) {
         "CREATE DOMAIN test.email_address AS public.citext CHECK (VALUE \
          ~ '@');",
     );
-    add(
-        &mut dump,
-        OT::Table,
-        "test",
-        "users",
+    let users = if mutated {
         "CREATE TABLE test.users (\n\
          id uuid DEFAULT public.uuid_generate_v4() NOT NULL,\n\
          state test.user_state DEFAULT 'unverified'::test.user_state \
          NOT NULL,\n\
          email public.citext NOT NULL,\n\
-         locale text DEFAULT 'en-US'::text NOT NULL\n);",
-    );
+         nickname text,\n\
+         locale text DEFAULT 'en-US'::text NOT NULL\n);"
+    } else {
+        "CREATE TABLE test.users (\n\
+         id uuid DEFAULT public.uuid_generate_v4() NOT NULL,\n\
+         state test.user_state DEFAULT 'unverified'::test.user_state \
+         NOT NULL,\n\
+         email public.citext NOT NULL,\n\
+         locale text DEFAULT 'en-US'::text NOT NULL\n);"
+    };
+    add(&mut dump, OT::Table, "test", "users", users);
     add(
         &mut dump,
         OT::Constraint,
@@ -124,40 +139,79 @@ fn fixture_archive(path: &std::path::Path) {
         "user_id_seq",
         "ALTER SEQUENCE test.user_id_seq OWNED BY test.users.id;",
     );
-    add(
-        &mut dump,
-        OT::View,
-        "test",
-        "us_users",
-        "CREATE VIEW test.us_users AS SELECT id, email FROM test.users \
-         WHERE (locale = 'en-US'::text);",
-    );
+    if !mutated {
+        add(
+            &mut dump,
+            OT::View,
+            "test",
+            "us_users",
+            "CREATE VIEW test.us_users AS SELECT id, email FROM \
+             test.users WHERE (locale = 'en-US'::text);",
+        );
+    }
+    let function = if mutated {
+        "CREATE FUNCTION test.set_last_modified() RETURNS trigger \
+         LANGUAGE plpgsql AS $$ BEGIN NEW.last_modified_at = \
+         clock_timestamp(); RETURN NEW; END; $$;"
+    } else {
+        "CREATE FUNCTION test.set_last_modified() RETURNS trigger \
+         LANGUAGE plpgsql AS $$ BEGIN NEW.last_modified_at = \
+         CURRENT_TIMESTAMP; RETURN NEW; END; $$;"
+    };
     add(
         &mut dump,
         OT::Function,
         "test",
         "set_last_modified()",
-        "CREATE FUNCTION test.set_last_modified() RETURNS trigger \
-         LANGUAGE plpgsql AS $$ BEGIN NEW.last_modified_at = \
-         CURRENT_TIMESTAMP; RETURN NEW; END; $$;",
+        function,
     );
     dump.save(path).expect("failed to save archive");
 }
 
 fn pull_args(archive: &std::path::Path, dest: &std::path::Path) -> cli::Pull {
-    let parsed = cli::Cli::try_parse_from([
-        "pglifecycle",
-        "pull",
-        "--dump",
-        archive.to_str().unwrap(),
-        "--gitkeep",
-        dest.to_str().unwrap(),
-    ])
-    .expect("failed to parse args");
+    pull_args_with(archive, dest, &["--gitkeep"])
+}
+
+fn pull_args_with(
+    archive: &std::path::Path,
+    dest: &std::path::Path,
+    extra: &[&str],
+) -> cli::Pull {
+    let mut argv =
+        vec!["pglifecycle", "pull", "--dump", archive.to_str().unwrap()];
+    argv.extend_from_slice(extra);
+    argv.push(dest.to_str().unwrap());
+    let parsed = cli::Cli::try_parse_from(argv).expect("failed to parse args");
     match parsed.action {
         cli::Action::Pull(args) => args,
         _ => unreachable!(),
     }
+}
+
+/// Relative path → (content, mtime) for every file under `root`
+fn snapshot(
+    root: &std::path::Path,
+) -> std::collections::BTreeMap<String, (String, std::time::SystemTime)> {
+    let mut files = std::collections::BTreeMap::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        for entry in std::fs::read_dir(&dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            let relative = path
+                .strip_prefix(root)
+                .unwrap()
+                .to_string_lossy()
+                .to_string();
+            let content = std::fs::read_to_string(&path).unwrap();
+            let mtime = path.metadata().unwrap().modified().unwrap();
+            files.insert(relative, (content, mtime));
+        }
+    }
+    files
 }
 
 #[test]
@@ -199,6 +253,99 @@ fn pulled_project_loads_and_validates() {
         "ROLE",
     ] {
         assert!(kinds.contains(&expected), "missing {expected}: {kinds:?}");
+    }
+}
+
+#[test]
+fn update_after_bootstrap_is_noop() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("fixtures.dump");
+    fixture_archive(&archive);
+    let dest = dir.path().join("project");
+    pull::pull(&pull_args(&archive, &dest)).expect("bootstrap failed");
+    let before = snapshot(&dest);
+
+    pull::pull(&pull_args_with(&archive, &dest, &["--update"]))
+        .expect("update failed");
+
+    let after = snapshot(&dest);
+    assert_eq!(
+        before, after,
+        "update from an identical dump must be a no-op"
+    );
+}
+
+#[test]
+fn update_rewrites_only_changed_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("fixtures.dump");
+    fixture_archive(&archive);
+    let mutated = dir.path().join("mutated.dump");
+    mutated_archive(&mutated);
+    let dest = dir.path().join("project");
+    pull::pull(&pull_args(&archive, &dest)).expect("bootstrap failed");
+    let before = snapshot(&dest);
+
+    pull::pull(&pull_args_with(&mutated, &dest, &["--update"]))
+        .expect("update failed");
+
+    let after = snapshot(&dest);
+    let changed: Vec<&String> = after
+        .iter()
+        .filter(|(path, state)| before.get(*path) != Some(state))
+        .map(|(path, _)| path)
+        .collect();
+    assert_eq!(
+        changed,
+        vec![
+            "functions/test/set_last_modified.yaml",
+            "tables/test/users.yaml"
+        ],
+        "only the mutated objects' files may change"
+    );
+    assert!(after["tables/test/users.yaml"].0.contains("nickname"));
+    assert!(
+        after["functions/test/set_last_modified.yaml"]
+            .0
+            .contains("clock_timestamp"),
+    );
+    // the dropped view's file is stale but preserved without --prune
+    assert!(dest.join("views/test/us_users.yaml").exists());
+
+    pull::pull(&pull_args_with(&mutated, &dest, &["--update", "--prune"]))
+        .expect("prune failed");
+    assert!(!dest.join("views/test/us_users.yaml").exists());
+    assert!(
+        !dest.join("views/test").exists(),
+        "emptied schema directory must be removed"
+    );
+    assert!(dest.join("views").exists(), "top-level layout is preserved");
+
+    let project = project::load(&dest).expect("updated project must load");
+    assert_eq!(project.name, "fixtures");
+}
+
+#[test]
+fn update_requires_existing_project() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("fixtures.dump");
+    fixture_archive(&archive);
+    let dest = dir.path().join("missing");
+    let error = pull::pull(&pull_args_with(&archive, &dest, &["--update"]))
+        .unwrap_err();
+    assert!(error.contains("project.yaml"), "unexpected error: {error}");
+}
+
+#[test]
+fn update_flag_conflicts() {
+    for argv in [
+        vec!["pglifecycle", "pull", "--update", "--force", "/tmp/x"],
+        vec!["pglifecycle", "pull", "--prune", "/tmp/x"],
+    ] {
+        assert!(
+            cli::Cli::try_parse_from(&argv).is_err(),
+            "expected {argv:?} to be rejected"
+        );
     }
 }
 

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -326,6 +326,47 @@ fn update_rewrites_only_changed_files() {
 }
 
 #[test]
+fn prune_removes_stale_remaining_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("fixtures.dump");
+    fixture_archive(&archive);
+    let dest = dir.path().join("project");
+    pull::pull(&pull_args(&archive, &dest)).expect("bootstrap failed");
+    std::fs::write(dest.join("remaining.yaml"), "[]\n").unwrap();
+
+    pull::pull(&pull_args_with(&archive, &dest, &["--update", "--prune"]))
+        .expect("prune failed");
+
+    assert!(
+        !dest.join("remaining.yaml").exists(),
+        "stale remaining.yaml must be pruned"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn prune_does_not_follow_symlinked_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("fixtures.dump");
+    fixture_archive(&archive);
+    let dest = dir.path().join("project");
+    pull::pull(&pull_args(&archive, &dest)).expect("bootstrap failed");
+    let outside = dir.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let outside_file = outside.join("other.yaml");
+    std::fs::write(&outside_file, "outside: true\n").unwrap();
+    std::os::unix::fs::symlink(&outside, dest.join("views/linked")).unwrap();
+
+    pull::pull(&pull_args_with(&archive, &dest, &["--update", "--prune"]))
+        .expect("prune failed");
+
+    assert!(
+        outside_file.exists(),
+        "files behind a symlinked directory must not be pruned"
+    );
+}
+
+#[test]
 fn update_requires_existing_project() {
     let dir = tempfile::tempdir().unwrap();
     let archive = dir.path().join("fixtures.dump");


### PR DESCRIPTION
## Summary
Add an update mode to `pull`: `--update` merges a fresh pull into an existing project, rewriting only files whose content changed, and `--prune` deletes files for objects that no longer exist in the database.

## Problem
`pull` could only bootstrap a new project (or clobber one with `--force`). Keeping a project in sync with an evolving database meant regenerating everything, losing the ability to see what actually changed. This is Phase 5 of the rewrite plan ("pull update mode"), whose gate is: re-pulling an unchanged database is a no-op, and after a database migration `git diff` shows exactly the migrated objects and nothing else.

## Solution
Render-then-compare instead of a model-level diff module: the existing dump→assembly→writer pipeline now renders each project file to an in-memory `path → YAML` map (`pull/writer.rs` refactor; bootstrap output is unchanged). In update mode (`pull/update.rs`), a file is written only when missing or its bytes differ. YAML files on disk under the directories pull manages (`tables/`, `views/`, `functions/`, …) that the render did not produce are reported as stale — warned by default, deleted with `--prune` (with emptied schema subdirectories cleaned up). `dml/` and other project content are never touched, and `--ignore` paths are neither rewritten nor pruned.

Because the writer's output is deterministic, byte comparison gives an exact no-op on an unchanged database without the diff-normalization risk a model-level comparison carries; the shared `diff` module remains a `deploy`-time concern.

## Impact
New opt-in flags only; bootstrap behavior is byte-identical. `--update` conflicts with `--force`, `--prune` requires `--update`. One caveat documented in `docs/commands.md`: overloaded function files are numbered in dump order, so adding/removing an overload can renumber a sibling's file.

## Testing
- New integration tests cover the Phase 5 gates: update from an identical dump changes no file contents or mtimes; a mutated dump (added column, changed function, dropped view) rewrites exactly those files; stale files survive without `--prune` and are removed with it; `--update` without an existing project errors; invalid flag combinations are rejected.
- `bin/round-trip` gained a `pull --update` no-op gate and passes end-to-end against the Docker PostgreSQL 17 container.
- `cargo test` (76 tests), `cargo fmt`, and `cargo clippy --all-targets -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--update` to incrementally sync a project (rewrites only files whose content changed); requires an existing project.
  * Added `--prune` to remove project files for database objects that no longer exist (only for managed directories; requires `--update`).

* **Documentation**
  * Documented `--update`/`--prune` semantics, ignore-path effects, and overload-file renumbering behavior.

* **Tests**
  * Added integration tests covering noop updates, selective rewrites, pruning behavior, and CLI flag validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->