### PR TITLE
Add the deploy command: diff a database against the project

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -31,6 +31,40 @@ topological sort.
 pglifecycle build PROJECT DEST
 ```
 
+## deploy
+
+Compare a live database (or an existing dump) against the project and
+emit the DDL needed to make the database match: `CREATE` for objects
+missing from the database, `DROP` for objects missing from the
+project, and a drop+recreate fallback for objects that exist in both
+but differ. The script goes to stdout (or `-o FILE`) with a summary on
+stderr; it is meant to be applied separately, for example as a CI
+step:
+
+```bash
+pglifecycle deploy -o deploy.sql PROJECT
+psql --single-transaction -v ON_ERROR_STOP=1 -f deploy.sql
+```
+
+| Option | Description |
+| --- | --- |
+| `-D, --dump FILE` | Compare against a `pg_dump -Fc` file instead of connecting |
+| `-o, --output FILE` | Write the DDL script to FILE instead of stdout |
+| `--allow-drop` | Include destructive statements in the script |
+| `-x, --no-privileges` | Do not include GRANT/REVOKE |
+
+The connection options match `pull` (see below).
+
+Destructive statements — `DROP` for database-only objects and the
+drop+recreate fallback for changed ones — are excluded from the script
+unless `--allow-drop` is given; each exclusion is reported on stderr
+and counted in the script header. Ownership is not managed (the script
+behaves like `pg_restore --no-owner`), and roles, users, groups, and
+tablespaces are skipped entirely: they are cluster-level objects a
+single-database dump cannot capture. Object types `pull` does not yet
+model (aggregates, casts, operators, …) are created when missing but
+otherwise only existence-checked and left untouched.
+
 ## pull
 
 Create a project from a live database or an existing dump. Entry DDL is

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,8 @@ pub enum Action {
     Build(Build),
     /// Create a skeleton project
     Create(Create),
+    /// Generate the DDL to make a database match the project
+    Deploy(Deploy),
     /// Create or update a project from a database or dump
     Pull(Pull),
 }
@@ -43,6 +45,7 @@ impl Action {
         match self {
             Action::Build(_) => "build",
             Action::Create(_) => "create",
+            Action::Deploy(_) => "deploy",
             Action::Pull(_) => "pull",
         }
     }
@@ -88,6 +91,39 @@ pub struct Create {
     /// The path to create the skeleton project in
     #[arg(value_name = "DEST")]
     pub destination: PathBuf,
+}
+
+#[derive(Args)]
+#[command(disable_help_flag = true)]
+pub struct Deploy {
+    /// Print help
+    #[arg(long, action = clap::ArgAction::Help)]
+    help: Option<bool>,
+
+    /// Compare against a pre-existing pg_dump file instead of
+    /// connecting to a database
+    #[arg(short = 'D', long)]
+    pub dump: Option<PathBuf>,
+
+    /// Write the DDL script to a file instead of STDOUT
+    #[arg(short = 'o', long)]
+    pub output: Option<PathBuf>,
+
+    /// Include destructive statements (DROP, drop+recreate fallbacks)
+    /// in the script
+    #[arg(long)]
+    pub allow_drop: bool,
+
+    /// do not include privileges (grant/revoke)
+    #[arg(short = 'x', long)]
+    pub no_privileges: bool,
+
+    #[command(flatten)]
+    pub connection: Connection,
+
+    /// The path to the pglifecycle project
+    #[arg(value_name = "PROJECT")]
+    pub project: PathBuf,
 }
 
 /// PostgreSQL connection options shared by commands that talk to a

--- a/src/deploy/diff.rs
+++ b/src/deploy/diff.rs
@@ -27,7 +27,7 @@ pub struct ObjectKey {
 impl ObjectKey {
     pub fn new(desc: ObjectType, definition: &Definition) -> Self {
         let name = match definition {
-            Definition::Function(f) => f.identity(),
+            Definition::Function(f) => function_key_name(f),
             _ => definition.name(),
         };
         // extension names are database-unique; their schema field is
@@ -38,6 +38,30 @@ impl ObjectKey {
         };
         Self { desc, schema, name }
     }
+}
+
+/// The function identity signature with canonicalized parameter
+/// types, so a repo `fn(int4)` keys identically to the server's
+/// `fn(integer)` (mirrors [`crate::models::Function::identity`])
+fn function_key_name(function: &crate::models::Function) -> String {
+    let args: Vec<String> = function
+        .parameters
+        .iter()
+        .flatten()
+        .filter(|p| p.mode != "OUT" && p.mode != "TABLE")
+        .map(|p| {
+            let mut parts: Vec<String> = Vec::new();
+            if p.mode != "IN" {
+                parts.push(p.mode.clone());
+            }
+            if let Some(name) = &p.name {
+                parts.push(name.clone());
+            }
+            parts.push(canonical_type(&p.data_type));
+            parts.join(" ")
+        })
+        .collect();
+    format!("{}({})", function.name, args.join(", "))
 }
 
 impl std::fmt::Display for ObjectKey {
@@ -248,11 +272,17 @@ fn normalize(value: &mut Value) {
 
 /// Canonicalize common type-name aliases the way PostgreSQL does on
 /// ingest, so a hand-edited `int4` does not falsely diff against the
-/// server's `integer` (PLAN.md risk #5)
+/// server's `integer` (PLAN.md risk #5). A length/precision modifier
+/// (`varchar(255)`, `numeric(10,2)`) and an array suffix are split
+/// off the base name so the alias can be matched and reattached.
 fn canonical_type(data_type: &str) -> String {
-    let (name, array) = match data_type.strip_suffix("[]") {
-        Some(name) => (name, "[]"),
-        None => (data_type, ""),
+    let (body, array) = match data_type.trim_end().strip_suffix("[]") {
+        Some(body) => (body.trim_end(), "[]"),
+        None => (data_type.trim_end(), ""),
+    };
+    let (name, modifier) = match body.find('(') {
+        Some(index) => (body[..index].trim_end(), &body[index..]),
+        None => (body, ""),
     };
     let canonical = match name {
         "bool" => "boolean",
@@ -268,7 +298,7 @@ fn canonical_type(data_type: &str) -> String {
         "varchar" => "character varying",
         other => other,
     };
-    format!("{canonical}{array}")
+    format!("{canonical}{modifier}{array}")
 }
 
 #[cfg(test)]
@@ -336,5 +366,52 @@ mod tests {
             name: String::from("test"),
         };
         assert_eq!(key.to_string(), "SCHEMA test");
+    }
+
+    #[test]
+    fn existence_key_strips_signature() {
+        // unmodeled-type overloads conflate to one existence key: an
+        // aggregate present in both sides under any overload reads as
+        // "exists" regardless of argument types (documented limit —
+        // these types are existence-checked, not diffed)
+        assert_eq!(
+            existence_key("AGGREGATE", "test", "sum(integer)"),
+            existence_key("AGGREGATE", "test", "sum(numeric)")
+        );
+        assert_ne!(
+            existence_key("AGGREGATE", "test", "sum(integer)"),
+            existence_key("AGGREGATE", "test", "max(integer)")
+        );
+    }
+
+    #[test]
+    fn function_key_canonicalizes_parameter_types() {
+        let repo: crate::models::Function =
+            serde_json::from_value(serde_json::json!({
+                "name": "f",
+                "schema": "test",
+                "owner": "postgres",
+                "returns": "integer",
+                "language": "sql",
+                "parameters": [{"mode": "IN", "data_type": "int4"}],
+            }))
+            .unwrap();
+        let server: crate::models::Function =
+            serde_json::from_value(serde_json::json!({
+                "name": "f",
+                "schema": "test",
+                "owner": "postgres",
+                "returns": "integer",
+                "language": "sql",
+                "parameters": [{"mode": "IN", "data_type": "integer"}],
+            }))
+            .unwrap();
+        assert_eq!(
+            ObjectKey::new(ObjectType::Function, &Definition::Function(repo)),
+            ObjectKey::new(
+                ObjectType::Function,
+                &Definition::Function(server)
+            )
+        );
     }
 }

--- a/src/deploy/diff.rs
+++ b/src/deploy/diff.rs
@@ -1,0 +1,340 @@
+//! Model-level comparison between a loaded project and a database
+//! snapshot. Both sides hold the same `models::` structs (the project
+//! via [`crate::project::load`], the database via
+//! [`crate::pull::Assembly`]), so definitions compare as normalized
+//! JSON values.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::Value;
+
+use crate::constants::ObjectType;
+use crate::models::Definition;
+use crate::project::Project;
+use crate::pull::Assembly;
+
+/// Identity of a database object on either side of the diff
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ObjectKey {
+    pub desc: ObjectType,
+    /// Empty for schemaless object types
+    pub schema: String,
+    /// Functions use the identity signature (`name(args)`), since the
+    /// bare name is ambiguous across overloads
+    pub name: String,
+}
+
+impl ObjectKey {
+    pub fn new(desc: ObjectType, definition: &Definition) -> Self {
+        let name = match definition {
+            Definition::Function(f) => f.identity(),
+            _ => definition.name(),
+        };
+        // extension names are database-unique; their schema field is
+        // the installation target, not part of their identity
+        let schema = match definition {
+            Definition::Extension(_) => String::new(),
+            _ => definition.schema().unwrap_or_default().to_string(),
+        };
+        Self { desc, schema, name }
+    }
+}
+
+impl std::fmt::Display for ObjectKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.schema.is_empty() {
+            write!(f, "{} {}", self.desc.as_str(), self.name)
+        } else {
+            write!(f, "{} {}.{}", self.desc.as_str(), self.schema, self.name)
+        }
+    }
+}
+
+/// How a repo inventory item relates to the database
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Change {
+    /// In the repo but not the database → CREATE
+    Added,
+    /// In both and identical → nothing to do
+    Unchanged,
+    /// In both but different → ALTER, or the gated drop+recreate
+    /// fallback
+    Changed,
+    /// Exists on both sides but the type is not yet model-diffable
+    Undiffable,
+    /// Out of deploy's scope (roles, users, groups, tablespaces)
+    Skipped,
+}
+
+/// The classification of every repo inventory item plus the
+/// database-only objects
+pub struct Diff {
+    /// Inventory item id → change classification
+    pub items: BTreeMap<usize, Change>,
+    /// Objects in the database with no repo counterpart → DROP
+    pub removed: Vec<ObjectKey>,
+}
+
+/// Object types deploy does not manage: roles, users, and groups
+/// require cluster-level access pg_dump does not capture, and
+/// tablespaces are likewise absent from a single-database dump —
+/// diffing them would re-create them on every run
+const SKIPPED: &[ObjectType] = &[
+    ObjectType::Group,
+    ObjectType::Role,
+    ObjectType::Tablespace,
+    ObjectType::User,
+];
+
+pub fn diff(project: &Project, assembly: &Assembly) -> Diff {
+    let mut database = database_index(assembly);
+    let existing = existence_index(assembly);
+    let mut items = BTreeMap::new();
+    for item in &project.inventory {
+        let change = if SKIPPED.contains(&item.desc) {
+            log::debug!(
+                "Skipping {} {}: not managed by deploy",
+                item.desc.as_str(),
+                item.definition.name()
+            );
+            Change::Skipped
+        } else if modeled(item.desc) {
+            let key = ObjectKey::new(item.desc, &item.definition);
+            match database.remove(&key) {
+                None => Change::Added,
+                Some(db) => {
+                    if normalized(&item.definition) == normalized(&db) {
+                        Change::Unchanged
+                    } else {
+                        Change::Changed
+                    }
+                }
+            }
+        } else if existing.contains(&existence_key(
+            item.desc.as_str(),
+            item.definition.schema().unwrap_or_default(),
+            &item.definition.name(),
+        )) {
+            Change::Undiffable
+        } else {
+            Change::Added
+        };
+        items.insert(item.id, change);
+    }
+    let removed = database.into_keys().collect();
+    Diff { items, removed }
+}
+
+/// Object types the [`Assembly`] parses into models; everything else
+/// lands in `Assembly::remaining` and can only be existence-checked
+fn modeled(desc: ObjectType) -> bool {
+    matches!(
+        desc,
+        ObjectType::Domain
+            | ObjectType::Extension
+            | ObjectType::Function
+            | ObjectType::MaterializedView
+            | ObjectType::ProceduralLanguage
+            | ObjectType::Schema
+            | ObjectType::Sequence
+            | ObjectType::Table
+            | ObjectType::Type
+            | ObjectType::View
+    )
+}
+
+/// `ObjectKey → Definition` for every object the snapshot modeled
+fn database_index(assembly: &Assembly) -> BTreeMap<ObjectKey, Definition> {
+    let mut index = BTreeMap::new();
+    let mut insert = |desc: ObjectType, definition: Definition| {
+        index.insert(ObjectKey::new(desc, &definition), definition);
+    };
+    for d in &assembly.schemas {
+        insert(ObjectType::Schema, Definition::Schema(d.clone()));
+    }
+    for d in &assembly.extensions {
+        insert(ObjectType::Extension, Definition::Extension(d.clone()));
+    }
+    for d in &assembly.languages {
+        insert(
+            ObjectType::ProceduralLanguage,
+            Definition::Language(d.clone()),
+        );
+    }
+    for d in &assembly.domains {
+        insert(ObjectType::Domain, Definition::Domain(d.clone()));
+    }
+    for d in &assembly.types {
+        insert(ObjectType::Type, Definition::Type(d.clone()));
+    }
+    for d in &assembly.sequences {
+        insert(ObjectType::Sequence, Definition::Sequence(d.clone()));
+    }
+    for d in &assembly.tables {
+        insert(ObjectType::Table, Definition::Table(d.clone()));
+    }
+    for d in &assembly.views {
+        insert(ObjectType::View, Definition::View(d.clone()));
+    }
+    for d in &assembly.materialized_views {
+        insert(
+            ObjectType::MaterializedView,
+            Definition::MaterializedView(d.clone()),
+        );
+    }
+    for d in &assembly.functions {
+        insert(ObjectType::Function, Definition::Function(d.clone()));
+    }
+    index
+}
+
+/// Existence-only index over the snapshot entries that were not
+/// parsed into models (`Assembly::remaining`)
+fn existence_index(assembly: &Assembly) -> BTreeSet<(String, String, String)> {
+    assembly
+        .remaining
+        .iter()
+        .filter_map(|r| {
+            let tag = r.tag.as_deref()?;
+            Some(existence_key(
+                &r.desc,
+                r.namespace.as_deref().unwrap_or_default(),
+                tag,
+            ))
+        })
+        .collect()
+}
+
+/// Match key for existence-only comparison; argument lists are
+/// stripped because pg_dump's signature formatting and the build's
+/// may differ (overloads of unmodeled types therefore conflate)
+fn existence_key(
+    desc: &str,
+    namespace: &str,
+    tag: &str,
+) -> (String, String, String) {
+    let name = tag.split('(').next().unwrap_or(tag).trim_end();
+    (desc.to_string(), namespace.to_string(), name.to_string())
+}
+
+/// A definition as a JSON value with the fields deploy does not
+/// manage removed and type aliases canonicalized
+fn normalized(definition: &Definition) -> Value {
+    let mut value = serde_json::to_value(definition).unwrap_or(Value::Null);
+    normalize(&mut value);
+    value
+}
+
+fn normalize(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            // ownership is out of deploy's scope (a flat SQL script
+            // cannot apply pg_restore-style ownership anyway)
+            map.remove("owner");
+            for (key, child) in map.iter_mut() {
+                if key == "data_type"
+                    && let Some(data_type) = child.as_str()
+                {
+                    *child = Value::String(canonical_type(data_type));
+                } else {
+                    normalize(child);
+                }
+            }
+        }
+        Value::Array(items) => items.iter_mut().for_each(normalize),
+        _ => {}
+    }
+}
+
+/// Canonicalize common type-name aliases the way PostgreSQL does on
+/// ingest, so a hand-edited `int4` does not falsely diff against the
+/// server's `integer` (PLAN.md risk #5)
+fn canonical_type(data_type: &str) -> String {
+    let (name, array) = match data_type.strip_suffix("[]") {
+        Some(name) => (name, "[]"),
+        None => (data_type, ""),
+    };
+    let canonical = match name {
+        "bool" => "boolean",
+        "char" => "character",
+        "decimal" => "numeric",
+        "float4" => "real",
+        "float8" => "double precision",
+        "int2" => "smallint",
+        "int4" | "int" => "integer",
+        "int8" => "bigint",
+        "timestamptz" => "timestamp with time zone",
+        "timetz" => "time with time zone",
+        "varchar" => "character varying",
+        other => other,
+    };
+    format!("{canonical}{array}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models;
+
+    fn table(name: &str, comment: Option<&str>) -> models::Table {
+        let mut value = serde_json::json!({
+            "name": name,
+            "schema": "test",
+            "owner": "postgres",
+        });
+        if let Some(comment) = comment {
+            value["comment"] = comment.into();
+        }
+        serde_json::from_value(value).expect("table deserializes")
+    }
+
+    #[test]
+    fn canonicalizes_type_aliases() {
+        assert_eq!(canonical_type("int4"), "integer");
+        assert_eq!(canonical_type("varchar"), "character varying");
+        assert_eq!(
+            canonical_type("timestamptz[]"),
+            "timestamp with time \
+            zone[]"
+        );
+        assert_eq!(canonical_type("uuid"), "uuid");
+    }
+
+    #[test]
+    fn owner_differences_are_ignored() {
+        let mut a = table("users", None);
+        let mut b = table("users", None);
+        a.owner = String::from("postgres");
+        b.owner = String::from("app");
+        assert_eq!(
+            normalized(&Definition::Table(a)),
+            normalized(&Definition::Table(b))
+        );
+    }
+
+    #[test]
+    fn comment_differences_are_changes() {
+        let a = table("users", Some("Users"));
+        let b = table("users", Some("User records"));
+        assert_ne!(
+            normalized(&Definition::Table(a)),
+            normalized(&Definition::Table(b))
+        );
+    }
+
+    #[test]
+    fn object_key_display() {
+        let key = ObjectKey {
+            desc: ObjectType::Table,
+            schema: String::from("test"),
+            name: String::from("users"),
+        };
+        assert_eq!(key.to_string(), "TABLE test.users");
+        let key = ObjectKey {
+            desc: ObjectType::Schema,
+            schema: String::new(),
+            name: String::from("test"),
+        };
+        assert_eq!(key.to_string(), "SCHEMA test");
+    }
+}

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -1,0 +1,291 @@
+//! The `deploy` command: compare the repo project against a live
+//! database (or an existing dump) and emit the DDL needed to make the
+//! database match the project (PLAN.md Phase 6).
+//!
+//! Output first: the script goes to stdout or `--output` and is meant
+//! to be applied separately (e.g. `psql --single-transaction
+//! -v ON_ERROR_STOP=1 -f deploy.sql` in a CI step). Destructive
+//! statements — DROPs for objects missing from the repo and the
+//! drop+recreate fallback for in-place changes deploy cannot yet
+//! express — are excluded unless `--allow-drop` is given.
+
+mod diff;
+
+use std::io::IsTerminal;
+
+use crate::deploy::diff::{Change, Diff, ObjectKey};
+use crate::utils::quote_ident;
+use crate::{build, cli, constants, pgdump, project, pull};
+
+pub fn deploy(args: &cli::Deploy) -> Result<(), String> {
+    if args.connection.password && !std::io::stdin().is_terminal() {
+        return Err(String::from(
+            "--password requires an interactive terminal; set PGPASSWORD \
+             or use a pgpass file instead",
+        ));
+    }
+    let project = project::load(&args.project)?;
+    let source = source_label(args);
+    log::info!("Comparing {} against {source}", project.name);
+    let ddl = pgdump::DumpDdl {
+        no_privileges: args.no_privileges,
+        ..Default::default()
+    };
+    let (assembly, snapshot) =
+        pull::snapshot(args.dump.as_deref(), &args.connection, &ddl, false)?;
+    let diff = diff::diff(&project, &assembly);
+    let mut output = build::assemble(&project)?;
+    output.dump.sort_entries();
+    let plan = plan(&diff, &output, &snapshot, args)?;
+    report(&diff, &plan);
+    write_script(&plan, &project.name, &source, args)
+}
+
+/// One statement in the deploy plan
+struct Statement {
+    label: String,
+    sql: String,
+}
+
+/// The ordered script plus the destructive statements excluded from
+/// it when `--allow-drop` is not given
+struct Plan {
+    included: Vec<Statement>,
+    excluded: Vec<Statement>,
+}
+
+/// Assemble the ordered plan: DROPs for database-only objects first
+/// (reverse snapshot order), then the repo archive's entries in
+/// topological order — plain CREATEs for added objects, gated
+/// drop+recreate for changed ones
+fn plan(
+    diff: &Diff,
+    output: &build::BuildOutput,
+    snapshot: &libpgdump::Dump,
+    args: &cli::Deploy,
+) -> Result<Plan, String> {
+    let mut included = Vec::new();
+    let mut excluded = Vec::new();
+    let mut push = |destructive: bool, statement: Statement| {
+        if destructive && !args.allow_drop {
+            excluded.push(statement);
+        } else {
+            included.push(statement);
+        }
+    };
+    // pg_dump archives are stored in dependency order, so dropping in
+    // reverse entry order removes dependents before dependencies
+    let removed: Vec<&ObjectKey> = snapshot
+        .entries()
+        .iter()
+        .rev()
+        .filter_map(entry_key)
+        .filter_map(|key| diff.removed.iter().find(|r| **r == key))
+        .collect();
+    for key in &removed {
+        push(
+            true,
+            Statement {
+                label: key.to_string(),
+                sql: drop_sql(key),
+            },
+        );
+    }
+    // database-only objects whose snapshot entry could not be keyed
+    // (should not happen for modeled types) still need dropping;
+    // append them after the ordered ones
+    for key in &diff.removed {
+        if !removed.contains(&key) {
+            push(
+                true,
+                Statement {
+                    label: key.to_string(),
+                    sql: drop_sql(key),
+                },
+            );
+        }
+    }
+    for entry in output.dump.entries() {
+        if args.no_privileges && entry.desc == libpgdump::ObjectType::Acl {
+            continue;
+        }
+        let direct = output.item_ids.get(&entry.dump_id);
+        let owners: Vec<usize> = match direct {
+            Some(id) => vec![*id],
+            None => entry
+                .dependencies
+                .iter()
+                .filter_map(|dep| output.item_ids.get(dep).copied())
+                .collect(),
+        };
+        if owners.is_empty() {
+            continue;
+        }
+        let changes: Vec<Change> = owners
+            .iter()
+            .filter_map(|id| diff.items.get(id).copied())
+            .collect();
+        let label = entry_label(entry);
+        let Some(defn) = entry.defn.clone() else {
+            continue;
+        };
+        if changes.iter().all(|c| *c == Change::Added) {
+            push(false, Statement { label, sql: defn });
+        } else if changes.contains(&Change::Changed)
+            && changes
+                .iter()
+                .all(|c| matches!(c, Change::Added | Change::Changed))
+        {
+            // drop+recreate fallback: the object's own entry leads
+            // with its DROP; child entries (indexes, triggers,
+            // comments, ACLs) are recreated alongside it
+            let mut sql = String::new();
+            if direct.is_some()
+                && let Some(drop) = &entry.drop_stmt
+            {
+                sql.push_str(drop);
+            }
+            sql.push_str(&defn);
+            push(true, Statement { label, sql });
+        }
+    }
+    Ok(Plan { included, excluded })
+}
+
+/// Log what the plan skipped or excluded so the script is honest
+/// about what it does not cover
+fn report(diff: &Diff, plan: &Plan) {
+    let undiffable = diff
+        .items
+        .values()
+        .filter(|c| **c == Change::Undiffable)
+        .count();
+    if undiffable > 0 {
+        log::warn!(
+            "{undiffable} object(s) exist in both the project and the \
+             database but their types cannot be compared yet; they were \
+             left untouched"
+        );
+    }
+    for statement in &plan.excluded {
+        log::warn!(
+            "{}: change requires a destructive statement; re-run with \
+             --allow-drop to include it",
+            statement.label
+        );
+    }
+    log::info!(
+        "Plan: {} statement(s) included, {} excluded",
+        plan.included.len(),
+        plan.excluded.len()
+    );
+}
+
+/// Write the script to `--output` or stdout with a self-describing
+/// header
+fn write_script(
+    plan: &Plan,
+    project: &str,
+    source: &str,
+    args: &cli::Deploy,
+) -> Result<(), String> {
+    let mut script = format!(
+        "-- pglifecycle deploy\n-- project: {project}\n-- source: \
+         {source}\n"
+    );
+    if plan.excluded.is_empty() {
+        script.push_str("-- destructive statements: included\n");
+    } else {
+        script.push_str(&format!(
+            "-- destructive statements: {} excluded (re-run with \
+             --allow-drop)\n",
+            plan.excluded.len()
+        ));
+    }
+    if plan.included.is_empty() {
+        script.push_str("-- no changes: the database matches the project\n");
+    }
+    for statement in &plan.included {
+        script
+            .push_str(&format!("\n-- {}\n{}", statement.label, statement.sql));
+    }
+    match &args.output {
+        Some(path) => std::fs::write(path, script)
+            .map_err(|e| format!("failed to write {}: {e}", path.display())),
+        None => {
+            print!("{script}");
+            Ok(())
+        }
+    }
+}
+
+/// `DROP <type> IF EXISTS <name>` for a database-only object
+fn drop_sql(key: &ObjectKey) -> String {
+    // function keys are identity signatures and must not be quoted
+    // wholesale; everything else gets identifier quoting
+    let name = match key.desc {
+        constants::ObjectType::Function => key.name.clone(),
+        _ => quote_ident(&key.name),
+    };
+    let qualified = if key.schema.is_empty() {
+        name
+    } else {
+        format!("{}.{name}", quote_ident(&key.schema))
+    };
+    format!("DROP {} IF EXISTS {qualified};\n", key.desc.as_str())
+}
+
+/// Map a snapshot entry to the diff key space (modeled types only);
+/// the schema component mirrors [`ObjectKey::new`] — empty for
+/// schemaless types and extensions
+fn entry_key(entry: &libpgdump::Entry) -> Option<ObjectKey> {
+    use libpgdump::ObjectType as OT;
+    let desc = match entry.desc {
+        OT::Domain => constants::ObjectType::Domain,
+        OT::Extension => constants::ObjectType::Extension,
+        OT::Function => constants::ObjectType::Function,
+        OT::MaterializedView => constants::ObjectType::MaterializedView,
+        OT::ProceduralLanguage => constants::ObjectType::ProceduralLanguage,
+        OT::Schema => constants::ObjectType::Schema,
+        OT::Sequence => constants::ObjectType::Sequence,
+        OT::Table => constants::ObjectType::Table,
+        OT::Type => constants::ObjectType::Type,
+        OT::View => constants::ObjectType::View,
+        _ => return None,
+    };
+    let schema = match desc {
+        constants::ObjectType::Extension
+        | constants::ObjectType::ProceduralLanguage
+        | constants::ObjectType::Schema => String::new(),
+        _ => entry.namespace.clone().unwrap_or_default(),
+    };
+    Some(ObjectKey {
+        desc,
+        schema,
+        name: entry.tag.clone()?,
+    })
+}
+
+/// `DESC namespace.tag` for plan labels
+fn entry_label(entry: &libpgdump::Entry) -> String {
+    let tag = entry.tag.as_deref().unwrap_or_default();
+    match entry.namespace.as_deref() {
+        Some(namespace) if !namespace.is_empty() => {
+            format!("{} {namespace}.{tag}", entry.desc.as_str())
+        }
+        _ => format!("{} {tag}", entry.desc.as_str()),
+    }
+}
+
+/// Human-readable comparison source for the header and logs
+fn source_label(args: &cli::Deploy) -> String {
+    match &args.dump {
+        Some(path) => format!("dump {}", path.display()),
+        None => format!(
+            "{}:{}/{}",
+            args.connection.host,
+            args.connection.port,
+            args.connection.dbname.as_deref().unwrap_or_default()
+        ),
+    }
+}

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -52,6 +52,9 @@ struct Statement {
 struct Plan {
     included: Vec<Statement>,
     excluded: Vec<Statement>,
+    /// How many of `included` are destructive (non-zero only with
+    /// `--allow-drop`)
+    included_destructive: usize,
 }
 
 /// Assemble the ordered plan: DROPs for database-only objects first
@@ -66,36 +69,46 @@ fn plan(
 ) -> Result<Plan, String> {
     let mut included = Vec::new();
     let mut excluded = Vec::new();
+    let mut included_destructive = 0usize;
     let mut push = |destructive: bool, statement: Statement| {
         if destructive && !args.allow_drop {
             excluded.push(statement);
         } else {
+            if destructive {
+                included_destructive += 1;
+            }
             included.push(statement);
         }
     };
     // pg_dump archives are stored in dependency order, so dropping in
     // reverse entry order removes dependents before dependencies
-    let removed: Vec<&ObjectKey> = snapshot
+    let wanted: std::collections::BTreeSet<&ObjectKey> =
+        diff.removed.iter().collect();
+    let mut emitted: std::collections::BTreeSet<&ObjectKey> =
+        std::collections::BTreeSet::new();
+    let ordered: Vec<&ObjectKey> = snapshot
         .entries()
         .iter()
         .rev()
         .filter_map(entry_key)
-        .filter_map(|key| diff.removed.iter().find(|r| **r == key))
+        .filter_map(|key| wanted.get(&key).copied())
         .collect();
-    for key in &removed {
-        push(
-            true,
-            Statement {
-                label: key.to_string(),
-                sql: drop_sql(key),
-            },
-        );
+    for key in ordered {
+        if emitted.insert(key) {
+            push(
+                true,
+                Statement {
+                    label: key.to_string(),
+                    sql: drop_sql(key),
+                },
+            );
+        }
     }
     // database-only objects whose snapshot entry could not be keyed
     // (should not happen for modeled types) still need dropping;
     // append them after the ordered ones
     for key in &diff.removed {
-        if !removed.contains(&key) {
+        if !emitted.contains(key) {
             push(
                 true,
                 Statement {
@@ -149,7 +162,11 @@ fn plan(
             push(true, Statement { label, sql });
         }
     }
-    Ok(Plan { included, excluded })
+    Ok(Plan {
+        included,
+        excluded,
+        included_destructive,
+    })
 }
 
 /// Log what the plan skipped or excluded so the script is honest
@@ -193,14 +210,19 @@ fn write_script(
         "-- pglifecycle deploy\n-- project: {project}\n-- source: \
          {source}\n"
     );
-    if plan.excluded.is_empty() {
-        script.push_str("-- destructive statements: included\n");
-    } else {
+    if !plan.excluded.is_empty() {
         script.push_str(&format!(
             "-- destructive statements: {} excluded (re-run with \
              --allow-drop)\n",
             plan.excluded.len()
         ));
+    } else if plan.included_destructive > 0 {
+        script.push_str(&format!(
+            "-- destructive statements: {} included\n",
+            plan.included_destructive
+        ));
+    } else {
+        script.push_str("-- destructive statements: none\n");
     }
     if plan.included.is_empty() {
         script.push_str("-- no changes: the database matches the project\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod build;
 pub mod cli;
 pub mod constants;
 pub mod ddl;
+pub mod deploy;
 pub mod models;
 pub mod pgdump;
 pub mod project;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use pglifecycle::{build, cli, project, pull, skeleton};
+use pglifecycle::{build, cli, deploy, project, pull, skeleton};
 
 fn main() -> ExitCode {
     let args = cli::Cli::parse();
@@ -17,6 +17,7 @@ fn main() -> ExitCode {
         cli::Action::Build(args) => project::load(&args.project)
             .and_then(|p| build::build(&p, &args.destination)),
         cli::Action::Create(create) => skeleton::create(create),
+        cli::Action::Deploy(args) => deploy::deploy(args),
         cli::Action::Pull(args) => pull::pull(args),
     };
     match result {
@@ -51,10 +52,12 @@ fn configure_logging(args: &cli::Cli) {
             eprintln!("warning: failed to create log file {}", path.display());
         }
     }
+    // log to stderr so command output (e.g. the deploy script on
+    // stdout) stays clean
     if let Err(err) = simplelog::TermLogger::init(
         level,
         simplelog::Config::default(),
-        simplelog::TerminalMode::Stdout,
+        simplelog::TerminalMode::Stderr,
         simplelog::ColorChoice::Auto,
     ) {
         eprintln!("warning: failed to initialize terminal logging: {err}");

--- a/tests/deploy.rs
+++ b/tests/deploy.rs
@@ -1,0 +1,206 @@
+//! `deploy` integration: projects pulled from synthesized archives are
+//! compared against other archives offline via `--dump`; the emitted
+//! script must contain exactly the expected CREATE/DROP statements and
+//! honor the `--allow-drop` gate
+
+mod common;
+
+use clap::Parser;
+use common::{fixture_archive, mutated_archive};
+use pglifecycle::{cli, deploy, pull};
+
+fn pull_project(archive: &std::path::Path, dest: &std::path::Path) {
+    let argv = vec![
+        "pglifecycle",
+        "pull",
+        "--dump",
+        archive.to_str().unwrap(),
+        dest.to_str().unwrap(),
+    ];
+    let parsed = cli::Cli::try_parse_from(argv).expect("failed to parse args");
+    let cli::Action::Pull(args) = parsed.action else {
+        unreachable!()
+    };
+    pull::pull(&args).expect("pull failed");
+}
+
+/// Run deploy against `archive` and return the script written via -o
+fn deploy_script(
+    project: &std::path::Path,
+    archive: &std::path::Path,
+    extra: &[&str],
+) -> String {
+    let output = project.with_extension("sql");
+    let mut argv = vec![
+        "pglifecycle",
+        "deploy",
+        "--dump",
+        archive.to_str().unwrap(),
+        "-o",
+        output.to_str().unwrap(),
+    ];
+    argv.extend_from_slice(extra);
+    argv.push(project.to_str().unwrap());
+    let parsed = cli::Cli::try_parse_from(argv).expect("failed to parse args");
+    let cli::Action::Deploy(args) = parsed.action else {
+        unreachable!()
+    };
+    deploy::deploy(&args).expect("deploy failed");
+    std::fs::read_to_string(&output).expect("script must exist")
+}
+
+#[test]
+fn matching_database_is_an_empty_plan() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("fixtures.dump");
+    fixture_archive(&archive);
+    let project = dir.path().join("project");
+    pull_project(&archive, &project);
+
+    let script = deploy_script(&project, &archive, &[]);
+
+    assert!(
+        script.contains("-- no changes"),
+        "expected an empty plan, got:\n{script}"
+    );
+    for verb in ["CREATE", "DROP", "ALTER"] {
+        assert!(
+            !script.contains(&format!("\n{verb} ")),
+            "unexpected {verb} statement in:\n{script}"
+        );
+    }
+}
+
+#[test]
+fn missing_objects_are_created() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("fixtures.dump");
+    fixture_archive(&baseline);
+    let mutated = dir.path().join("mutated.dump");
+    mutated_archive(&mutated);
+    // the project has the view; the "database" (mutated) does not
+    let project = dir.path().join("project");
+    pull_project(&baseline, &project);
+
+    let script = deploy_script(&project, &mutated, &[]);
+
+    assert!(
+        script.contains("CREATE VIEW test.us_users"),
+        "missing view CREATE in:\n{script}"
+    );
+    // the users table and function differ (nickname column, function
+    // body): in-place ALTER is not supported yet, so without
+    // --allow-drop nothing destructive may appear
+    assert!(!script.contains("DROP TABLE"), "gated drop in:\n{script}");
+    assert!(
+        !script.contains("CREATE TABLE"),
+        "drop+recreate must be gated:\n{script}"
+    );
+    assert!(script.contains("excluded"), "header must note exclusions");
+}
+
+#[test]
+fn changed_objects_replace_with_allow_drop() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("fixtures.dump");
+    fixture_archive(&baseline);
+    let mutated = dir.path().join("mutated.dump");
+    mutated_archive(&mutated);
+    let project = dir.path().join("project");
+    pull_project(&baseline, &project);
+
+    let script = deploy_script(&project, &mutated, &["--allow-drop"]);
+
+    // the changed table is dropped and recreated from the repo
+    assert!(
+        script.contains("DROP TABLE IF EXISTS test.users"),
+        "missing table drop in:\n{script}"
+    );
+    assert!(
+        script.contains("CREATE TABLE test.users"),
+        "missing table recreate in:\n{script}"
+    );
+    assert!(
+        !script.contains("nickname"),
+        "the repo (without nickname) is authoritative:\n{script}"
+    );
+    assert!(
+        script.contains("DROP FUNCTION IF EXISTS"),
+        "missing function replace in:\n{script}"
+    );
+    assert!(
+        script.contains("CURRENT_TIMESTAMP"),
+        "recreated function must use the repo body:\n{script}"
+    );
+    // the table's primary key, index, and comment ride along with the
+    // recreate
+    assert!(
+        script.contains("users_unique_email"),
+        "missing index recreate in:\n{script}"
+    );
+    assert!(
+        script.contains("COMMENT ON TABLE test.users"),
+        "missing comment recreate in:\n{script}"
+    );
+}
+
+#[test]
+fn database_only_objects_drop_with_allow_drop() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("fixtures.dump");
+    fixture_archive(&baseline);
+    let mutated = dir.path().join("mutated.dump");
+    mutated_archive(&mutated);
+    // the project (from mutated) has no view; the "database" does
+    let project = dir.path().join("project");
+    pull_project(&mutated, &project);
+
+    let gated = deploy_script(&project, &baseline, &[]);
+    assert!(
+        !gated.contains("DROP VIEW"),
+        "view drop must be gated:\n{gated}"
+    );
+    assert!(gated.contains("excluded"), "header must note exclusions");
+
+    let script = deploy_script(&project, &baseline, &["--allow-drop"]);
+    assert!(
+        script.contains("DROP VIEW IF EXISTS test.us_users"),
+        "missing view drop in:\n{script}"
+    );
+}
+
+#[test]
+fn script_header_is_self_describing() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("fixtures.dump");
+    fixture_archive(&archive);
+    let project = dir.path().join("project");
+    pull_project(&archive, &project);
+
+    let script = deploy_script(&project, &archive, &[]);
+
+    assert!(script.starts_with("-- pglifecycle deploy\n"));
+    assert!(script.contains("-- project: fixtures\n"));
+    assert!(script.contains("-- source: dump "));
+    assert!(script.contains("-- destructive statements: included\n"));
+}
+
+#[test]
+fn deploy_requires_a_project() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("fixtures.dump");
+    fixture_archive(&archive);
+    let project = dir.path().join("missing");
+    let argv = vec![
+        "pglifecycle",
+        "deploy",
+        "--dump",
+        archive.to_str().unwrap(),
+        project.to_str().unwrap(),
+    ];
+    let parsed = cli::Cli::try_parse_from(argv).expect("failed to parse args");
+    let cli::Action::Deploy(args) = parsed.action else {
+        unreachable!()
+    };
+    assert!(deploy::deploy(&args).is_err());
+}

--- a/tests/deploy.rs
+++ b/tests/deploy.rs
@@ -182,7 +182,7 @@ fn script_header_is_self_describing() {
     assert!(script.starts_with("-- pglifecycle deploy\n"));
     assert!(script.contains("-- project: fixtures\n"));
     assert!(script.contains("-- source: dump "));
-    assert!(script.contains("-- destructive statements: included\n"));
+    assert!(script.contains("-- destructive statements: none\n"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
First slice of PLAN.md Phase 6: `pglifecycle deploy` compares a live database (or a dump via `--dump`) against the repo project and emits the DDL needed to make the database match — CREATE for missing objects, DROP for database-only objects, and a gated drop+recreate fallback for changed ones.

**Stacked on #23** (the behavior-neutral refactors); only the last commit is new here.

## Problem
With `pull` covering database→repo, the repo→database direction needs a synchronizer: given a project, produce the alteration DDL to bring a database in line with it, safely (destructive statements gated) and CI-friendly (a script artifact applied in a separate step, e.g. `psql --single-transaction -v ON_ERROR_STOP=1 -f deploy.sql`).

## Solution
- **src/deploy/diff.rs** — model-level comparison. Both sides land in the same `models::` structs (`project::load` vs `pull::snapshot`), so definitions compare as normalized JSON: `owner` stripped (ownership is out of scope for a flat script), common type aliases canonicalized (`int4` → `integer`, …). Functions key on their identity signature so overloads diff correctly. Roles/users/groups/tablespaces are skipped — they are cluster-level and absent from a single-database dump, so diffing them would re-create them every run. Types `pull` does not yet model are existence-checked only.
- **src/deploy/mod.rs** — plan assembly. DROPs for database-only objects come first in reverse snapshot entry order (pg_dump archives are stored topologically sorted); then `build::assemble`'s sorted entries are walked: plain CREATE for added objects with their child indexes/triggers/comments/ACLs riding along at their topological positions, drop+recreate for changed objects. Destructive statements are excluded without `--allow-drop`, warned about on stderr, and counted in the script's self-describing header.
- Terminal logging moves from stdout to **stderr** so the script owns stdout (small user-visible change, called out here deliberately).
- In-place ALTER renderers (`ALTER TABLE ADD COLUMN`, `CREATE OR REPLACE`, …) land in follow-up PRs; until then any changed object takes the gated drop+recreate path, so the tool is honest about what it would do.

## Impact
New command; no changes to existing command behavior other than logging moving to stderr. `--apply` (optional direct execution) and the Phase 6 round-trip gates come in later PRs.

## Testing
88 tests pass (`cargo test`), including six new offline integration tests in tests/deploy.rs driven by synthesized archives. Clippy clean. Smoke-tested against real pg_dump output: a project pulled from a dump of fixtures/schema.sql deploys against the same dump as an empty plan, and a live mutation (added column) produces the expected gated drop+recreate with index and comment recreated alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)