### PR TITLE
pull: emit role settings (closes #20)

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -874,7 +874,47 @@ impl Builder {
         } else {
             vec!["DROP ROLE IF EXISTS".into(), quote_ident(&d.name)]
         };
-        self.add_item(item, create, drop, false)
+        self.add_item(item, create, drop, false)?;
+        self.dump_role_settings(item, "ROLE", &d.name, d.settings.as_deref())
+    }
+
+    /// Emit one `ALTER ROLE|USER name SET guc TO value` entry per
+    /// setting, each depending on the role/user create entry so the
+    /// topological sort applies it after the role exists
+    fn dump_role_settings(
+        &mut self,
+        item: &Item,
+        keyword: &str,
+        name: &str,
+        settings: Option<&[Map<String, Value>]>,
+    ) -> Result<(), String> {
+        let Some(settings) = settings else {
+            return Ok(());
+        };
+        let Some(&parent_dump_id) = self.dump_id_map.get(&item.id) else {
+            return Ok(());
+        };
+        let owner = self.superuser.clone();
+        for object in settings {
+            for (setting, value) in object {
+                let defn = vec![format!(
+                    "ALTER {keyword} {} SET {setting} TO {}",
+                    quote_ident(name),
+                    render_setting_value(value)
+                )];
+                self.add_entry(
+                    keyword,
+                    "",
+                    name,
+                    &owner,
+                    &defn,
+                    &[],
+                    &[parent_dump_id],
+                    None,
+                )?;
+            }
+        }
+        Ok(())
     }
 
     fn dump_schema(&mut self, item: &Item) -> Result<(), String> {
@@ -1670,7 +1710,8 @@ impl Builder {
         } else {
             vec!["DROP USER IF EXISTS".into(), quote_ident(&d.name)]
         };
-        self.add_item(item, create, drop, false)
+        self.add_item(item, create, drop, false)?;
+        self.dump_role_settings(item, "USER", &d.name, d.settings.as_deref())
     }
 
     fn dump_user_mapping(&mut self, item: &Item) -> Result<(), String> {
@@ -1767,6 +1808,24 @@ fn push_role_options(
         push_bool_option(sql, "LOGIN", options.login);
     }
     push_bool_option(sql, "SUPERUSER", options.superuser);
+}
+
+/// `ALTER ROLE ... SET guc TO value` value rendering: a list (e.g.
+/// `search_path`) joins its elements bare, a scalar renders as a
+/// single-quoted literal
+fn render_setting_value(value: &Value) -> String {
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .map(|item| match item {
+                Value::String(s) => s.clone(),
+                other => other.to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+        Value::String(s) => postgres_value(&Value::String(s.clone())),
+        other => other.to_string(),
+    }
 }
 
 /// DEFAULT clause rendering: strings that look like SQL expressions

--- a/src/ddl/acl.rs
+++ b/src/ddl/acl.rs
@@ -126,7 +126,7 @@ pub(crate) fn role_setting(
     Ok(Statement::AlterRoleSetting {
         role,
         name,
-        value: values.join(", "),
+        value: values,
     })
 }
 
@@ -505,7 +505,7 @@ mod tests {
         };
         assert_eq!(role, "app_user");
         assert_eq!(name, "search_path");
-        assert_eq!(value, "test, public");
+        assert_eq!(value, vec!["test", "public"]);
     }
 
     #[test]

--- a/src/ddl/mod.rs
+++ b/src/ddl/mod.rs
@@ -66,11 +66,12 @@ pub enum Statement {
     /// ALTER ROLE ... WITH options — the assembly merges these into
     /// the role created by CREATE ROLE
     AlterRole(RoleDef),
-    /// ALTER ROLE `role` SET `name` TO `value`
+    /// ALTER ROLE `role` SET `name` TO `value` — `value` keeps the
+    /// parsed elements (a single scalar or a list like `search_path`)
     AlterRoleSetting {
         role: String,
         name: String,
-        value: String,
+        value: Vec<String>,
     },
     /// Parsed successfully but not (yet) a supported statement type
     Unsupported(String),

--- a/src/models/roles.rs
+++ b/src/models/roles.rs
@@ -89,8 +89,10 @@ pub struct Role {
     pub revocations: Option<Acls>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<RoleOptions>,
+    /// `ALTER ROLE ... SET` parameters, as the schema's array of
+    /// `{ name: value }` objects (role.yml / user.yml `settings`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub settings: Option<Map<String, Value>>,
+    pub settings: Option<Vec<Map<String, Value>>>,
 }
 
 /// Options for a role or user
@@ -134,6 +136,8 @@ pub struct User {
     pub revocations: Option<Acls>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<RoleOptions>,
+    /// `ALTER ROLE ... SET` parameters, as the schema's array of
+    /// `{ name: value }` objects (role.yml / user.yml `settings`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub settings: Option<Map<String, Value>>,
+    pub settings: Option<Vec<Map<String, Value>>>,
 }

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -407,7 +407,16 @@ impl Assembly {
             Statement::CreateRole(def) => self.merge_role(def, true),
             Statement::AlterRole(def) => self.merge_role(def, false),
             Statement::AlterRoleSetting { role, name, value } => {
-                self.role(&role).settings.insert(name, Value::String(value));
+                // a single element stays a scalar; a list (e.g.
+                // search_path) keeps its elements so it round-trips as
+                // `SET search_path TO a, b` rather than one bogus value
+                let value = match value.as_slice() {
+                    [single] => Value::String(single.clone()),
+                    _ => Value::Array(
+                        value.into_iter().map(Value::String).collect(),
+                    ),
+                };
+                self.role(&role).settings.insert(name, value);
             }
             Statement::RoleMembership {
                 revoke,
@@ -1143,7 +1152,8 @@ mod tests {
                  CREATE ROLE readonly;\n\
                  ALTER ROLE readonly WITH NOLOGIN;\n\
                  GRANT readonly TO app GRANTED BY postgres;\n\
-                 ALTER ROLE app SET search_path TO test;\n\
+                 ALTER ROLE app SET search_path TO test, public;\n\
+                 ALTER ROLE app SET work_mem TO '64MB';\n\
                  \\unrestrict abc123\n",
             )
             .unwrap();
@@ -1154,12 +1164,104 @@ mod tests {
         assert_eq!(app.options.login, Some(true));
         assert_eq!(app.options.superuser, Some(false));
         assert_eq!(app.grants.roles, vec!["readonly"]);
+        // a multi-element setting keeps its list shape; a scalar stays
+        // a string
         assert_eq!(
             app.settings.get("search_path"),
-            Some(&Value::String("test".into()))
+            Some(&Value::Array(vec![
+                Value::String("test".into()),
+                Value::String("public".into()),
+            ]))
+        );
+        assert_eq!(
+            app.settings.get("work_mem"),
+            Some(&Value::String("64MB".into()))
         );
         let readonly = &assembly.roles["readonly"];
         assert!(readonly.created);
         assert_eq!(readonly.options.login, Some(false));
+    }
+
+    /// Role settings survive the full pull → write → load → build
+    /// path: emitted in the schema's array-of-objects shape (so the
+    /// project validates and loads), then rendered back as
+    /// `ALTER ROLE ... SET` entries in the build archive
+    #[test]
+    fn role_settings_round_trip_through_build() {
+        use clap::Parser;
+        let mut assembly = Assembly {
+            dbname: String::from("settings"),
+            ..Assembly::default()
+        };
+        assembly
+            .ingest_roles(
+                "CREATE ROLE app;\n\
+                 ALTER ROLE app SET search_path TO test, public;\n\
+                 ALTER ROLE app SET work_mem TO '64MB';\n",
+            )
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("project");
+        let dump = dir.path().join("unused.dump");
+        let args = match cli::Cli::try_parse_from([
+            "pglifecycle",
+            "pull",
+            "--dump",
+            dump.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .unwrap()
+        .action
+        {
+            cli::Action::Pull(args) => args,
+            _ => unreachable!(),
+        };
+        let files = writer::render(&assembly, &args).unwrap();
+        writer::write_bootstrap(&files, &args).unwrap();
+
+        // load validates each file against its schema, so a successful
+        // load proves the emitted settings shape matches role.yml
+        let project = crate::project::load(&dest).unwrap();
+        let role = project
+            .inventory
+            .iter()
+            .find_map(|item| match &item.definition {
+                models::Definition::Role(role) if role.name == "app" => {
+                    Some(role)
+                }
+                _ => None,
+            })
+            .expect("app role");
+        assert_eq!(
+            role.settings,
+            Some(vec![
+                serde_json::from_value(serde_json::json!({
+                    "search_path": ["test", "public"]
+                }))
+                .unwrap(),
+                serde_json::from_value(serde_json::json!({
+                    "work_mem": "64MB"
+                }))
+                .unwrap(),
+            ])
+        );
+
+        let archive = dir.path().join("settings.dump");
+        crate::build::build(&project, &archive).unwrap();
+        let built = libpgdump::load(&archive).unwrap();
+        let settings: Vec<&str> = built
+            .entries()
+            .iter()
+            .filter_map(|e| e.defn.as_deref())
+            .filter(|defn| defn.starts_with("ALTER ROLE"))
+            .collect();
+        assert_eq!(
+            settings,
+            vec![
+                "ALTER ROLE app SET search_path TO test, public;\n",
+                "ALTER ROLE app SET work_mem TO '64MB';\n",
+            ]
+        );
     }
 }

--- a/src/pull/writer.rs
+++ b/src/pull/writer.rs
@@ -211,15 +211,7 @@ impl Writer {
     /// distinguish groups)
     fn write_roles(&mut self, assembly: &Assembly) -> Result<(), String> {
         for (name, state) in &assembly.roles {
-            if !state.settings.is_empty() {
-                // role.yml declares settings as an array of objects but
-                // the model (and the Python build) expects a mapping;
-                // skip emission until the contract is reconciled
-                log::warn!(
-                    "Skipping settings for role {name}: not representable \
-                     in the current role schema"
-                );
-            }
+            let settings = role_settings(state);
             if state.password.is_some() || state.valid_until.is_some() {
                 let user = models::User {
                     name: name.clone(),
@@ -230,7 +222,7 @@ impl Writer {
                     grants: state.grants.to_acls(),
                     revocations: state.revocations.to_acls(),
                     options: user_options(state),
-                    settings: None,
+                    settings,
                 };
                 self.save(
                     Path::new("users").join(format!("{name}.yaml")),
@@ -246,7 +238,7 @@ impl Writer {
                     revocations: state.revocations.to_acls(),
                     options: (state.options != models::RoleOptions::default())
                         .then(|| state.options.clone()),
-                    settings: None,
+                    settings,
                 };
                 self.save(
                     Path::new("roles").join(format!("{name}.yaml")),
@@ -302,6 +294,27 @@ fn user_options(state: &RoleState) -> Option<models::RoleOptions> {
     let mut options = state.options.clone();
     options.login = None;
     (options != models::RoleOptions::default()).then_some(options)
+}
+
+/// Convert accumulated `ALTER ROLE ... SET` state (a `name → value`
+/// map) into the schema's `settings` array of single-key objects, one
+/// per parameter, ordered by name for a deterministic diff
+fn role_settings(state: &RoleState) -> Option<Vec<Map<String, Value>>> {
+    if state.settings.is_empty() {
+        return None;
+    }
+    let mut names: Vec<&String> = state.settings.keys().collect();
+    names.sort();
+    Some(
+        names
+            .into_iter()
+            .map(|name| {
+                let mut object = Map::new();
+                object.insert(name.clone(), state.settings[name].clone());
+                object
+            })
+            .collect(),
+    )
 }
 
 fn serialize<T: serde::Serialize>(value: &T) -> Result<Value, String> {


### PR DESCRIPTION
## Summary
Fixes #20 — `pglifecycle pull` was dropping `ALTER ROLE … SET` entries with a warning, and `build` never rendered role settings at all, so they were lost end-to-end.

## Problem
The internal `RoleState.settings` is a `Map<String, Value>`, but `schemata/role.yml` (and `user.yml`) declare `settings` as an **array of objects**. Because the model field was a mapping that didn't match the contract, `write_roles` skipped emission entirely. Even a hand-authored `settings:` block would then be silently ignored by `build`, which had no settings handling.

## Solution
- **models**: `Role`/`User` `settings` is now `Vec<Map<String, Value>>` — the schema's array of single-key `{ name: value }` objects — instead of a mapping.
- **ddl**: `Statement::AlterRoleSetting` carries the parsed values as a list, so a multi-element setting like `search_path` keeps its elements. pull stores a single value as a scalar string and a list as an array, so `SET search_path TO a, b` round-trips rather than collapsing into one bogus value.
- **pull/writer**: emits settings (sorted by name for a deterministic `git diff`) into the role/user file instead of skipping them.
- **build**: renders each setting as an `ALTER ROLE|USER name SET guc TO value` entry that depends on the role's create entry (so the topological sort applies it after the role exists). A list joins bare; a scalar renders as a quoted literal.

## Impact
Roles/users with `SET` parameters now round-trip through `pull` → project → `build`. No change for roles without settings (the new build path is a no-op when `settings` is `None`).

## Testing
- New `role_settings_round_trip_through_build` test covers the full pull → write → load (which validates against `role.yml`) → build → SQL path.
- The parsing test now exercises both a list (`search_path`) and a scalar (`work_mem`).
- Verified the generated `ALTER ROLE … SET` SQL applies cleanly against PostgreSQL 17, and `bin/round-trip` still passes (schema diff empty).

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing and preserving role and user settings during database migrations.
  * Settings with multiple values (e.g., `search_path`) are now correctly maintained as lists instead of being collapsed into single strings.

* **Bug Fixes**
  * Fixed role/user settings to properly round-trip during export and reimport operations, ensuring data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->