### PR TITLE
Add in-place table ALTER renderers to deploy

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1061,35 +1061,7 @@ impl Builder {
                     inner.push(render_constraint("PRIMARY KEY", primary_key));
                 }
                 for fk in d.foreign_keys.as_deref().unwrap_or_default() {
-                    let mut fk_sql = vec![
-                        format!("FOREIGN KEY ({})", fk.columns.join(", ")),
-                        "REFERENCES".into(),
-                        fk.references.name.clone(),
-                        format!("({})", fk.references.columns.join(", ")),
-                    ];
-                    if let Some(match_type) = &fk.match_type {
-                        fk_sql.push("MATCH".into());
-                        fk_sql.push(match_type.clone());
-                    }
-                    if let Some(on_delete) = &fk.on_delete
-                        && on_delete != "NO ACTION"
-                    {
-                        fk_sql.push("ON DELETE".into());
-                        fk_sql.push(on_delete.clone());
-                    }
-                    if let Some(on_update) = &fk.on_update
-                        && on_update != "NO ACTION"
-                    {
-                        fk_sql.push("ON UPDATE".into());
-                        fk_sql.push(on_update.clone());
-                    }
-                    if fk.deferrable == Some(true) {
-                        fk_sql.push("DEFERRABLE".into());
-                    }
-                    if fk.initially_deferred == Some(true) {
-                        fk_sql.push("INITIALLY DEFERRED".into());
-                    }
-                    inner.push(fk_sql.join(" "));
+                    inner.push(render_foreign_key(fk));
                 }
                 create.push(inner.join(", "));
                 create.push(")".into());
@@ -1152,72 +1124,7 @@ impl Builder {
             quote_ident(&table.schema),
             quote_ident(&index.name)
         );
-        let mut create = vec!["CREATE".into()];
-        if index.unique == Some(true) {
-            create.push("UNIQUE".into());
-        }
-        create.push("INDEX".into());
-        create.push(quote_ident(&index.name));
-        create.push("ON".into());
-        if index.recurse == Some(false) {
-            create.push("ONLY".into());
-        }
-        create.push(self.item_name(parent));
-        if let Some(method) = &index.method {
-            create.push("USING".into());
-            create.push(method.clone());
-        }
-        create.push("(".into());
-        let columns: Vec<String> = index
-            .columns
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            .map(|c| {
-                let mut sql = vec![
-                    c.name
-                        .clone()
-                        .or_else(|| c.expression.clone())
-                        .unwrap_or_default(),
-                ];
-                if let Some(collation) = &c.collation {
-                    sql.push("COLLATION".into());
-                    sql.push(collation.clone());
-                }
-                if let Some(opclass) = &c.opclass {
-                    sql.push(opclass.clone());
-                }
-                if let Some(direction) = &c.direction {
-                    sql.push(direction.clone());
-                }
-                if let Some(null_placement) = &c.null_placement {
-                    sql.push("NULLS".into());
-                    sql.push(null_placement.clone());
-                }
-                sql.join(" ")
-            })
-            .collect();
-        create.push(columns.join(", "));
-        create.push(")".into());
-        if let Some(include) = &index.include {
-            create.push(format!("INCLUDE ({})", include.join(", ")));
-        }
-        if let Some(storage_parameters) = &index.storage_parameters {
-            create.push("WITH".into());
-            let params: Vec<String> = storage_parameters
-                .iter()
-                .map(|(k, v)| format!("{k}={}", raw_value(v)))
-                .collect();
-            create.push(params.join(", "));
-        }
-        if let Some(tablespace) = &index.tablespace {
-            create.push("TABLESPACE".into());
-            create.push(tablespace.clone());
-        }
-        if let Some(where_clause) = &index.where_clause {
-            create.push("WHERE".into());
-            create.push(where_clause.clone());
-        }
+        let create = render_index(index, &self.item_name(parent));
         let drop = vec!["DROP INDEX IF EXISTS".into(), qualified];
         let parent_dump_id = self.dump_id_map[&parent.id];
         let dump_id = self.add_entry(
@@ -1250,42 +1157,7 @@ impl Builder {
         table: &crate::models::Table,
     ) -> Result<(), String> {
         let name = trigger.name.clone().unwrap_or_default();
-        let (create, drop) = if let Some(sql) = &trigger.sql {
-            (vec![sql.clone()], vec![])
-        } else {
-            let mut create = vec![
-                "CREATE".into(),
-                "TRIGGER".into(),
-                name.clone(),
-                trigger.when.clone().unwrap_or_default(),
-                trigger.events.clone().unwrap_or_default().join(" OR "),
-                "ON".into(),
-                self.item_name(parent),
-            ];
-            if let Some(for_each) = &trigger.for_each {
-                create.push("FOR EACH".into());
-                create.push(for_each.clone());
-            }
-            if let Some(condition) = &trigger.condition {
-                create.push("WHEN".into());
-                create.push(condition.clone());
-            }
-            create.push("EXECUTE".into());
-            create.push("FUNCTION".into());
-            create.push(trigger.function.clone().unwrap_or_default());
-            if let Some(arguments) = &trigger.arguments {
-                let args: Vec<String> =
-                    arguments.iter().map(raw_value).collect();
-                create.push(format!("({})", args.join(", ")));
-            }
-            let drop = vec![
-                "DROP TRIGGER IF EXISTS".into(),
-                name.clone(),
-                "ON".into(),
-                self.item_name(parent),
-            ];
-            (create, drop)
-        };
+        let (create, drop) = render_trigger(trigger, &self.item_name(parent));
         let parent_dump_id = self.dump_id_map[&parent.id];
         let dump_id = self.add_entry(
             "TRIGGER",
@@ -1798,7 +1670,7 @@ fn push_role_options(
 /// else renders as a literal. Deviation 9: Python quoted every string,
 /// producing unrestorable SQL for expression defaults like
 /// `uuid_generate_v4()`.
-fn render_default(value: &Value) -> String {
+pub(crate) fn render_default(value: &Value) -> String {
     if let Value::String(s) = value {
         const RAW_KEYWORDS: &[&str] = &[
             "CURRENT_CATALOG",
@@ -1825,7 +1697,7 @@ fn render_default(value: &Value) -> String {
     postgres_value(value)
 }
 
-fn render_table_column(column: &Column) -> String {
+pub(crate) fn render_table_column(column: &Column) -> String {
     let mut sql = vec![column.name.clone(), column.data_type.clone()];
     if let Some(collation) = &column.collation {
         sql.push("COLLATE".into());
@@ -1856,9 +1728,158 @@ fn render_table_column(column: &Column) -> String {
     sql.join(" ")
 }
 
+/// CREATE INDEX rendering, shared by build and deploy; `table_name`
+/// is the quoted, qualified table
+pub(crate) fn render_index(index: &Index, table_name: &str) -> Vec<String> {
+    let mut create = vec!["CREATE".into()];
+    if index.unique == Some(true) {
+        create.push("UNIQUE".into());
+    }
+    create.push("INDEX".into());
+    create.push(quote_ident(&index.name));
+    create.push("ON".into());
+    if index.recurse == Some(false) {
+        create.push("ONLY".into());
+    }
+    create.push(table_name.to_string());
+    if let Some(method) = &index.method {
+        create.push("USING".into());
+        create.push(method.clone());
+    }
+    create.push("(".into());
+    let columns: Vec<String> = index
+        .columns
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|c| {
+            let mut sql = vec![
+                c.name
+                    .clone()
+                    .or_else(|| c.expression.clone())
+                    .unwrap_or_default(),
+            ];
+            if let Some(collation) = &c.collation {
+                sql.push("COLLATION".into());
+                sql.push(collation.clone());
+            }
+            if let Some(opclass) = &c.opclass {
+                sql.push(opclass.clone());
+            }
+            if let Some(direction) = &c.direction {
+                sql.push(direction.clone());
+            }
+            if let Some(null_placement) = &c.null_placement {
+                sql.push("NULLS".into());
+                sql.push(null_placement.clone());
+            }
+            sql.join(" ")
+        })
+        .collect();
+    create.push(columns.join(", "));
+    create.push(")".into());
+    if let Some(include) = &index.include {
+        create.push(format!("INCLUDE ({})", include.join(", ")));
+    }
+    if let Some(storage_parameters) = &index.storage_parameters {
+        create.push("WITH".into());
+        let params: Vec<String> = storage_parameters
+            .iter()
+            .map(|(k, v)| format!("{k}={}", raw_value(v)))
+            .collect();
+        create.push(params.join(", "));
+    }
+    if let Some(tablespace) = &index.tablespace {
+        create.push("TABLESPACE".into());
+        create.push(tablespace.clone());
+    }
+    if let Some(where_clause) = &index.where_clause {
+        create.push("WHERE".into());
+        create.push(where_clause.clone());
+    }
+    create
+}
+
+/// CREATE TRIGGER / DROP TRIGGER rendering, shared by build and
+/// deploy; `table_name` is the quoted, qualified table
+pub(crate) fn render_trigger(
+    trigger: &Trigger,
+    table_name: &str,
+) -> (Vec<String>, Vec<String>) {
+    if let Some(sql) = &trigger.sql {
+        return (vec![sql.clone()], vec![]);
+    }
+    let name = trigger.name.clone().unwrap_or_default();
+    let mut create = vec![
+        "CREATE".into(),
+        "TRIGGER".into(),
+        name.clone(),
+        trigger.when.clone().unwrap_or_default(),
+        trigger.events.clone().unwrap_or_default().join(" OR "),
+        "ON".into(),
+        table_name.to_string(),
+    ];
+    if let Some(for_each) = &trigger.for_each {
+        create.push("FOR EACH".into());
+        create.push(for_each.clone());
+    }
+    if let Some(condition) = &trigger.condition {
+        create.push("WHEN".into());
+        create.push(condition.clone());
+    }
+    create.push("EXECUTE".into());
+    create.push("FUNCTION".into());
+    create.push(trigger.function.clone().unwrap_or_default());
+    if let Some(arguments) = &trigger.arguments {
+        let args: Vec<String> = arguments.iter().map(raw_value).collect();
+        create.push(format!("({})", args.join(", ")));
+    }
+    let drop = vec![
+        "DROP TRIGGER IF EXISTS".into(),
+        name,
+        "ON".into(),
+        table_name.to_string(),
+    ];
+    (create, drop)
+}
+
+/// FOREIGN KEY clause rendering, shared by the inline table form and
+/// deploy's `ADD CONSTRAINT`
+pub(crate) fn render_foreign_key(fk: &crate::models::ForeignKey) -> String {
+    let mut fk_sql = vec![
+        format!("FOREIGN KEY ({})", fk.columns.join(", ")),
+        "REFERENCES".into(),
+        fk.references.name.clone(),
+        format!("({})", fk.references.columns.join(", ")),
+    ];
+    if let Some(match_type) = &fk.match_type {
+        fk_sql.push("MATCH".into());
+        fk_sql.push(match_type.clone());
+    }
+    if let Some(on_delete) = &fk.on_delete
+        && on_delete != "NO ACTION"
+    {
+        fk_sql.push("ON DELETE".into());
+        fk_sql.push(on_delete.clone());
+    }
+    if let Some(on_update) = &fk.on_update
+        && on_update != "NO ACTION"
+    {
+        fk_sql.push("ON UPDATE".into());
+        fk_sql.push(on_update.clone());
+    }
+    if fk.deferrable == Some(true) {
+        fk_sql.push("DEFERRABLE".into());
+    }
+    if fk.initially_deferred == Some(true) {
+        fk_sql.push("INITIALLY DEFERRED".into());
+    }
+    fk_sql.join(" ")
+}
+
 /// UNIQUE / PRIMARY KEY constraint rendering
 /// (ports _format_sql_constraint; INCLUDE columns get a proper clause)
-fn render_constraint(
+pub(crate) fn render_constraint(
     constraint_type: &str,
     constraint: &ConstraintColumns,
 ) -> String {

--- a/src/deploy/alter.rs
+++ b/src/deploy/alter.rs
@@ -316,7 +316,15 @@ fn indexes(table: &str, repo: &Table, db: &Table, alters: &mut Vec<Alter>) {
                 quote_ident(&index.name)
             )
         },
-        |index| format!("{};\n", build::render_index(index, table).join(" ")),
+        |index| {
+            let mut sql =
+                format!("{};\n", build::render_index(index, table).join(" "));
+            if let Some(comment) = &index.comment {
+                let name = format!("{schema}.{}", quote_ident(&index.name));
+                sql.push_str(&comment_on("INDEX", &name, Some(comment)));
+            }
+            sql
+        },
     );
 }
 
@@ -352,7 +360,18 @@ fn triggers(
             )
         },
         |trigger| {
-            format!("{};\n", build::render_trigger(trigger, table).0.join(" "))
+            let mut sql = format!(
+                "{};\n",
+                build::render_trigger(trigger, table).0.join(" ")
+            );
+            if let Some(comment) = &trigger.comment {
+                let name = format!(
+                    "{} ON {table}",
+                    quote_ident(trigger.name.as_deref().unwrap_or_default())
+                );
+                sql.push_str(&comment_on("TRIGGER", &name, Some(comment)));
+            }
+            sql
         },
     );
     true
@@ -572,6 +591,31 @@ mod tests {
     }
 
     #[test]
+    fn recreated_index_emits_its_comment() {
+        let mut repo = base_table();
+        repo["indexes"] = serde_json::json!([{
+            "name": "users_email_idx",
+            "columns": [{"name": "email"}],
+            "comment": "lookup by email",
+        }]);
+        let mut db = base_table();
+        db["indexes"] = serde_json::json!([{
+            "name": "users_email_idx",
+            "columns": [{"name": "id"}],
+        }]);
+        let alters = statements(table(&parse_table(repo), &parse_table(db)));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "DROP INDEX IF EXISTS test.users_email_idx;\n",
+                "CREATE INDEX users_email_idx ON test.users ( email );\n\
+                 COMMENT ON INDEX test.users_email_idx IS \
+                 $$lookup by email$$;\n",
+            ]
+        );
+    }
+
+    #[test]
     fn triggers_reconcile_by_name() {
         let mut repo = base_table();
         repo["triggers"] = serde_json::json!([{
@@ -589,6 +633,39 @@ mod tests {
                 "CREATE TRIGGER set_last_modified BEFORE UPDATE ON \
                  test.users FOR EACH ROW EXECUTE FUNCTION \
                  test.set_last_modified();\n"
+            ]
+        );
+    }
+
+    #[test]
+    fn recreated_trigger_emits_its_comment() {
+        let mut repo = base_table();
+        repo["triggers"] = serde_json::json!([{
+            "name": "set_last_modified",
+            "when": "BEFORE",
+            "events": ["UPDATE"],
+            "for_each": "ROW",
+            "function": "test.set_last_modified()",
+            "comment": "stamp updates",
+        }]);
+        let mut db = base_table();
+        db["triggers"] = serde_json::json!([{
+            "name": "set_last_modified",
+            "when": "BEFORE",
+            "events": ["INSERT"],
+            "for_each": "ROW",
+            "function": "test.set_last_modified()",
+        }]);
+        let alters = statements(table(&parse_table(repo), &parse_table(db)));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "DROP TRIGGER IF EXISTS set_last_modified ON test.users;\n",
+                "CREATE TRIGGER set_last_modified BEFORE UPDATE ON \
+                 test.users FOR EACH ROW EXECUTE FUNCTION \
+                 test.set_last_modified();\n\
+                 COMMENT ON TRIGGER set_last_modified ON test.users IS \
+                 $$stamp updates$$;\n",
             ]
         );
     }

--- a/src/deploy/alter.rs
+++ b/src/deploy/alter.rs
@@ -1,0 +1,648 @@
+//! In-place ALTER renderers for objects that exist in both the
+//! project and the database but differ. Each resolver returns either
+//! the statements that reconcile the database in place or
+//! [`Resolution::Replace`], the gated drop+recreate fallback the
+//! caller assembles from the build archive's entries.
+//!
+//! Index, trigger, and constraint drops are not gated: they lose no
+//! data and the repo is authoritative. Only data-destructive
+//! statements (DROP COLUMN, ALTER COLUMN TYPE) are.
+
+use crate::build;
+use crate::deploy::diff::canonical_type;
+use crate::models::{
+    CheckConstraint, Column, Definition, ForeignKey, Index, Table, Trigger,
+};
+use crate::utils::quote_ident;
+
+/// One reconciliation statement
+pub(crate) struct Alter {
+    pub sql: String,
+    pub destructive: bool,
+}
+
+impl Alter {
+    fn new(sql: String) -> Self {
+        Self {
+            sql,
+            destructive: false,
+        }
+    }
+
+    fn destructive(sql: String) -> Self {
+        Self {
+            sql,
+            destructive: true,
+        }
+    }
+}
+
+/// The outcome of resolving a changed object
+pub(crate) enum Resolution {
+    /// Reconcile in place with these statements
+    Statements(Vec<Alter>),
+    /// No in-place form exists (or is implemented yet): drop and
+    /// recreate from the repo definition, gated behind --allow-drop
+    Replace,
+}
+
+/// Resolve a changed object into in-place statements where supported
+pub(crate) fn resolve(repo: &Definition, database: &Definition) -> Resolution {
+    match (repo, database) {
+        (Definition::Table(repo), Definition::Table(database)) => {
+            table(repo, database)
+        }
+        _ => Resolution::Replace,
+    }
+}
+
+fn qualified(schema: &str, name: &str) -> String {
+    format!("{}.{}", quote_ident(schema), quote_ident(name))
+}
+
+fn table(repo: &Table, db: &Table) -> Resolution {
+    // properties only expressible by rebuilding the table
+    if repo.sql != db.sql
+        || repo.unlogged != db.unlogged
+        || repo.from_type != db.from_type
+        || repo.parents != db.parents
+        || repo.like_table != db.like_table
+        || repo.partition != db.partition
+        || repo.partitions != db.partitions
+        || repo.access_method != db.access_method
+        || repo.storage_parameters != db.storage_parameters
+        || repo.tablespace != db.tablespace
+        || repo.index_tablespace != db.index_tablespace
+    {
+        return Resolution::Replace;
+    }
+    let name = qualified(&repo.schema, &repo.name);
+    let mut alters = Vec::new();
+    if !columns(&name, repo, db, &mut alters)
+        || !constraints(&name, repo, db, &mut alters)
+        || !triggers(&name, repo, db, &mut alters)
+    {
+        return Resolution::Replace;
+    }
+    indexes(&name, repo, db, &mut alters);
+    if repo.comment != db.comment {
+        alters.push(Alter::new(comment_on(
+            "TABLE",
+            &name,
+            repo.comment.as_deref(),
+        )));
+    }
+    Resolution::Statements(alters)
+}
+
+/// Column reconciliation; returns false where only a rebuild works
+/// (reordered columns, collation/generation changes)
+fn columns(
+    table: &str,
+    repo: &Table,
+    db: &Table,
+    alters: &mut Vec<Alter>,
+) -> bool {
+    let repo_columns = repo.columns.as_deref().unwrap_or_default();
+    let db_columns = db.columns.as_deref().unwrap_or_default();
+    // column position cannot be altered in place: the columns present
+    // on both sides must appear in the same relative order
+    let in_db: Vec<&str> = repo_columns
+        .iter()
+        .map(|c| c.name.as_str())
+        .filter(|name| db_columns.iter().any(|c| c.name == *name))
+        .collect();
+    let in_repo: Vec<&str> = db_columns
+        .iter()
+        .map(|c| c.name.as_str())
+        .filter(|name| repo_columns.iter().any(|c| c.name == *name))
+        .collect();
+    if in_db != in_repo {
+        return false;
+    }
+    for column in repo_columns {
+        match db_columns.iter().find(|c| c.name == column.name) {
+            None => alters.push(Alter::new(format!(
+                "ALTER TABLE {table} ADD COLUMN {};\n",
+                build::render_table_column(column)
+            ))),
+            Some(existing) => {
+                if !alter_column(table, column, existing, alters) {
+                    return false;
+                }
+            }
+        }
+    }
+    for column in db_columns {
+        if !repo_columns.iter().any(|c| c.name == column.name) {
+            alters.push(Alter::destructive(format!(
+                "ALTER TABLE {table} DROP COLUMN {};\n",
+                quote_ident(&column.name)
+            )));
+        }
+    }
+    true
+}
+
+fn alter_column(
+    table: &str,
+    repo: &Column,
+    db: &Column,
+    alters: &mut Vec<Alter>,
+) -> bool {
+    // collation, generation, and inline check changes require a
+    // rebuild
+    if repo.collation != db.collation
+        || repo.generated != db.generated
+        || repo.check_constraint != db.check_constraint
+    {
+        return false;
+    }
+    let column = quote_ident(&repo.name);
+    if canonical_type(&repo.data_type) != canonical_type(&db.data_type) {
+        // a type change may rewrite the table (and can fail outright
+        // without a USING clause), so it is gated
+        alters.push(Alter::destructive(format!(
+            "ALTER TABLE {table} ALTER COLUMN {column} TYPE {};\n",
+            repo.data_type
+        )));
+    }
+    if repo.default != db.default {
+        alters.push(Alter::new(match &repo.default {
+            Some(default) => format!(
+                "ALTER TABLE {table} ALTER COLUMN {column} SET DEFAULT \
+                 {};\n",
+                build::render_default(default)
+            ),
+            None => format!(
+                "ALTER TABLE {table} ALTER COLUMN {column} DROP DEFAULT;\n"
+            ),
+        }));
+    }
+    if repo.nullable.unwrap_or(true) != db.nullable.unwrap_or(true) {
+        alters.push(Alter::new(if repo.nullable == Some(false) {
+            format!(
+                "ALTER TABLE {table} ALTER COLUMN {column} SET NOT \
+                     NULL;\n"
+            )
+        } else {
+            format!(
+                "ALTER TABLE {table} ALTER COLUMN {column} DROP NOT \
+                     NULL;\n"
+            )
+        }));
+    }
+    if repo.comment != db.comment {
+        alters.push(Alter::new(comment_on(
+            "COLUMN",
+            &format!("{table}.{column}"),
+            repo.comment.as_deref(),
+        )));
+    }
+    true
+}
+
+/// Constraint reconciliation. Check constraints and foreign keys are
+/// named in the model and reconcile as DROP/ADD pairs; primary keys
+/// and unique constraints are unnamed, so only additions are
+/// expressible — removals and changes fall back to a rebuild
+fn constraints(
+    table: &str,
+    repo: &Table,
+    db: &Table,
+    alters: &mut Vec<Alter>,
+) -> bool {
+    match (&repo.primary_key, &db.primary_key) {
+        (repo_pk, db_pk) if repo_pk == db_pk => {}
+        (Some(pk), None) => alters.push(Alter::new(format!(
+            "ALTER TABLE {table} ADD {};\n",
+            build::render_constraint("PRIMARY KEY", pk)
+        ))),
+        _ => return false,
+    }
+    let repo_unique = repo.unique_constraints.as_deref().unwrap_or_default();
+    let db_unique = db.unique_constraints.as_deref().unwrap_or_default();
+    if db_unique.iter().any(|u| !repo_unique.contains(u)) {
+        return false;
+    }
+    for unique in repo_unique {
+        if !db_unique.contains(unique) {
+            alters.push(Alter::new(format!(
+                "ALTER TABLE {table} ADD {};\n",
+                build::render_constraint("UNIQUE", unique)
+            )));
+        }
+    }
+    let repo_checks = repo.check_constraints.as_deref().unwrap_or_default();
+    let db_checks = db.check_constraints.as_deref().unwrap_or_default();
+    named_pairs(
+        alters,
+        db_checks,
+        repo_checks,
+        |check: &CheckConstraint| check.name.clone(),
+        |check| {
+            format!(
+                "ALTER TABLE {table} DROP CONSTRAINT {};\n",
+                quote_ident(&check.name)
+            )
+        },
+        |check| {
+            format!(
+                "ALTER TABLE {table} ADD CONSTRAINT {} CHECK ({});\n",
+                quote_ident(&check.name),
+                check.expression
+            )
+        },
+    );
+    let repo_fks = repo.foreign_keys.as_deref().unwrap_or_default();
+    let db_fks = db.foreign_keys.as_deref().unwrap_or_default();
+    named_pairs(
+        alters,
+        db_fks,
+        repo_fks,
+        |fk: &ForeignKey| fk.name.clone(),
+        |fk| {
+            format!(
+                "ALTER TABLE {table} DROP CONSTRAINT {};\n",
+                quote_ident(&fk.name)
+            )
+        },
+        |fk| {
+            format!(
+                "ALTER TABLE {table} ADD CONSTRAINT {} {};\n",
+                quote_ident(&fk.name),
+                build::render_foreign_key(fk)
+            )
+        },
+    );
+    true
+}
+
+/// Reconcile named child objects: drop database-side entries that are
+/// missing or different in the repo, then add the repo-side entries
+/// the database is missing (a changed entry produces both)
+fn named_pairs<T: PartialEq>(
+    alters: &mut Vec<Alter>,
+    database: &[T],
+    repo: &[T],
+    name: impl Fn(&T) -> String,
+    drop: impl Fn(&T) -> String,
+    add: impl Fn(&T) -> String,
+) {
+    for existing in database {
+        match repo.iter().find(|t| name(t) == name(existing)) {
+            Some(wanted) if wanted == existing => {}
+            _ => alters.push(Alter::new(drop(existing))),
+        }
+    }
+    for wanted in repo {
+        match database.iter().find(|t| name(t) == name(wanted)) {
+            Some(existing) if existing == wanted => {}
+            _ => alters.push(Alter::new(add(wanted))),
+        }
+    }
+}
+
+fn indexes(table: &str, repo: &Table, db: &Table, alters: &mut Vec<Alter>) {
+    let schema = quote_ident(&repo.schema);
+    named_pairs(
+        alters,
+        db.indexes.as_deref().unwrap_or_default(),
+        repo.indexes.as_deref().unwrap_or_default(),
+        |index: &Index| index.name.clone(),
+        |index| {
+            format!(
+                "DROP INDEX IF EXISTS {schema}.{};\n",
+                quote_ident(&index.name)
+            )
+        },
+        |index| format!("{};\n", build::render_index(index, table).join(" ")),
+    );
+}
+
+/// Trigger reconciliation; triggers without names cannot be matched
+/// or dropped, so a difference involving one falls back to a rebuild
+fn triggers(
+    table: &str,
+    repo: &Table,
+    db: &Table,
+    alters: &mut Vec<Alter>,
+) -> bool {
+    let repo_triggers = repo.triggers.as_deref().unwrap_or_default();
+    let db_triggers = db.triggers.as_deref().unwrap_or_default();
+    if repo_triggers == db_triggers {
+        return true;
+    }
+    if repo_triggers
+        .iter()
+        .chain(db_triggers)
+        .any(|t| t.name.is_none())
+    {
+        return false;
+    }
+    named_pairs(
+        alters,
+        db_triggers,
+        repo_triggers,
+        |trigger: &Trigger| trigger.name.clone().unwrap_or_default(),
+        |trigger| {
+            format!(
+                "DROP TRIGGER IF EXISTS {} ON {table};\n",
+                quote_ident(trigger.name.as_deref().unwrap_or_default())
+            )
+        },
+        |trigger| {
+            format!("{};\n", build::render_trigger(trigger, table).0.join(" "))
+        },
+    );
+    true
+}
+
+/// `COMMENT ON <desc> <name> IS ...` matching the build's comment
+/// entry text shape; a removed comment becomes `IS NULL`
+fn comment_on(desc: &str, name: &str, comment: Option<&str>) -> String {
+    match comment {
+        Some(comment) => {
+            format!("COMMENT ON {desc} {name} IS $${comment}$$;\n")
+        }
+        None => format!("COMMENT ON {desc} {name} IS NULL;\n"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models;
+
+    fn parse_table(value: serde_json::Value) -> Table {
+        serde_json::from_value(value).expect("table deserializes")
+    }
+
+    fn base_table() -> serde_json::Value {
+        serde_json::json!({
+            "name": "users",
+            "schema": "test",
+            "owner": "postgres",
+            "columns": [
+                {"name": "id", "data_type": "uuid", "nullable": false},
+                {"name": "email", "data_type": "text", "nullable": false},
+            ],
+        })
+    }
+
+    fn statements(resolution: Resolution) -> Vec<Alter> {
+        match resolution {
+            Resolution::Statements(alters) => alters,
+            Resolution::Replace => panic!("expected in-place statements"),
+        }
+    }
+
+    fn sql(alters: &[Alter]) -> Vec<&str> {
+        alters.iter().map(|a| a.sql.as_str()).collect()
+    }
+
+    #[test]
+    fn added_column_renders_add_column() {
+        let mut repo = base_table();
+        repo["columns"].as_array_mut().unwrap().push(
+            serde_json::json!({"name": "nickname", "data_type": "text"}),
+        );
+        let alters =
+            statements(table(&parse_table(repo), &parse_table(base_table())));
+        assert_eq!(
+            sql(&alters),
+            vec!["ALTER TABLE test.users ADD COLUMN nickname text;\n"]
+        );
+        assert!(!alters[0].destructive);
+    }
+
+    #[test]
+    fn removed_column_is_destructive() {
+        let mut db = base_table();
+        db["columns"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({"name": "legacy", "data_type": "text"}));
+        let alters =
+            statements(table(&parse_table(base_table()), &parse_table(db)));
+        assert_eq!(
+            sql(&alters),
+            vec!["ALTER TABLE test.users DROP COLUMN legacy;\n"]
+        );
+        assert!(alters[0].destructive);
+    }
+
+    #[test]
+    fn type_change_is_destructive() {
+        let mut repo = base_table();
+        repo["columns"][1]["data_type"] = "character varying".into();
+        let alters =
+            statements(table(&parse_table(repo), &parse_table(base_table())));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "ALTER TABLE test.users ALTER COLUMN email TYPE character \
+                 varying;\n"
+            ]
+        );
+        assert!(alters[0].destructive);
+    }
+
+    #[test]
+    fn aliased_type_is_not_a_change() {
+        let mut repo = base_table();
+        repo["columns"][1]["data_type"] = "varchar".into();
+        let mut db = base_table();
+        db["columns"][1]["data_type"] = "character varying".into();
+        let alters = statements(table(&parse_table(repo), &parse_table(db)));
+        assert!(alters.is_empty(), "alias must not diff: {:?}", sql(&alters));
+    }
+
+    #[test]
+    fn default_and_nullability_toggle() {
+        let mut repo = base_table();
+        repo["columns"][1]["default"] = "'unknown'::text".into();
+        repo["columns"][1]["nullable"] = true.into();
+        let alters =
+            statements(table(&parse_table(repo), &parse_table(base_table())));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "ALTER TABLE test.users ALTER COLUMN email SET DEFAULT \
+                 'unknown'::text;\n",
+                "ALTER TABLE test.users ALTER COLUMN email DROP NOT NULL;\n",
+            ]
+        );
+        assert!(alters.iter().all(|a| !a.destructive));
+    }
+
+    #[test]
+    fn reordered_columns_require_replace() {
+        let mut repo = base_table();
+        repo["columns"].as_array_mut().unwrap().reverse();
+        assert!(matches!(
+            table(&parse_table(repo), &parse_table(base_table())),
+            Resolution::Replace
+        ));
+    }
+
+    #[test]
+    fn primary_key_addition_and_removal() {
+        let mut repo = base_table();
+        repo["primary_key"] = serde_json::json!(["id"]);
+        let alters =
+            statements(table(&parse_table(repo), &parse_table(base_table())));
+        assert_eq!(
+            sql(&alters),
+            vec!["ALTER TABLE test.users ADD PRIMARY KEY (id);\n"]
+        );
+        // removal cannot name the constraint → rebuild
+        let mut db = base_table();
+        db["primary_key"] = serde_json::json!(["id"]);
+        assert!(matches!(
+            table(&parse_table(base_table()), &parse_table(db)),
+            Resolution::Replace
+        ));
+    }
+
+    #[test]
+    fn check_constraints_reconcile_as_pairs() {
+        let mut repo = base_table();
+        repo["check_constraints"] = serde_json::json!([
+            {"name": "email_has_at", "expression": "email ~ '@'"},
+        ]);
+        let mut db = base_table();
+        db["check_constraints"] = serde_json::json!([
+            {"name": "email_has_at", "expression": "email <> ''"},
+        ]);
+        let alters = statements(table(&parse_table(repo), &parse_table(db)));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "ALTER TABLE test.users DROP CONSTRAINT email_has_at;\n",
+                "ALTER TABLE test.users ADD CONSTRAINT email_has_at CHECK \
+                 (email ~ '@');\n",
+            ]
+        );
+    }
+
+    #[test]
+    fn foreign_keys_reconcile_as_pairs() {
+        let mut repo = base_table();
+        repo["foreign_keys"] = serde_json::json!([{
+            "name": "users_org_fk",
+            "columns": ["org_id"],
+            "references": {"name": "test.orgs", "columns": ["id"]},
+            "on_delete": "CASCADE",
+        }]);
+        let alters =
+            statements(table(&parse_table(repo), &parse_table(base_table())));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "ALTER TABLE test.users ADD CONSTRAINT users_org_fk FOREIGN \
+                 KEY (org_id) REFERENCES test.orgs (id) ON DELETE CASCADE;\n"
+            ]
+        );
+    }
+
+    #[test]
+    fn indexes_reconcile_without_gating() {
+        let mut repo = base_table();
+        repo["indexes"] = serde_json::json!([{
+            "name": "users_email_idx",
+            "unique": true,
+            "columns": [{"name": "email"}],
+        }]);
+        let mut db = base_table();
+        db["indexes"] = serde_json::json!([{
+            "name": "users_legacy_idx",
+            "columns": [{"name": "id"}],
+        }]);
+        let alters = statements(table(&parse_table(repo), &parse_table(db)));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "DROP INDEX IF EXISTS test.users_legacy_idx;\n",
+                "CREATE UNIQUE INDEX users_email_idx ON test.users ( email \
+                 );\n",
+            ]
+        );
+        assert!(alters.iter().all(|a| !a.destructive));
+    }
+
+    #[test]
+    fn triggers_reconcile_by_name() {
+        let mut repo = base_table();
+        repo["triggers"] = serde_json::json!([{
+            "name": "set_last_modified",
+            "when": "BEFORE",
+            "events": ["UPDATE"],
+            "for_each": "ROW",
+            "function": "test.set_last_modified()",
+        }]);
+        let alters =
+            statements(table(&parse_table(repo), &parse_table(base_table())));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "CREATE TRIGGER set_last_modified BEFORE UPDATE ON \
+                 test.users FOR EACH ROW EXECUTE FUNCTION \
+                 test.set_last_modified();\n"
+            ]
+        );
+    }
+
+    #[test]
+    fn comment_changes_render_comment_on() {
+        let mut repo = base_table();
+        repo["comment"] = "User records".into();
+        repo["columns"][1]["comment"] = "Email address".into();
+        let alters = statements(table(
+            &parse_table(repo.clone()),
+            &parse_table(base_table()),
+        ));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "COMMENT ON COLUMN test.users.email IS $$Email address$$;\n",
+                "COMMENT ON TABLE test.users IS $$User records$$;\n",
+            ]
+        );
+        let alters =
+            statements(table(&parse_table(base_table()), &parse_table(repo)));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "COMMENT ON COLUMN test.users.email IS NULL;\n",
+                "COMMENT ON TABLE test.users IS NULL;\n",
+            ]
+        );
+    }
+
+    #[test]
+    fn storage_parameter_changes_require_replace() {
+        let mut repo = base_table();
+        repo["storage_parameters"] = serde_json::json!({"fillfactor": 70});
+        assert!(matches!(
+            table(&parse_table(repo), &parse_table(base_table())),
+            Resolution::Replace
+        ));
+    }
+
+    #[test]
+    fn non_table_definitions_replace() {
+        let schema: models::Schema =
+            serde_json::from_value(serde_json::json!(
+                {"name": "test", "owner": "postgres"}
+            ))
+            .unwrap();
+        assert!(matches!(
+            resolve(
+                &Definition::Schema(schema.clone()),
+                &Definition::Schema(schema)
+            ),
+            Resolution::Replace
+        ));
+    }
+}

--- a/src/deploy/diff.rs
+++ b/src/deploy/diff.rs
@@ -95,6 +95,10 @@ pub enum Change {
 pub struct Diff {
     /// Inventory item id → change classification
     pub items: BTreeMap<usize, Change>,
+    /// Inventory item id → the database-side definition, for items
+    /// classified [`Change::Changed`] (the ALTER renderers need both
+    /// sides)
+    pub changed: BTreeMap<usize, Definition>,
     /// Objects in the database with no repo counterpart → DROP
     pub removed: Vec<ObjectKey>,
 }
@@ -114,6 +118,7 @@ pub fn diff(project: &Project, assembly: &Assembly) -> Diff {
     let mut database = database_index(assembly);
     let existing = existence_index(assembly);
     let mut items = BTreeMap::new();
+    let mut changed = BTreeMap::new();
     for item in &project.inventory {
         let change = if SKIPPED.contains(&item.desc) {
             log::debug!(
@@ -130,6 +135,7 @@ pub fn diff(project: &Project, assembly: &Assembly) -> Diff {
                     if normalized(&item.definition) == normalized(&db) {
                         Change::Unchanged
                     } else {
+                        changed.insert(item.id, db);
                         Change::Changed
                     }
                 }
@@ -146,7 +152,11 @@ pub fn diff(project: &Project, assembly: &Assembly) -> Diff {
         items.insert(item.id, change);
     }
     let removed = database.into_keys().collect();
-    Diff { items, removed }
+    Diff {
+        items,
+        changed,
+        removed,
+    }
 }
 
 /// Object types the [`Assembly`] parses into models; everything else
@@ -275,7 +285,7 @@ fn normalize(value: &mut Value) {
 /// server's `integer` (PLAN.md risk #5). A length/precision modifier
 /// (`varchar(255)`, `numeric(10,2)`) and an array suffix are split
 /// off the base name so the alias can be matched and reattached.
-fn canonical_type(data_type: &str) -> String {
+pub(crate) fn canonical_type(data_type: &str) -> String {
     let (body, array) = match data_type.trim_end().strip_suffix("[]") {
         Some(body) => (body.trim_end(), "[]"),
         None => (data_type.trim_end(), ""),

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -51,13 +51,18 @@ fn resolutions(
     project: &project::Project,
     diff: &Diff,
 ) -> BTreeMap<usize, Resolution> {
+    let inventory_by_id = project
+        .inventory
+        .iter()
+        .map(|item| (item.id, &item.definition))
+        .collect::<BTreeMap<_, _>>();
     diff.changed
         .iter()
         .map(|(id, database)| {
-            (
-                *id,
-                alter::resolve(&project.inventory[*id].definition, database),
-            )
+            let repo = inventory_by_id
+                .get(id)
+                .expect("changed item id missing from project inventory");
+            (*id, alter::resolve(repo, database))
         })
         .collect()
 }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -5,14 +5,17 @@
 //! Output first: the script goes to stdout or `--output` and is meant
 //! to be applied separately (e.g. `psql --single-transaction
 //! -v ON_ERROR_STOP=1 -f deploy.sql` in a CI step). Destructive
-//! statements — DROPs for objects missing from the repo and the
-//! drop+recreate fallback for in-place changes deploy cannot yet
-//! express — are excluded unless `--allow-drop` is given.
+//! statements — DROPs for objects missing from the repo, data-losing
+//! column changes, and the drop+recreate fallback for changes with no
+//! in-place form — are excluded unless `--allow-drop` is given.
 
+mod alter;
 mod diff;
 
+use std::collections::BTreeMap;
 use std::io::IsTerminal;
 
+use crate::deploy::alter::Resolution;
 use crate::deploy::diff::{Change, Diff, ObjectKey};
 use crate::utils::quote_ident;
 use crate::{build, cli, constants, pgdump, project, pull};
@@ -34,11 +37,29 @@ pub fn deploy(args: &cli::Deploy) -> Result<(), String> {
     let (assembly, snapshot) =
         pull::snapshot(args.dump.as_deref(), &args.connection, &ddl, false)?;
     let diff = diff::diff(&project, &assembly);
+    let resolutions = resolutions(&project, &diff);
     let mut output = build::assemble(&project)?;
     output.dump.sort_entries();
-    let plan = plan(&diff, &output, &snapshot, args)?;
+    let plan = plan(&diff, &resolutions, &output, &snapshot, args)?;
     report(&diff, &plan);
     write_script(&plan, &project.name, &source, args)
+}
+
+/// Resolve each changed item into in-place statements or the
+/// drop+recreate fallback
+fn resolutions(
+    project: &project::Project,
+    diff: &Diff,
+) -> BTreeMap<usize, Resolution> {
+    diff.changed
+        .iter()
+        .map(|(id, database)| {
+            (
+                *id,
+                alter::resolve(&project.inventory[*id].definition, database),
+            )
+        })
+        .collect()
 }
 
 /// One statement in the deploy plan
@@ -59,10 +80,11 @@ struct Plan {
 
 /// Assemble the ordered plan: DROPs for database-only objects first
 /// (reverse snapshot order), then the repo archive's entries in
-/// topological order — plain CREATEs for added objects, gated
-/// drop+recreate for changed ones
+/// topological order — plain CREATEs for added objects, in-place
+/// ALTERs where a renderer exists, gated drop+recreate otherwise
 fn plan(
     diff: &Diff,
+    resolutions: &BTreeMap<usize, Resolution>,
     output: &build::BuildOutput,
     snapshot: &libpgdump::Dump,
     args: &cli::Deploy,
@@ -144,22 +166,50 @@ fn plan(
         };
         if changes.iter().all(|c| *c == Change::Added) {
             push(false, Statement { label, sql: defn });
-        } else if changes.contains(&Change::Changed)
-            && changes
+            continue;
+        }
+        if !changes.contains(&Change::Changed)
+            || !changes
                 .iter()
                 .all(|c| matches!(c, Change::Added | Change::Changed))
         {
-            // drop+recreate fallback: the object's own entry leads
-            // with its DROP; child entries (indexes, triggers,
-            // comments, ACLs) are recreated alongside it
-            let mut sql = String::new();
-            if direct.is_some()
-                && let Some(drop) = &entry.drop_stmt
-            {
-                sql.push_str(drop);
+            continue;
+        }
+        // the object's own entry: emit its in-place statements, or
+        // lead with its DROP for the drop+recreate fallback
+        if let Some(id) = direct {
+            match resolutions.get(id) {
+                Some(Resolution::Statements(alters)) => {
+                    for alter in alters {
+                        push(
+                            alter.destructive,
+                            Statement {
+                                label: label.clone(),
+                                sql: alter.sql.clone(),
+                            },
+                        );
+                    }
+                }
+                _ => {
+                    let mut sql = String::new();
+                    if let Some(drop) = &entry.drop_stmt {
+                        sql.push_str(drop);
+                    }
+                    sql.push_str(&defn);
+                    push(true, Statement { label, sql });
+                }
             }
-            sql.push_str(&defn);
-            push(true, Statement { label, sql });
+            continue;
+        }
+        // child entries (indexes, triggers, comments, ACLs): ride
+        // along only with a drop+recreate — in-place resolutions
+        // reconcile their children themselves
+        let replace = owners.iter().any(|id| {
+            diff.items.get(id) == Some(&Change::Changed)
+                && matches!(resolutions.get(id), Some(Resolution::Replace))
+        });
+        if replace {
+            push(true, Statement { label, sql: defn });
         }
     }
     Ok(Plan {

--- a/tests/deploy.rs
+++ b/tests/deploy.rs
@@ -88,19 +88,19 @@ fn missing_objects_are_created() {
         script.contains("CREATE VIEW test.us_users"),
         "missing view CREATE in:\n{script}"
     );
-    // the users table and function differ (nickname column, function
-    // body): in-place ALTER is not supported yet, so without
-    // --allow-drop nothing destructive may appear
+    // the database has an extra column (nickname) and a changed
+    // function: the column drop and the function replace are both
+    // destructive, so without --allow-drop neither may appear
     assert!(!script.contains("DROP TABLE"), "gated drop in:\n{script}");
     assert!(
-        !script.contains("CREATE TABLE"),
-        "drop+recreate must be gated:\n{script}"
+        !script.contains("DROP COLUMN"),
+        "destructive column change must be gated:\n{script}"
     );
     assert!(script.contains("excluded"), "header must note exclusions");
 }
 
 #[test]
-fn changed_objects_replace_with_allow_drop() {
+fn table_reconciles_in_place_function_replaces() {
     let dir = tempfile::tempdir().unwrap();
     let baseline = dir.path().join("fixtures.dump");
     fixture_archive(&baseline);
@@ -111,19 +111,18 @@ fn changed_objects_replace_with_allow_drop() {
 
     let script = deploy_script(&project, &mutated, &["--allow-drop"]);
 
-    // the changed table is dropped and recreated from the repo
+    // the table is reconciled in place — the database's extra column
+    // is dropped, not the whole table
     assert!(
-        script.contains("DROP TABLE IF EXISTS test.users"),
-        "missing table drop in:\n{script}"
+        !script.contains("DROP TABLE"),
+        "table must be altered, not replaced:\n{script}"
     );
     assert!(
-        script.contains("CREATE TABLE test.users"),
-        "missing table recreate in:\n{script}"
+        script.contains("ALTER TABLE test.users DROP COLUMN nickname;"),
+        "missing in-place column drop in:\n{script}"
     );
-    assert!(
-        !script.contains("nickname"),
-        "the repo (without nickname) is authoritative:\n{script}"
-    );
+    // the function has no in-place renderer yet, so it drop+recreates
+    // from the repo body
     assert!(
         script.contains("DROP FUNCTION IF EXISTS"),
         "missing function replace in:\n{script}"
@@ -132,15 +131,31 @@ fn changed_objects_replace_with_allow_drop() {
         script.contains("CURRENT_TIMESTAMP"),
         "recreated function must use the repo body:\n{script}"
     );
-    // the table's primary key, index, and comment ride along with the
-    // recreate
+}
+
+#[test]
+fn added_column_reconciles_in_place() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("fixtures.dump");
+    fixture_archive(&baseline);
+    let mutated = dir.path().join("mutated.dump");
+    mutated_archive(&mutated);
+    // project has the nickname column (from mutated); the database
+    // (baseline) does not — deploy should ADD it, non-destructively
+    let project = dir.path().join("project");
+    pull_project(&mutated, &project);
+
+    // no --allow-drop: a column add is not destructive, so it is
+    // included; its presence in the script proves that
+    let script = deploy_script(&project, &baseline, &[]);
+
     assert!(
-        script.contains("users_unique_email"),
-        "missing index recreate in:\n{script}"
+        script.contains("ALTER TABLE test.users ADD COLUMN nickname text;"),
+        "missing in-place column add in:\n{script}"
     );
     assert!(
-        script.contains("COMMENT ON TABLE test.users"),
-        "missing comment recreate in:\n{script}"
+        !script.contains("DROP TABLE"),
+        "an added column must not trigger a replace:\n{script}"
     );
 }
 


### PR DESCRIPTION
## Summary
Third slice of PLAN.md Phase 6: changed **tables** now reconcile with in-place `ALTER` statements instead of always falling back to the gated drop+recreate.

**Stacked on #24** (which is stacked on #23); only the last commit is new here.

## Problem
PR #24 shipped `deploy` with a single strategy for changed objects: drop and recreate, gated behind `--allow-drop`. That is correct but destructive for changes PostgreSQL can express in place (adding a column, toggling a default), so routine drift required the destructive flag and lost data unnecessarily.

## Solution
`src/deploy/alter.rs` resolves a changed object into either in-place statements or the drop+recreate fallback. Table coverage:
- **Columns**: `ADD COLUMN`, `SET`/`DROP DEFAULT`, `SET`/`DROP NOT NULL` (ungated); `DROP COLUMN` and `ALTER COLUMN TYPE` (destructive, gated). Reordered columns and collation/generation changes still rebuild.
- **Constraints**: DROP/ADD pairs for named check constraints and foreign keys; `PRIMARY KEY`/`UNIQUE` additions (removal can't be named → rebuild).
- **Indexes and triggers**: DROP/CREATE reconciliation, **ungated** — they lose no data and the repo is authoritative (per the plan decision).
- **COMMENT ON** for the table and its columns.
- Partitioning, storage params, access method, and type-shape changes fall back to drop+recreate.

Build's rendering is reused by extracting `render_index`, `render_trigger`, and `render_foreign_key` as `pub(crate)` (behavior-neutral; existing build tests prove it). The diff now records the database-side definition for each changed item so the renderers see both sides.

Functions, views, sequences, domains, types, and ACLs keep using drop+recreate until their renderers land in the final PR.

## Impact
Far fewer changes need `--allow-drop`; table drift converges without data loss.

## Testing
89 tests pass, including new golden-string unit tests per renderer and updated integration tests. Smoke-tested live: a mutation (added column + NOT NULL toggle) on a real database deploys as in-place ALTERs, applies in a single transaction, and a re-deploy is an empty plan (convergence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized SQL rendering to enable safer, reusable DDL generation.
  * Enhanced reconciliation so many schema changes (add/drop columns, indexes, triggers, comments) apply in-place when safe; unnecessary table replacements are avoided.
  * Destructive operations are explicitly gated and excluded unless allowed.

* **Tests**
  * Expanded integration tests covering in-place alters, destructive gating, and trigger/index/comment reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->