### PR TITLE
Complete deploy: remaining renderers, --apply, and Phase 6 gates

### DIFF
--- a/bin/deploy-gates
+++ b/bin/deploy-gates
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Phase 6 deploy gates (PLAN.md):
+#
+#   1. Equivalence — deploy --apply against an empty database yields the
+#      same schema as build + pg_restore (schema-only dumps match).
+#   2. Convergence — mutate the database, deploy --apply --allow-drop,
+#      then a re-deploy produces an empty plan.
+#   3. Safety — without --allow-drop the script has no destructive
+#      statements and --apply refuses while drops are pending.
+#
+# Requires a PostgreSQL superuser connection (defaults target the
+# compose.yaml container; override with PGHOST/PGPORT/PGUSER) and the
+# postgres client tools on PATH.
+set -euo pipefail
+
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-postgres}"
+export PGHOST PGPORT PGUSER
+
+SOURCE_DB=deploy_source
+TARGET_DB=deploy_target
+WORKDIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$WORKDIR"
+    psql -d postgres -q -c "DROP DATABASE IF EXISTS ${TARGET_DB}" \
+        >/dev/null 2>&1 || true
+    psql -d postgres -q -c "DROP DATABASE IF EXISTS ${SOURCE_DB}" \
+        >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+# Schema-only dump with the per-dump \restrict token stripped
+dump_schema() {
+    pg_dump -d "$1" --schema-only --no-owner \
+        | grep -v '^\\\(un\)\{0,1\}restrict '
+}
+
+echo "==> Building pglifecycle"
+cargo build --quiet
+
+echo "==> Creating ${SOURCE_DB} from fixtures/schema.sql"
+psql -d postgres -q -c "DROP DATABASE IF EXISTS ${SOURCE_DB}"
+psql -d postgres -q -c "CREATE DATABASE ${SOURCE_DB}"
+psql -d "${SOURCE_DB}" -q -v ON_ERROR_STOP=1 -f fixtures/schema.sql
+
+echo "==> pull a project from ${SOURCE_DB}"
+pg_dump -d "${SOURCE_DB}" -Fc --schema-only -f "${WORKDIR}/source.dump"
+./target/debug/pglifecycle pull --dump "${WORKDIR}/source.dump" \
+    "${WORKDIR}/project"
+
+echo "==> Gate 1: equivalence (deploy --apply into an empty database)"
+psql -d postgres -q -c "DROP DATABASE IF EXISTS ${TARGET_DB}"
+psql -d postgres -q -c "CREATE DATABASE ${TARGET_DB}"
+./target/debug/pglifecycle deploy --apply -d "${TARGET_DB}" \
+    "${WORKDIR}/project"
+dump_schema "${SOURCE_DB}" > "${WORKDIR}/source.sql"
+dump_schema "${TARGET_DB}" > "${WORKDIR}/target.sql"
+if diff -u "${WORKDIR}/source.sql" "${WORKDIR}/target.sql"; then
+    echo "Equivalence gate passed: schema diff is empty"
+else
+    echo "Equivalence gate FAILED: deployed schema differs from source" >&2
+    exit 1
+fi
+
+echo "==> Gate 2: convergence (mutate, deploy --apply, re-deploy is empty)"
+# exercise a column add (gated drop), a nullability flip (in place),
+# and a domain default (in-place ALTER DOMAIN)
+psql -d "${TARGET_DB}" -q -v ON_ERROR_STOP=1 <<'SQL'
+ALTER TABLE test.users ADD COLUMN scratch text;
+ALTER TABLE test.users ALTER COLUMN display_name SET NOT NULL;
+ALTER DOMAIN test.bcp47_locale SET DEFAULT 'en-US';
+SQL
+./target/debug/pglifecycle deploy --apply --allow-drop -d "${TARGET_DB}" \
+    "${WORKDIR}/project"
+./target/debug/pglifecycle deploy -o "${WORKDIR}/replan.sql" \
+    -d "${TARGET_DB}" "${WORKDIR}/project"
+if grep -q '^-- no changes' "${WORKDIR}/replan.sql"; then
+    echo "Convergence gate passed: re-deploy is an empty plan"
+else
+    echo "Convergence gate FAILED: re-deploy is not empty" >&2
+    cat "${WORKDIR}/replan.sql" >&2
+    exit 1
+fi
+
+echo "==> Gate 3: safety (drops gated without --allow-drop)"
+psql -d "${TARGET_DB}" -q -v ON_ERROR_STOP=1 \
+    -c "ALTER TABLE test.users ADD COLUMN scratch text;"
+./target/debug/pglifecycle deploy -o "${WORKDIR}/gated.sql" \
+    -d "${TARGET_DB}" "${WORKDIR}/project"
+if grep -Eq 'DROP TABLE|DROP COLUMN|ALTER COLUMN .* TYPE' \
+        "${WORKDIR}/gated.sql"; then
+    echo "Safety gate FAILED: destructive statement in the script" >&2
+    cat "${WORKDIR}/gated.sql" >&2
+    exit 1
+fi
+if ./target/debug/pglifecycle deploy --apply -d "${TARGET_DB}" \
+        "${WORKDIR}/project" 2>/dev/null; then
+    echo "Safety gate FAILED: --apply did not refuse pending drops" >&2
+    exit 1
+fi
+echo "Safety gate passed: drops excluded and --apply refused"
+
+echo "All deploy gates passed"

--- a/bin/deploy-gates
+++ b/bin/deploy-gates
@@ -95,9 +95,15 @@ if grep -Eq 'DROP TABLE|DROP COLUMN|ALTER COLUMN .* TYPE' \
     cat "${WORKDIR}/gated.sql" >&2
     exit 1
 fi
+APPLY_ERR="${WORKDIR}/apply.err"
 if ./target/debug/pglifecycle deploy --apply -d "${TARGET_DB}" \
-        "${WORKDIR}/project" 2>/dev/null; then
+        "${WORKDIR}/project" > /dev/null 2>"${APPLY_ERR}"; then
     echo "Safety gate FAILED: --apply did not refuse pending drops" >&2
+    exit 1
+fi
+if ! grep -q "destructive statement(s) are pending" "${APPLY_ERR}"; then
+    echo "Safety gate FAILED: --apply failed for an unexpected reason" >&2
+    cat "${APPLY_ERR}" >&2
     exit 1
 fi
 echo "Safety gate passed: drops excluded and --apply refused"

--- a/bin/deploy-gates
+++ b/bin/deploy-gates
@@ -44,6 +44,11 @@ echo "==> Creating ${SOURCE_DB} from fixtures/schema.sql"
 psql -d postgres -q -c "DROP DATABASE IF EXISTS ${SOURCE_DB}"
 psql -d postgres -q -c "CREATE DATABASE ${SOURCE_DB}"
 psql -d "${SOURCE_DB}" -q -v ON_ERROR_STOP=1 -f fixtures/schema.sql
+# a comment-less view (dependency-free so it needs no ordering): the
+# project carries no comment, so a database-only comment must be
+# cleared during convergence (gate 2)
+psql -d "${SOURCE_DB}" -q -v ON_ERROR_STOP=1 \
+    -c "CREATE VIEW test.deploy_probe AS SELECT 1 AS n;"
 
 echo "==> pull a project from ${SOURCE_DB}"
 pg_dump -d "${SOURCE_DB}" -Fc --schema-only -f "${WORKDIR}/source.dump"
@@ -66,11 +71,14 @@ fi
 
 echo "==> Gate 2: convergence (mutate, deploy --apply, re-deploy is empty)"
 # exercise a column add (gated drop), a nullability flip (in place),
-# and a domain default (in-place ALTER DOMAIN)
+# a domain default (in-place ALTER DOMAIN), and a database-only comment
+# on an OR REPLACE object (must be cleared with COMMENT ... IS NULL so
+# the re-deploy converges)
 psql -d "${TARGET_DB}" -q -v ON_ERROR_STOP=1 <<'SQL'
 ALTER TABLE test.users ADD COLUMN scratch text;
 ALTER TABLE test.users ALTER COLUMN display_name SET NOT NULL;
 ALTER DOMAIN test.bcp47_locale SET DEFAULT 'en-US';
+COMMENT ON VIEW test.deploy_probe IS 'stale, not in repo';
 SQL
 ./target/debug/pglifecycle deploy --apply --allow-drop -d "${TARGET_DB}" \
     "${WORKDIR}/project"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,34 +36,68 @@ pglifecycle build PROJECT DEST
 Compare a live database (or an existing dump) against the project and
 emit the DDL needed to make the database match: `CREATE` for objects
 missing from the database, `DROP` for objects missing from the
-project, and a drop+recreate fallback for objects that exist in both
-but differ. The script goes to stdout (or `-o FILE`) with a summary on
-stderr; it is meant to be applied separately, for example as a CI
-step:
+project, and an in-place reconciliation (or a drop+recreate fallback)
+for objects that exist in both but differ. The script goes to stdout
+(or `-o FILE`) with a summary on stderr; by default nothing is
+executed, so it can be applied as a separate CI step:
 
 ```bash
 pglifecycle deploy -o deploy.sql PROJECT
 psql --single-transaction -v ON_ERROR_STOP=1 -f deploy.sql
 ```
 
+`--apply` runs the script directly instead, in a single transaction
+via `psql` (it rolls back on the first error and refuses while gated
+destructive statements are pending).
+
 | Option | Description |
 | --- | --- |
 | `-D, --dump FILE` | Compare against a `pg_dump -Fc` file instead of connecting |
 | `-o, --output FILE` | Write the DDL script to FILE instead of stdout |
+| `--apply` | Execute the script in one transaction via psql (conflicts with `--dump`) |
 | `--allow-drop` | Include destructive statements in the script |
 | `-x, --no-privileges` | Do not include GRANT/REVOKE |
 
 The connection options match `pull` (see below).
 
-Destructive statements — `DROP` for database-only objects and the
-drop+recreate fallback for changed ones — are excluded from the script
-unless `--allow-drop` is given; each exclusion is reported on stderr
-and counted in the script header. Ownership is not managed (the script
-behaves like `pg_restore --no-owner`), and roles, users, groups, and
-tablespaces are skipped entirely: they are cluster-level objects a
-single-database dump cannot capture. Object types `pull` does not yet
-model (aggregates, casts, operators, …) are created when missing but
-otherwise only existence-checked and left untouched.
+### Change reconciliation
+
+Objects that differ between the project and the database are
+reconciled in place where PostgreSQL can express it:
+
+- **Tables** — add column, set/drop default, set/drop not-null,
+  add/drop check constraints and foreign keys, primary-key and unique
+  additions, index and trigger create/drop, and comment changes.
+  Dropping a column, changing a column type, reordering columns, and
+  partitioning/storage changes fall back to drop+recreate.
+- **Functions and views** — `CREATE OR REPLACE` (a function whose
+  return type changed must be dropped first, so it falls back).
+- **Sequences** — a single `ALTER SEQUENCE` of the changed options.
+- **Domains** — set/drop default; a base-type or constraint change
+  falls back.
+- **Enum types** — `ALTER TYPE ... ADD VALUE` for appended values;
+  reordering or removing values falls back.
+- **Extensions** — `ALTER EXTENSION ... UPDATE` / `SET SCHEMA`.
+- Everything else falls back to drop+recreate.
+
+### Destructive statements and limits
+
+Destructive statements — `DROP` for database-only objects, data-losing
+column changes, and every drop+recreate fallback — are excluded from
+the script unless `--allow-drop` is given; each exclusion is reported
+on stderr and counted in the script header, and `--apply` refuses while
+any are pending. Index, trigger, and constraint drops issued while
+reconciling a table are *not* gated: they lose no data and the project
+is authoritative.
+
+Ownership is not managed (the script behaves like
+`pg_restore --no-owner`), and roles, users, groups, and tablespaces are
+skipped entirely — they are cluster-level objects a single-database
+dump cannot capture. Object types `pull` does not yet model
+(aggregates, casts, operators, …) are created when missing but
+otherwise only existence-checked and left untouched. Privileges on
+created objects are emitted (unless `-x`); privilege changes on objects
+that already exist are not yet diffed.
 
 ## pull
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,11 @@ pub struct Deploy {
     #[arg(short = 'o', long)]
     pub output: Option<PathBuf>,
 
+    /// Execute the script against the database in a single transaction
+    /// via psql instead of only printing it
+    #[arg(long, conflicts_with = "dump")]
+    pub apply: bool,
+
     /// Include destructive statements (DROP, drop+recreate fallbacks)
     /// in the script
     #[arg(long)]

--- a/src/deploy/alter.rs
+++ b/src/deploy/alter.rs
@@ -44,8 +44,11 @@ pub(crate) enum Resolution {
     Statements(Vec<Alter>),
     /// Re-issue the object's CREATE as `CREATE OR REPLACE` (functions
     /// and views); non-destructive, the caller rewrites the entry's
-    /// leading verb
-    OrReplace,
+    /// leading verb. `CREATE OR REPLACE` keeps the existing comment, so
+    /// `comment` carries the `COMMENT ON` statement to run afterward
+    /// when it changed (including the `IS NULL` form on removal); `None`
+    /// means the comment is unchanged.
+    OrReplace { comment: Option<String> },
     /// No in-place form exists (or is implemented yet): drop and
     /// recreate from the repo definition, gated behind --allow-drop
     Replace,
@@ -69,7 +72,18 @@ pub(crate) fn resolve(repo: &Definition, database: &Definition) -> Resolution {
         // replaced and must be dropped first
         (Definition::Function(repo), Definition::Function(db)) => {
             if repo.returns == db.returns {
-                Resolution::OrReplace
+                // function names carry their full identity signature,
+                // so COMMENT ON FUNCTION takes the name verbatim
+                let target =
+                    format!("{}.{}", quote_ident(&repo.schema), repo.name);
+                Resolution::OrReplace {
+                    comment: comment_delta(
+                        "FUNCTION",
+                        &target,
+                        &repo.comment,
+                        &db.comment,
+                    ),
+                }
             } else {
                 Resolution::Replace
             }
@@ -92,7 +106,14 @@ fn qualified(schema: &str, name: &str) -> String {
 /// here.
 fn view(repo: &View, db: &View) -> Resolution {
     if view_columns_compatible(repo, db) {
-        Resolution::OrReplace
+        Resolution::OrReplace {
+            comment: comment_delta(
+                "VIEW",
+                &qualified(&repo.schema, &repo.name),
+                &repo.comment,
+                &db.comment,
+            ),
+        }
     } else {
         Resolution::Replace
     }
@@ -620,6 +641,19 @@ fn schema(repo: &Schema, db: &Schema) -> Resolution {
     Resolution::Statements(alters)
 }
 
+/// The `COMMENT ON` statement to reconcile a comment that changed
+/// between the repo and database, or `None` when it is unchanged. Used
+/// for `CREATE OR REPLACE` objects, which preserve the existing comment
+/// and so need it re-stated (or cleared with `IS NULL`) separately.
+fn comment_delta(
+    desc: &str,
+    name: &str,
+    repo: &Option<String>,
+    db: &Option<String>,
+) -> Option<String> {
+    (repo != db).then(|| comment_on(desc, name, repo.as_deref()))
+}
+
 /// `COMMENT ON <desc> <name> IS ...` matching the build's comment
 /// entry text shape; a removed comment becomes `IS NULL`
 fn comment_on(desc: &str, name: &str, comment: Option<&str>) -> String {
@@ -982,7 +1016,7 @@ mod tests {
         };
         assert!(matches!(
             resolve(&f("SELECT 2"), &f("SELECT 1")),
-            Resolution::OrReplace
+            Resolution::OrReplace { .. }
         ));
     }
 
@@ -1017,8 +1051,62 @@ mod tests {
         };
         assert!(matches!(
             resolve(&v("SELECT 2"), &v("SELECT 1")),
-            Resolution::OrReplace
+            Resolution::OrReplace { .. }
         ));
+    }
+
+    fn or_replace_comment(resolution: Resolution) -> Option<String> {
+        match resolution {
+            Resolution::OrReplace { comment } => comment,
+            _ => panic!("expected OR REPLACE"),
+        }
+    }
+
+    #[test]
+    fn function_comment_removal_clears_it() {
+        let f = |comment: Option<&str>| -> Definition {
+            let mut value = serde_json::json!({
+                "name": "f(integer)", "schema": "test", "owner": "postgres",
+                "returns": "integer", "language": "sql",
+                "definition": "SELECT 1",
+            });
+            if let Some(comment) = comment {
+                value["comment"] = comment.into();
+            }
+            Definition::Function(serde_json::from_value(value).unwrap())
+        };
+        // removal emits IS NULL so a re-deploy converges
+        assert_eq!(
+            or_replace_comment(resolve(&f(None), &f(Some("old")))),
+            Some("COMMENT ON FUNCTION test.f(integer) IS NULL;\n".into())
+        );
+        // a set comment is re-stated, an unchanged one is left alone
+        assert_eq!(
+            or_replace_comment(resolve(&f(Some("new")), &f(Some("old")))),
+            Some("COMMENT ON FUNCTION test.f(integer) IS $$new$$;\n".into())
+        );
+        assert_eq!(
+            or_replace_comment(resolve(&f(Some("same")), &f(Some("same")))),
+            None
+        );
+    }
+
+    #[test]
+    fn view_comment_removal_clears_it() {
+        let v = |comment: Option<&str>| -> Definition {
+            let mut value = serde_json::json!({
+                "name": "v", "schema": "test", "owner": "postgres",
+                "query": "SELECT 1",
+            });
+            if let Some(comment) = comment {
+                value["comment"] = comment.into();
+            }
+            Definition::View(serde_json::from_value(value).unwrap())
+        };
+        assert_eq!(
+            or_replace_comment(resolve(&v(None), &v(Some("old")))),
+            Some("COMMENT ON VIEW test.v IS NULL;\n".into())
+        );
     }
 
     fn view_with_columns(columns: serde_json::Value) -> Definition {
@@ -1038,7 +1126,7 @@ mod tests {
                 &view_with_columns(serde_json::json!(["a", "b"])),
                 &view_with_columns(serde_json::json!(["a"])),
             ),
-            Resolution::OrReplace
+            Resolution::OrReplace { .. }
         ));
     }
 

--- a/src/deploy/alter.rs
+++ b/src/deploy/alter.rs
@@ -12,7 +12,7 @@ use crate::build;
 use crate::deploy::diff::canonical_type;
 use crate::models::{
     CheckConstraint, Column, Definition, Domain, Extension, ForeignKey, Index,
-    Schema, Sequence, Table, Trigger, Type,
+    Schema, Sequence, Table, Trigger, Type, View, ViewColumn,
 };
 use crate::utils::quote_ident;
 
@@ -74,13 +74,53 @@ pub(crate) fn resolve(repo: &Definition, database: &Definition) -> Resolution {
                 Resolution::Replace
             }
         }
-        (Definition::View(_), Definition::View(_)) => Resolution::OrReplace,
+        (Definition::View(repo), Definition::View(db)) => view(repo, db),
         _ => Resolution::Replace,
     }
 }
 
 fn qualified(schema: &str, name: &str) -> String {
     format!("{}.{}", quote_ident(schema), quote_ident(name))
+}
+
+/// CREATE OR REPLACE VIEW only succeeds when the new query's output
+/// columns stay compatible with the existing view: same names in the
+/// same order, with new columns added only at the end. A rename,
+/// reorder, or removal must fall back to the gated drop+recreate path.
+/// Column types can also force a drop, but the project model does not
+/// carry view column types, so only the name-level guard is applied
+/// here.
+fn view(repo: &View, db: &View) -> Resolution {
+    if view_columns_compatible(repo, db) {
+        Resolution::OrReplace
+    } else {
+        Resolution::Replace
+    }
+}
+
+fn view_column_name(column: &ViewColumn) -> &str {
+    match column {
+        ViewColumn::Name(name) => name,
+        ViewColumn::Detailed { name, .. } => name,
+    }
+}
+
+/// True when `repo`'s columns are the `db` columns optionally followed
+/// by additional columns (the only mutation CREATE OR REPLACE VIEW
+/// permits). Absent column metadata on either side is treated as
+/// unknown, so the caller keeps the existing OR REPLACE behavior
+/// rather than forcing an unnecessary drop.
+fn view_columns_compatible(repo: &View, db: &View) -> bool {
+    let (Some(repo_cols), Some(db_cols)) = (&repo.columns, &db.columns) else {
+        return true;
+    };
+    if repo_cols.len() < db_cols.len() {
+        return false;
+    }
+    repo_cols
+        .iter()
+        .zip(db_cols.iter())
+        .all(|(r, d)| view_column_name(r) == view_column_name(d))
 }
 
 fn table(repo: &Table, db: &Table) -> Resolution {
@@ -978,6 +1018,60 @@ mod tests {
         assert!(matches!(
             resolve(&v("SELECT 2"), &v("SELECT 1")),
             Resolution::OrReplace
+        ));
+    }
+
+    fn view_with_columns(columns: serde_json::Value) -> Definition {
+        Definition::View(
+            serde_json::from_value(serde_json::json!({
+                "name": "v", "schema": "test", "owner": "postgres",
+                "query": "SELECT 1", "columns": columns,
+            }))
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn view_appended_column_uses_or_replace() {
+        assert!(matches!(
+            resolve(
+                &view_with_columns(serde_json::json!(["a", "b"])),
+                &view_with_columns(serde_json::json!(["a"])),
+            ),
+            Resolution::OrReplace
+        ));
+    }
+
+    #[test]
+    fn view_renamed_column_replaces() {
+        assert!(matches!(
+            resolve(
+                &view_with_columns(serde_json::json!(["a", "c"])),
+                &view_with_columns(serde_json::json!(["a", "b"])),
+            ),
+            Resolution::Replace
+        ));
+    }
+
+    #[test]
+    fn view_reordered_column_replaces() {
+        assert!(matches!(
+            resolve(
+                &view_with_columns(serde_json::json!(["b", "a"])),
+                &view_with_columns(serde_json::json!(["a", "b"])),
+            ),
+            Resolution::Replace
+        ));
+    }
+
+    #[test]
+    fn view_removed_column_replaces() {
+        assert!(matches!(
+            resolve(
+                &view_with_columns(serde_json::json!(["a"])),
+                &view_with_columns(serde_json::json!(["a", "b"])),
+            ),
+            Resolution::Replace
         ));
     }
 

--- a/src/deploy/alter.rs
+++ b/src/deploy/alter.rs
@@ -520,7 +520,8 @@ fn enum_type(repo: &Type, db: &Type) -> Resolution {
     let mut alters: Vec<Alter> = repo_values[db_values.len()..]
         .iter()
         .map(|value| {
-            Alter::new(format!("ALTER TYPE {name} ADD VALUE '{value}';\n"))
+            let escaped = value.replace('\'', "''");
+            Alter::new(format!("ALTER TYPE {name} ADD VALUE '{escaped}';\n"))
         })
         .collect();
     if repo.comment != db.comment {
@@ -1016,6 +1017,22 @@ mod tests {
         assert_eq!(
             sql(&alters),
             vec!["ALTER TYPE test.state ADD VALUE 'c';\n"]
+        );
+    }
+
+    #[test]
+    fn enum_append_escapes_single_quotes() {
+        let db: Type = serde_json::from_value(serde_json::json!({
+            "name": "state", "schema": "test", "owner": "postgres",
+            "type": "enum", "enum": ["a"],
+        }))
+        .unwrap();
+        let mut repo = db.clone();
+        repo.enum_values = Some(vec!["a".into(), "can't".into()]);
+        let alters = statements(enum_type(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec!["ALTER TYPE test.state ADD VALUE 'can''t';\n"]
         );
     }
 

--- a/src/deploy/alter.rs
+++ b/src/deploy/alter.rs
@@ -11,7 +11,8 @@
 use crate::build;
 use crate::deploy::diff::canonical_type;
 use crate::models::{
-    CheckConstraint, Column, Definition, ForeignKey, Index, Table, Trigger,
+    CheckConstraint, Column, Definition, Domain, Extension, ForeignKey, Index,
+    Schema, Sequence, Table, Trigger, Type,
 };
 use crate::utils::quote_ident;
 
@@ -41,6 +42,10 @@ impl Alter {
 pub(crate) enum Resolution {
     /// Reconcile in place with these statements
     Statements(Vec<Alter>),
+    /// Re-issue the object's CREATE as `CREATE OR REPLACE` (functions
+    /// and views); non-destructive, the caller rewrites the entry's
+    /// leading verb
+    OrReplace,
     /// No in-place form exists (or is implemented yet): drop and
     /// recreate from the repo definition, gated behind --allow-drop
     Replace,
@@ -49,9 +54,27 @@ pub(crate) enum Resolution {
 /// Resolve a changed object into in-place statements where supported
 pub(crate) fn resolve(repo: &Definition, database: &Definition) -> Resolution {
     match (repo, database) {
-        (Definition::Table(repo), Definition::Table(database)) => {
-            table(repo, database)
+        (Definition::Table(repo), Definition::Table(db)) => table(repo, db),
+        (Definition::Sequence(repo), Definition::Sequence(db)) => {
+            sequence(repo, db)
         }
+        (Definition::Domain(repo), Definition::Domain(db)) => domain(repo, db),
+        (Definition::Type(repo), Definition::Type(db)) => enum_type(repo, db),
+        (Definition::Extension(repo), Definition::Extension(db)) => {
+            extension(repo, db)
+        }
+        (Definition::Schema(repo), Definition::Schema(db)) => schema(repo, db),
+        // CREATE OR REPLACE handles function bodies and view queries
+        // in place; a function whose return type changed cannot be
+        // replaced and must be dropped first
+        (Definition::Function(repo), Definition::Function(db)) => {
+            if repo.returns == db.returns {
+                Resolution::OrReplace
+            } else {
+                Resolution::Replace
+            }
+        }
+        (Definition::View(_), Definition::View(_)) => Resolution::OrReplace,
         _ => Resolution::Replace,
     }
 }
@@ -377,6 +400,185 @@ fn triggers(
     true
 }
 
+/// Sequence reconciliation: a single ALTER SEQUENCE of the changed
+/// options, plus a comment delta. Every sequence property is
+/// alterable in place, so this never falls back to a rebuild.
+fn sequence(repo: &Sequence, db: &Sequence) -> Resolution {
+    if repo.sql != db.sql {
+        return Resolution::Replace;
+    }
+    let name = qualified(&repo.schema, &repo.name);
+    let mut clauses: Vec<String> = Vec::new();
+    if repo.data_type != db.data_type
+        && let Some(data_type) = &repo.data_type
+    {
+        clauses.push(format!("AS {data_type}"));
+    }
+    if repo.increment_by != db.increment_by
+        && let Some(increment) = repo.increment_by
+    {
+        clauses.push(format!("INCREMENT BY {increment}"));
+    }
+    if repo.min_value != db.min_value {
+        clauses.push(match repo.min_value {
+            Some(min) => format!("MINVALUE {min}"),
+            None => "NO MINVALUE".into(),
+        });
+    }
+    if repo.max_value != db.max_value {
+        clauses.push(match repo.max_value {
+            Some(max) => format!("MAXVALUE {max}"),
+            None => "NO MAXVALUE".into(),
+        });
+    }
+    if repo.start_with != db.start_with
+        && let Some(start) = repo.start_with
+    {
+        clauses.push(format!("START WITH {start}"));
+    }
+    if repo.cache != db.cache
+        && let Some(cache) = repo.cache
+    {
+        clauses.push(format!("CACHE {cache}"));
+    }
+    if repo.cycle != db.cycle {
+        clauses.push(if repo.cycle == Some(true) {
+            "CYCLE".into()
+        } else {
+            "NO CYCLE".into()
+        });
+    }
+    if repo.owned_by != db.owned_by {
+        clauses.push(match &repo.owned_by {
+            Some(owner) => format!("OWNED BY {owner}"),
+            None => "OWNED BY NONE".into(),
+        });
+    }
+    let mut alters = Vec::new();
+    if !clauses.is_empty() {
+        alters.push(Alter::new(format!(
+            "ALTER SEQUENCE {name} {};\n",
+            clauses.join(" ")
+        )));
+    }
+    if repo.comment != db.comment {
+        alters.push(Alter::new(comment_on(
+            "SEQUENCE",
+            &name,
+            repo.comment.as_deref(),
+        )));
+    }
+    Resolution::Statements(alters)
+}
+
+/// Domain reconciliation: SET/DROP DEFAULT and a comment delta in
+/// place. A base-type, collation, or constraint change rebuilds (the
+/// domain's constraints are not all individually named).
+fn domain(repo: &Domain, db: &Domain) -> Resolution {
+    if repo.sql != db.sql
+        || repo.data_type != db.data_type
+        || repo.collation != db.collation
+        || repo.check_constraints != db.check_constraints
+    {
+        return Resolution::Replace;
+    }
+    let name = qualified(&repo.schema, &repo.name);
+    let mut alters = Vec::new();
+    if repo.default != db.default {
+        alters.push(Alter::new(match &repo.default {
+            Some(default) => {
+                format!("ALTER DOMAIN {name} SET DEFAULT {default};\n")
+            }
+            None => format!("ALTER DOMAIN {name} DROP DEFAULT;\n"),
+        }));
+    }
+    if repo.comment != db.comment {
+        alters.push(Alter::new(comment_on(
+            "DOMAIN",
+            &name,
+            repo.comment.as_deref(),
+        )));
+    }
+    Resolution::Statements(alters)
+}
+
+/// Enum reconciliation: append-only value additions via ALTER TYPE
+/// ADD VALUE. Any other change (reordering, insertion, removal, or a
+/// non-enum type kind) rebuilds.
+fn enum_type(repo: &Type, db: &Type) -> Resolution {
+    let (Some(repo_values), Some(db_values)) =
+        (&repo.enum_values, &db.enum_values)
+    else {
+        return Resolution::Replace;
+    };
+    // the database values must be an unchanged prefix of the repo's;
+    // only trailing additions can be expressed with ADD VALUE
+    if !repo_values.starts_with(db_values) {
+        return Resolution::Replace;
+    }
+    let name = qualified(&repo.schema, &repo.name);
+    let mut alters: Vec<Alter> = repo_values[db_values.len()..]
+        .iter()
+        .map(|value| {
+            Alter::new(format!("ALTER TYPE {name} ADD VALUE '{value}';\n"))
+        })
+        .collect();
+    if repo.comment != db.comment {
+        alters.push(Alter::new(comment_on(
+            "TYPE",
+            &name,
+            repo.comment.as_deref(),
+        )));
+    }
+    Resolution::Statements(alters)
+}
+
+/// Extension reconciliation: ALTER EXTENSION ... UPDATE/SET SCHEMA.
+fn extension(repo: &Extension, db: &Extension) -> Resolution {
+    let name = quote_ident(&repo.name);
+    let mut alters = Vec::new();
+    if repo.version != db.version
+        && let Some(version) = &repo.version
+    {
+        alters.push(Alter::new(format!(
+            "ALTER EXTENSION {name} UPDATE TO '{version}';\n"
+        )));
+    }
+    if repo.schema != db.schema
+        && let Some(schema) = &repo.schema
+    {
+        alters.push(Alter::new(format!(
+            "ALTER EXTENSION {name} SET SCHEMA {};\n",
+            quote_ident(schema)
+        )));
+    }
+    if repo.comment != db.comment {
+        alters.push(Alter::new(comment_on(
+            "EXTENSION",
+            &name,
+            repo.comment.as_deref(),
+        )));
+    }
+    Resolution::Statements(alters)
+}
+
+/// Schema reconciliation: only a comment delta is expressible in
+/// place; an owner/authorization change rebuilds.
+fn schema(repo: &Schema, db: &Schema) -> Resolution {
+    if repo.authorization != db.authorization {
+        return Resolution::Replace;
+    }
+    let mut alters = Vec::new();
+    if repo.comment != db.comment {
+        alters.push(Alter::new(comment_on(
+            "SCHEMA",
+            &quote_ident(&repo.name),
+            repo.comment.as_deref(),
+        )));
+    }
+    Resolution::Statements(alters)
+}
+
 /// `COMMENT ON <desc> <name> IS ...` matching the build's comment
 /// entry text shape; a removed comment becomes `IS NULL`
 fn comment_on(desc: &str, name: &str, comment: Option<&str>) -> String {
@@ -412,7 +614,7 @@ mod tests {
     fn statements(resolution: Resolution) -> Vec<Alter> {
         match resolution {
             Resolution::Statements(alters) => alters,
-            Resolution::Replace => panic!("expected in-place statements"),
+            _ => panic!("expected in-place statements"),
         }
     }
 
@@ -708,18 +910,173 @@ mod tests {
     }
 
     #[test]
-    fn non_table_definitions_replace() {
-        let schema: models::Schema =
-            serde_json::from_value(serde_json::json!(
-                {"name": "test", "owner": "postgres"}
-            ))
+    fn unsupported_definitions_replace() {
+        // a materialized view has no in-place form
+        let mview: models::MaterializedView =
+            serde_json::from_value(serde_json::json!({
+                "name": "m", "schema": "test", "owner": "postgres",
+                "query": "SELECT 1",
+            }))
             .unwrap();
         assert!(matches!(
             resolve(
-                &Definition::Schema(schema.clone()),
-                &Definition::Schema(schema)
+                &Definition::MaterializedView(mview.clone()),
+                &Definition::MaterializedView(mview)
             ),
             Resolution::Replace
         ));
+    }
+
+    #[test]
+    fn function_body_change_uses_or_replace() {
+        let f = |body: &str| -> Definition {
+            Definition::Function(
+                serde_json::from_value(serde_json::json!({
+                    "name": "f", "schema": "test", "owner": "postgres",
+                    "returns": "integer", "language": "sql",
+                    "definition": body,
+                }))
+                .unwrap(),
+            )
+        };
+        assert!(matches!(
+            resolve(&f("SELECT 2"), &f("SELECT 1")),
+            Resolution::OrReplace
+        ));
+    }
+
+    #[test]
+    fn function_return_type_change_replaces() {
+        let f = |returns: &str| -> Definition {
+            Definition::Function(
+                serde_json::from_value(serde_json::json!({
+                    "name": "f", "schema": "test", "owner": "postgres",
+                    "returns": returns, "language": "sql",
+                    "definition": "SELECT 1",
+                }))
+                .unwrap(),
+            )
+        };
+        assert!(matches!(
+            resolve(&f("bigint"), &f("integer")),
+            Resolution::Replace
+        ));
+    }
+
+    #[test]
+    fn view_change_uses_or_replace() {
+        let v = |query: &str| -> Definition {
+            Definition::View(
+                serde_json::from_value(serde_json::json!({
+                    "name": "v", "schema": "test", "owner": "postgres",
+                    "query": query,
+                }))
+                .unwrap(),
+            )
+        };
+        assert!(matches!(
+            resolve(&v("SELECT 2"), &v("SELECT 1")),
+            Resolution::OrReplace
+        ));
+    }
+
+    fn parse_sequence(value: serde_json::Value) -> Sequence {
+        serde_json::from_value(value).expect("sequence deserializes")
+    }
+
+    #[test]
+    fn sequence_options_render_one_alter() {
+        let base = serde_json::json!({
+            "name": "s", "schema": "test", "owner": "postgres",
+            "increment_by": 1, "cache": 1,
+        });
+        let mut repo = base.clone();
+        repo["increment_by"] = 2.into();
+        repo["max_value"] = 100.into();
+        repo["cycle"] = true.into();
+        let alters =
+            statements(sequence(&parse_sequence(repo), &parse_sequence(base)));
+        assert_eq!(
+            sql(&alters),
+            vec!["ALTER SEQUENCE test.s INCREMENT BY 2 MAXVALUE 100 CYCLE;\n"]
+        );
+        assert!(alters.iter().all(|a| !a.destructive));
+    }
+
+    #[test]
+    fn enum_append_adds_values() {
+        let db: Type = serde_json::from_value(serde_json::json!({
+            "name": "state", "schema": "test", "owner": "postgres",
+            "type": "enum", "enum": ["a", "b"],
+        }))
+        .unwrap();
+        let mut repo = db.clone();
+        repo.enum_values = Some(vec!["a".into(), "b".into(), "c".into()]);
+        let alters = statements(enum_type(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec!["ALTER TYPE test.state ADD VALUE 'c';\n"]
+        );
+    }
+
+    #[test]
+    fn enum_reorder_replaces() {
+        let db: Type = serde_json::from_value(serde_json::json!({
+            "name": "state", "schema": "test", "owner": "postgres",
+            "type": "enum", "enum": ["a", "b"],
+        }))
+        .unwrap();
+        let mut repo = db.clone();
+        repo.enum_values = Some(vec!["b".into(), "a".into()]);
+        assert!(matches!(enum_type(&repo, &db), Resolution::Replace));
+    }
+
+    #[test]
+    fn extension_version_change_updates() {
+        let db: Extension = serde_json::from_value(serde_json::json!({
+            "name": "citext", "version": "1.0",
+        }))
+        .unwrap();
+        let mut repo = db.clone();
+        repo.version = Some("1.6".into());
+        let alters = statements(extension(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec!["ALTER EXTENSION citext UPDATE TO '1.6';\n"]
+        );
+    }
+
+    #[test]
+    fn domain_default_changes_in_place_base_type_replaces() {
+        let db: Domain = serde_json::from_value(serde_json::json!({
+            "name": "d", "schema": "test", "owner": "postgres",
+            "data_type": "text",
+        }))
+        .unwrap();
+        let mut repo = db.clone();
+        repo.default = Some("'x'".into());
+        let alters = statements(domain(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec!["ALTER DOMAIN test.d SET DEFAULT 'x';\n"]
+        );
+        let mut retyped = db.clone();
+        retyped.data_type = Some("citext".into());
+        assert!(matches!(domain(&retyped, &db), Resolution::Replace));
+    }
+
+    #[test]
+    fn schema_comment_changes_in_place() {
+        let db: Schema = serde_json::from_value(serde_json::json!({
+            "name": "test", "owner": "postgres",
+        }))
+        .unwrap();
+        let mut repo = db.clone();
+        repo.comment = Some("App schema".into());
+        let alters = statements(schema(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec!["COMMENT ON SCHEMA test IS $$App schema$$;\n"]
+        );
     }
 }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -42,7 +42,49 @@ pub fn deploy(args: &cli::Deploy) -> Result<(), String> {
     output.dump.sort_entries();
     let plan = plan(&diff, &resolutions, &output, &snapshot, args)?;
     report(&diff, &plan);
-    write_script(&plan, &project.name, &source, args)
+    let script = render_script(&plan, &project.name, &source);
+    if let Some(path) = &args.output {
+        std::fs::write(path, &script)
+            .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+    } else if !args.apply {
+        print!("{script}");
+    }
+    if args.apply {
+        apply(&plan, &script, args)?;
+    }
+    Ok(())
+}
+
+/// Execute the plan against the database via psql, refusing if
+/// destructive statements were excluded
+fn apply(plan: &Plan, script: &str, args: &cli::Deploy) -> Result<(), String> {
+    if !plan.excluded.is_empty() {
+        return Err(format!(
+            "{} destructive statement(s) are pending; re-run with \
+             --allow-drop to apply them, or resolve them first",
+            plan.excluded.len()
+        ));
+    }
+    if plan.included.is_empty() {
+        log::info!(
+            "The database already matches the project; nothing to apply"
+        );
+        return Ok(());
+    }
+    let file = tempfile::Builder::new()
+        .prefix("pglifecycle-deploy-")
+        .suffix(".sql")
+        .tempfile()
+        .map_err(|e| format!("failed to create temp file: {e}"))?;
+    std::fs::write(file.path(), script).map_err(|e| {
+        format!("failed to write {}: {e}", file.path().display())
+    })?;
+    log::info!("Applying {} statement(s)", plan.included.len());
+    pgdump::apply(&args.connection, file.path()).map_err(|stderr| {
+        format!("deploy failed (the transaction was rolled back):\n{stderr}")
+    })?;
+    log::info!("Deploy applied successfully");
+    Ok(())
 }
 
 /// Resolve each changed item into in-place statements or the
@@ -180,8 +222,9 @@ fn plan(
         {
             continue;
         }
-        // the object's own entry: emit its in-place statements, or
-        // lead with its DROP for the drop+recreate fallback
+        // the object's own entry: emit its in-place statements,
+        // re-issue it as CREATE OR REPLACE, or lead with its DROP for
+        // the drop+recreate fallback
         if let Some(id) = direct {
             match resolutions.get(id) {
                 Some(Resolution::Statements(alters)) => {
@@ -195,6 +238,13 @@ fn plan(
                         );
                     }
                 }
+                Some(Resolution::OrReplace) => push(
+                    false,
+                    Statement {
+                        label,
+                        sql: defn.replacen("CREATE ", "CREATE OR REPLACE ", 1),
+                    },
+                ),
                 _ => {
                     let mut sql = String::new();
                     if let Some(drop) = &entry.drop_stmt {
@@ -206,15 +256,28 @@ fn plan(
             }
             continue;
         }
-        // child entries (indexes, triggers, comments, ACLs): ride
-        // along only with a drop+recreate — in-place resolutions
-        // reconcile their children themselves
-        let replace = owners.iter().any(|id| {
+        // child entries (indexes, triggers, comments, ACLs): a
+        // drop+recreate parent recreates them all (gated with it); an
+        // OR REPLACE parent keeps the object, so only its COMMENT may
+        // need re-issuing (idempotent, ungated); in-place ALTERs
+        // reconcile their own children
+        let is_comment = entry.desc == libpgdump::ObjectType::Comment;
+        let replaced = owners.iter().any(|id| {
             diff.items.get(id) == Some(&Change::Changed)
                 && matches!(resolutions.get(id), Some(Resolution::Replace))
         });
-        if replace {
+        let or_replaced_comment = is_comment
+            && owners.iter().any(|id| {
+                diff.items.get(id) == Some(&Change::Changed)
+                    && matches!(
+                        resolutions.get(id),
+                        Some(Resolution::OrReplace)
+                    )
+            });
+        if replaced {
             push(true, Statement { label, sql: defn });
+        } else if or_replaced_comment {
+            push(false, Statement { label, sql: defn });
         }
     }
     Ok(Plan {
@@ -253,14 +316,8 @@ fn report(diff: &Diff, plan: &Plan) {
     );
 }
 
-/// Write the script to `--output` or stdout with a self-describing
-/// header
-fn write_script(
-    plan: &Plan,
-    project: &str,
-    source: &str,
-    args: &cli::Deploy,
-) -> Result<(), String> {
+/// Render the script with a self-describing header
+fn render_script(plan: &Plan, project: &str, source: &str) -> String {
     let mut script = format!(
         "-- pglifecycle deploy\n-- project: {project}\n-- source: \
          {source}\n"
@@ -286,14 +343,7 @@ fn write_script(
         script
             .push_str(&format!("\n-- {}\n{}", statement.label, statement.sql));
     }
-    match &args.output {
-        Some(path) => std::fs::write(path, script)
-            .map_err(|e| format!("failed to write {}: {e}", path.display())),
-        None => {
-            print!("{script}");
-            Ok(())
-        }
-    }
+    script
 }
 
 /// `DROP <type> IF EXISTS <name>` for a database-only object

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -238,13 +238,30 @@ fn plan(
                         );
                     }
                 }
-                Some(Resolution::OrReplace) => push(
-                    false,
-                    Statement {
-                        label,
-                        sql: defn.replacen("CREATE ", "CREATE OR REPLACE ", 1),
-                    },
-                ),
+                Some(Resolution::OrReplace { comment }) => {
+                    push(
+                        false,
+                        Statement {
+                            label: label.clone(),
+                            sql: defn.replacen(
+                                "CREATE ",
+                                "CREATE OR REPLACE ",
+                                1,
+                            ),
+                        },
+                    );
+                    // CREATE OR REPLACE keeps the existing comment, so a
+                    // changed or removed one is reconciled separately
+                    if let Some(comment) = comment {
+                        push(
+                            false,
+                            Statement {
+                                label,
+                                sql: comment.clone(),
+                            },
+                        );
+                    }
+                }
                 _ => {
                     let mut sql = String::new();
                     if let Some(drop) = &entry.drop_stmt {
@@ -258,26 +275,15 @@ fn plan(
         }
         // child entries (indexes, triggers, comments, ACLs): a
         // drop+recreate parent recreates them all (gated with it); an
-        // OR REPLACE parent keeps the object, so only its COMMENT may
-        // need re-issuing (idempotent, ungated); in-place ALTERs
-        // reconcile their own children
-        let is_comment = entry.desc == libpgdump::ObjectType::Comment;
+        // OR REPLACE parent reconciles its own comment from its
+        // resolution (so removals clear, not just changes); in-place
+        // ALTERs reconcile their own children
         let replaced = owners.iter().any(|id| {
             diff.items.get(id) == Some(&Change::Changed)
                 && matches!(resolutions.get(id), Some(Resolution::Replace))
         });
-        let or_replaced_comment = is_comment
-            && owners.iter().any(|id| {
-                diff.items.get(id) == Some(&Change::Changed)
-                    && matches!(
-                        resolutions.get(id),
-                        Some(Resolution::OrReplace)
-                    )
-            });
         if replaced {
             push(true, Statement { label, sql: defn });
-        } else if or_replaced_comment {
-            push(false, Statement { label, sql: defn });
         }
     }
     Ok(Plan {

--- a/src/pgdump.rs
+++ b/src/pgdump.rs
@@ -1,7 +1,7 @@
 //! pg_dump / pg_dumpall subprocess wrappers (ports pgdump.py)
 
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::cli;
 
@@ -57,6 +57,10 @@ pub fn dump_roles(conn: &cli::Connection, path: &Path) -> Result<(), String> {
 pub fn apply(conn: &cli::Connection, script: &Path) -> Result<(), String> {
     let mut command = Command::new("psql");
     connection_args(&mut command, conn);
+    // connection_args may add -W when a password prompt is requested;
+    // inherit stdin so psql can read the prompted password (output()
+    // otherwise closes stdin)
+    command.stdin(Stdio::inherit());
     if let Some(dbname) = &conn.dbname {
         command.arg("-d").arg(dbname);
     }

--- a/src/pgdump.rs
+++ b/src/pgdump.rs
@@ -51,6 +51,32 @@ pub fn dump_roles(conn: &cli::Connection, path: &Path) -> Result<(), String> {
     execute(command)
 }
 
+/// Apply a SQL script to the database in a single transaction via
+/// `psql`, aborting on the first error. Returns psql's stderr on
+/// failure so the caller can map it back to a statement.
+pub fn apply(conn: &cli::Connection, script: &Path) -> Result<(), String> {
+    let mut command = Command::new("psql");
+    connection_args(&mut command, conn);
+    if let Some(dbname) = &conn.dbname {
+        command.arg("-d").arg(dbname);
+    }
+    command.arg("-X");
+    command.arg("-q");
+    command.arg("--single-transaction");
+    command.arg("-v").arg("ON_ERROR_STOP=1");
+    command.arg("-f").arg(script);
+    log::debug!("Executing {command:?}");
+    let output = command.output().map_err(|e| {
+        format!("failed to run {:?}: {e}", command.get_program())
+    })?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr)
+            .trim()
+            .to_string());
+    }
+    Ok(())
+}
+
 fn connection_args(command: &mut Command, conn: &cli::Connection) {
     command.arg("-h").arg(&conn.host);
     command.arg("-p").arg(conn.port.to_string());

--- a/tests/deploy.rs
+++ b/tests/deploy.rs
@@ -100,7 +100,7 @@ fn missing_objects_are_created() {
 }
 
 #[test]
-fn table_reconciles_in_place_function_replaces() {
+fn table_alters_in_place_function_or_replaces() {
     let dir = tempfile::tempdir().unwrap();
     let baseline = dir.path().join("fixtures.dump");
     fixture_archive(&baseline);
@@ -121,15 +121,19 @@ fn table_reconciles_in_place_function_replaces() {
         script.contains("ALTER TABLE test.users DROP COLUMN nickname;"),
         "missing in-place column drop in:\n{script}"
     );
-    // the function has no in-place renderer yet, so it drop+recreates
-    // from the repo body
+    // the function (same signature, changed body) is replaced in place
+    // with CREATE OR REPLACE, not dropped
     assert!(
-        script.contains("DROP FUNCTION IF EXISTS"),
-        "missing function replace in:\n{script}"
+        !script.contains("DROP FUNCTION"),
+        "function must use CREATE OR REPLACE, not drop:\n{script}"
+    );
+    assert!(
+        script.contains("CREATE OR REPLACE FUNCTION set_last_modified"),
+        "missing function OR REPLACE in:\n{script}"
     );
     assert!(
         script.contains("CURRENT_TIMESTAMP"),
-        "recreated function must use the repo body:\n{script}"
+        "replaced function must use the repo body:\n{script}"
     );
 }
 


### PR DESCRIPTION
## Summary
Final slice of PLAN.md Phase 6: in-place renderers for the remaining object types, optional direct execution (`--apply`), and the three Phase 6 gate checks.

**Stacked on #25 → #24 → #23**; only the last commit is new here.

## Problem
PR #25 added in-place reconciliation for tables; every other changed object type still fell back to the gated drop+recreate. Deploy also had no way to execute its script directly, and no end-to-end gate proving it converges against a real database.

## Solution
**Renderers** — changed objects beyond tables now reconcile in place:
- **Functions and views** via `CREATE OR REPLACE` (new `Resolution::OrReplace` rewrites the build entry's leading verb). A function whose return type changed can't be replaced, so it drops first.
- **Sequences** via a single `ALTER SEQUENCE` of the changed options.
- **Domains** via `SET`/`DROP DEFAULT` (base-type or constraint change rebuilds).
- **Enum types** via `ALTER TYPE ... ADD VALUE` for appended values (reorder/removal rebuilds).
- **Extensions** via `ALTER EXTENSION ... UPDATE` / `SET SCHEMA`.
- Schemas (comment) in place; everything else falls back to drop+recreate.

**`--apply`** executes the script in one transaction via `psql -X -q --single-transaction -v ON_ERROR_STOP=1`, refusing while gated drops are pending and surfacing psql's stderr on a rolled-back failure. It conflicts with `--dump`. The default is unchanged — emit the script only — so the CI artifact workflow still works.

**`bin/deploy-gates`** runs the three Phase 6 gates against the compose.yaml PostgreSQL:
1. *Equivalence* — `deploy --apply` into an empty database matches `build` + `pg_restore` (schema-only dumps are identical).
2. *Convergence* — mutate the database, `deploy --apply --allow-drop`, then a re-deploy is an empty plan.
3. *Safety* — without `--allow-drop` the script has no destructive statements and `--apply` refuses.

`docs/commands.md` documents the reconciliation matrix, gating, `--apply`, and the ownership/role/privilege limits.

**Comment removal on `CREATE OR REPLACE` objects** — `CREATE OR REPLACE` preserves an object's existing comment, so a function/view whose comment was removed in the repo never converged. The comment delta now rides on `Resolution::OrReplace` (computed by the resolver from the repo vs database comments) and is emitted after the `CREATE OR REPLACE`, including the `IS NULL` form on removal; the convergence gate adds a database-only view comment that must be cleared. Closes #28.

## Impact
Deploy now reconciles the common drift cases in place without `--allow-drop`, and can optionally apply directly. Privilege changes on existing objects are still not diffed (documented); that and the unmodeled object types are the remaining v1 boundaries.

## Testing
`cargo test` (100 lib + integration tests) and clippy clean. All three `bin/deploy-gates` checks pass against the Docker PostgreSQL 17 (`PGPORT=32768`), including the new comment-removal convergence case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--apply` mode to execute generated migrations in a single transaction (rolls back on error) and refuse execution when gated destructive changes are pending.
  * Expanded in-place reconciliation so functions/views can use `CREATE OR REPLACE`, and sequences/domains/enums/extensions/schemas gain targeted non-destructive updates.
  * Added a new `deploy-gates` script to validate equivalence, convergence, and safety behavior across gates.

* **Tests**
  * Updated deployment integration tests to reflect in-place function updates and revised expectations.

* **Documentation**
  * Expanded `deploy` command documentation, including `--apply`/`--dump` behavior and updated safety/destructive rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
