### PR TITLE
Add live progress indicator to pull

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +254,12 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -323,6 +341,30 @@ checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -524,6 +566,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif-log-bridge"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63703cf9069b85dbe6fe26e1c5230d013dee99d3559cd3d02ba39e099ef7ab02"
+dependencies = [
+ "indicatif",
+ "log",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -828,6 +894,8 @@ version = "2.0.0-alpha.0"
 dependencies = [
  "clap",
  "include_dir",
+ "indicatif",
+ "indicatif-log-bridge",
  "jsonschema",
  "libpgdump",
  "libpgfmt",
@@ -842,10 +910,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1095,6 +1175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,10 +1359,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml-norway"
@@ -1413,6 +1511,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +164,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -224,6 +239,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +260,18 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "displaydoc"
@@ -748,6 +786,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +892,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +958,7 @@ name = "pglifecycle"
 version = "2.0.0-alpha.0"
 dependencies = [
  "clap",
+ "ctrlc",
  "include_dir",
  "indicatif",
  "indicatif-log-bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.88"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
+ctrlc = "3.5.2"
 include_dir = "0.7.4"
 indicatif = "0.18.4"
 indicatif-log-bridge = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ rust-version = "1.88"
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 include_dir = "0.7.4"
+indicatif = "0.18.4"
+indicatif-log-bridge = "0.2.3"
 jsonschema = { version = "0.46.5", default-features = false }
 libpgdump = "2.1"
 libpgfmt = "1.1.2"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -121,6 +121,20 @@ pglifecycle pull [OPTIONS] DEST
 | `--gitkeep` | Create `.gitkeep` files in empty directories |
 | `--remove-empty-dirs` | Remove empty directories after generation |
 | `--save-remaining` | Save unprocessed dump entries to `remaining.yaml` |
+| `--error-file FILE` | Where to record failures and their DDL (default `pglifecycle-errors.log`) |
+
+### Diagnosing parse and format failures
+
+DDL that fails to parse, or SQL that fails to format, is logged and the
+offending statement is written to the error report (`--error-file`,
+default `pglifecycle-errors.log` in the working directory) alongside its
+full DDL, so a failure can be correlated with the exact statement that
+produced it. The file is created only when there is something to report.
+
+If `pull` is interrupted with Ctrl-C — for example because the formatter
+is stuck on a pathological statement — the statement in flight at that
+moment is written to the same report before exiting, turning a hang into
+a reproducer.
 
 Connection options mirror the PostgreSQL client tools and honor the
 standard `PGHOST`, `PGPORT`, `PGUSER`, and `PGDATABASE` environment

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,11 @@ pub struct Pull {
     #[arg(long)]
     pub save_remaining: bool,
 
+    /// File to record DDL that fails to parse or format, and the
+    /// statement in flight if interrupted (for reproducing hangs)
+    #[arg(long, default_value = "pglifecycle-errors.log")]
+    pub error_file: PathBuf,
+
     #[command(flatten)]
     pub connection: Connection,
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,218 @@
+//! Failure diagnostics for `pull`: a correlatable error report for DDL
+//! that fails to parse or format, plus capture of the statement in
+//! flight when the process is interrupted.
+//!
+//! The motivating case is an upstream formatter (libpgfmt) that loops
+//! forever on a pathological view: progress shows which object it
+//! stalled on, but reproducing the bug needs the exact SQL. [`enter`]
+//! records the statement about to be handed to the parser/formatter,
+//! and the Ctrl-C handler — which `ctrlc` runs on its own thread, so it
+//! fires even while the main thread is wedged — writes that SQL to the
+//! report before exiting. Parse/format errors are recorded the same
+//! way, so a single file correlates every failure with its DDL.
+//!
+//! When [`init`] has not been called (e.g. outside `pull`), every entry
+//! point is a no-op.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+struct State {
+    path: PathBuf,
+    /// The statement currently being parsed/formatted, captured on
+    /// interrupt; `None` between operations.
+    current: Mutex<Option<InFlight>>,
+    /// Whether the report file has been opened this run; the first
+    /// write truncates any stale file, later writes append.
+    opened: AtomicBool,
+}
+
+#[derive(Clone)]
+struct InFlight {
+    label: String,
+    sql: String,
+}
+
+static STATE: OnceLock<State> = OnceLock::new();
+
+/// Initialize the error report at `path` and install the interrupt
+/// handler that records the in-flight statement before exiting. Safe to
+/// call once per process; later calls are ignored.
+pub fn init(path: PathBuf) {
+    if STATE
+        .set(State {
+            path,
+            current: Mutex::new(None),
+            opened: AtomicBool::new(false),
+        })
+        .is_err()
+    {
+        return;
+    }
+    let _ = ctrlc::set_handler(|| {
+        if let Some(state) = STATE.get() {
+            report_interrupt(state);
+        }
+        std::process::exit(130);
+    });
+}
+
+/// Record the statement in flight (if any) to the report; called from
+/// the interrupt handler before exiting.
+fn report_interrupt(state: &State) {
+    let Some(in_flight) = state.current.lock().ok().and_then(|g| g.clone())
+    else {
+        return;
+    };
+    write(
+        state,
+        &format!("INTERRUPTED while processing {}", in_flight.label),
+        "SIGINT received while this statement was in flight (a likely \
+         parser/formatter hang)",
+        &in_flight.sql,
+    );
+    eprintln!(
+        "\nInterrupted while processing {}; its DDL was written to {}",
+        in_flight.label,
+        state.path.display()
+    );
+}
+
+/// Mark `sql` (labelled e.g. `view public.foo`) as the statement now in
+/// flight, so an interrupt during it captures the offending DDL. Pair
+/// every call with [`leave`].
+pub fn enter(label: impl Into<String>, sql: &str) {
+    if let Some(state) = STATE.get()
+        && let Ok(mut guard) = state.current.lock()
+    {
+        *guard = Some(InFlight {
+            label: label.into(),
+            sql: sql.to_string(),
+        });
+    }
+}
+
+/// Clear the in-flight statement after it completed.
+pub fn leave() {
+    if let Some(state) = STATE.get()
+        && let Ok(mut guard) = state.current.lock()
+    {
+        *guard = None;
+    }
+}
+
+/// Record a parse/format failure and its DDL to the report.
+pub fn record_failure(category: &str, label: &str, error: &str, sql: &str) {
+    if let Some(state) = STATE.get() {
+        write(state, &format!("{category}: {label}"), error, sql);
+    }
+}
+
+/// Append a delimited record; the first write of the run truncates a
+/// stale report and writes a header.
+fn write(state: &State, heading: &str, detail: &str, sql: &str) {
+    let fresh = !state.opened.swap(true, Ordering::SeqCst);
+    let file = OpenOptions::new()
+        .create(true)
+        .append(!fresh)
+        .write(true)
+        .truncate(fresh)
+        .open(&state.path);
+    let Ok(mut file) = file else {
+        log::warn!(
+            "failed to write the error report at {}",
+            state.path.display()
+        );
+        return;
+    };
+    let header = if fresh {
+        "# pglifecycle error report\n# Each record below is a failure and \
+         the DDL that produced it.\n\n"
+    } else {
+        ""
+    };
+    let _ = write!(
+        file,
+        "{header}=== {heading} ===\n{detail}\n--- DDL ---\n{}\n--- END ---\n\n",
+        sql.trim_end()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_failure_is_noop_without_init() {
+        // STATE is never set in this test process path; the call must
+        // simply do nothing rather than panic.
+        record_failure("FAILED TO PARSE", "VIEW x.y", "boom", "CREATE ...");
+        enter("view x.y", "CREATE VIEW ...");
+        leave();
+    }
+
+    #[test]
+    fn write_truncates_then_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State {
+            path: dir.path().join("errors.log"),
+            current: Mutex::new(None),
+            opened: AtomicBool::new(false),
+        };
+        write(
+            &state,
+            "FAILED TO PARSE: VIEW a.b",
+            "syntax error",
+            "CREATE A",
+        );
+        write(&state, "FAILED TO FORMAT: VIEW c.d", "loop", "CREATE C");
+        let body = std::fs::read_to_string(&state.path).unwrap();
+        assert!(body.starts_with("# pglifecycle error report"));
+        assert!(body.contains(
+            "=== FAILED TO PARSE: VIEW a.b ===\nsyntax \
+                                error\n--- DDL ---\nCREATE A\n--- END ---"
+        ));
+        assert!(body.contains("=== FAILED TO FORMAT: VIEW c.d ==="));
+        // the header appears exactly once (only the first write is fresh)
+        assert_eq!(body.matches("# pglifecycle error report").count(), 1);
+    }
+
+    #[test]
+    fn interrupt_records_the_in_flight_statement() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State {
+            path: dir.path().join("errors.log"),
+            current: Mutex::new(Some(InFlight {
+                label: "view report.weekly_production_trial_accounts".into(),
+                sql: "CREATE VIEW report.weekly_production_trial_accounts \
+                      AS SELECT 1;"
+                    .into(),
+            })),
+            opened: AtomicBool::new(false),
+        };
+        report_interrupt(&state);
+        let body = std::fs::read_to_string(&state.path).unwrap();
+        assert!(body.contains(
+            "=== INTERRUPTED while processing view \
+             report.weekly_production_trial_accounts ==="
+        ));
+        assert!(body.contains(
+            "CREATE VIEW report.weekly_production_trial_accounts AS SELECT 1;"
+        ));
+    }
+
+    #[test]
+    fn interrupt_with_nothing_in_flight_writes_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State {
+            path: dir.path().join("errors.log"),
+            current: Mutex::new(None),
+            opened: AtomicBool::new(false),
+        };
+        report_interrupt(&state);
+        assert!(!state.path.exists());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod ddl;
 pub mod deploy;
 pub mod models;
 pub mod pgdump;
+pub mod progress;
 pub mod project;
 pub mod pull;
 pub mod skeleton;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cli;
 pub mod constants;
 pub mod ddl;
 pub mod deploy;
+pub mod diagnostics;
 pub mod models;
 pub mod pgdump;
 pub mod progress;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use pglifecycle::{build, cli, deploy, project, pull, skeleton};
+use indicatif_log_bridge::LogWrapper;
+use pglifecycle::{build, cli, deploy, progress, project, pull, skeleton};
+use simplelog::SharedLogger;
 
 fn main() -> ExitCode {
     let args = cli::Cli::parse();
@@ -54,12 +56,32 @@ fn configure_logging(args: &cli::Cli) {
     }
     // log to stderr so command output (e.g. the deploy script on
     // stdout) stays clean
-    if let Err(err) = simplelog::TermLogger::init(
+    let logger = simplelog::TermLogger::new(
         level,
         simplelog::Config::default(),
         simplelog::TerminalMode::Stderr,
         simplelog::ColorChoice::Auto,
-    ) {
-        eprintln!("warning: failed to initialize terminal logging: {err}");
+    );
+    match progress::init() {
+        // on a terminal, route log records through the progress bridge
+        // so they print above any live bars instead of corrupting them
+        Some(multi) => {
+            if let Err(err) = LogWrapper::new(multi, *logger).try_init() {
+                eprintln!(
+                    "warning: failed to initialize terminal logging: {err}"
+                );
+            } else {
+                log::set_max_level(level);
+            }
+        }
+        None => {
+            if let Err(err) = log::set_boxed_logger(logger.as_log()) {
+                eprintln!(
+                    "warning: failed to initialize terminal logging: {err}"
+                );
+            } else {
+                log::set_max_level(level);
+            }
+        }
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,87 @@
+//! Live progress reporting for long-running commands (currently
+//! `pull`). Bars render on stderr only when it is a terminal, so piped
+//! or redirected output stays clean; otherwise every call is a no-op
+//! and the log output is the only signal.
+
+use std::io::IsTerminal;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+static MULTI: OnceLock<Option<MultiProgress>> = OnceLock::new();
+
+/// Initialize progress rendering, returning the [`MultiProgress`] to
+/// hand to the log bridge when stderr is a terminal (so log lines print
+/// above the bars instead of corrupting them). Call once, from `main`;
+/// a no-op result means progress is disabled.
+pub fn init() -> Option<MultiProgress> {
+    let multi = std::io::stderr().is_terminal().then(MultiProgress::new);
+    let _ = MULTI.set(multi.clone());
+    multi
+}
+
+fn multi() -> Option<&'static MultiProgress> {
+    MULTI.get().and_then(Option::as_ref)
+}
+
+/// A spinner for a phase of unknown duration; ticks on its own until
+/// finished or dropped.
+pub fn spinner(message: impl Into<String>) -> Task {
+    let Some(multi) = multi() else {
+        return Task(None);
+    };
+    let bar = multi.add(ProgressBar::new_spinner());
+    bar.set_style(
+        ProgressStyle::with_template("{spinner} {msg} ({elapsed})").unwrap(),
+    );
+    bar.set_message(message.into());
+    bar.enable_steady_tick(Duration::from_millis(100));
+    Task(Some(bar))
+}
+
+/// A bar tracking `len` items; advance it with [`Task::inc`] and label
+/// the item in flight with [`Task::set_message`] so a stall is
+/// attributable to a specific object.
+pub fn bar(len: u64, message: impl Into<String>) -> Task {
+    let Some(multi) = multi() else {
+        return Task(None);
+    };
+    let bar = multi.add(ProgressBar::new(len));
+    bar.set_style(
+        ProgressStyle::with_template(
+            "{msg} [{bar:30}] {pos}/{len} ({elapsed})",
+        )
+        .unwrap()
+        .progress_chars("=>-"),
+    );
+    bar.set_message(message.into());
+    Task(Some(bar))
+}
+
+/// Handle to an in-flight bar or spinner; every method is a no-op when
+/// progress rendering is disabled.
+pub struct Task(Option<ProgressBar>);
+
+impl Task {
+    /// Advance a bar by one item.
+    pub fn inc(&self) {
+        if let Some(bar) = &self.0 {
+            bar.inc(1);
+        }
+    }
+
+    /// Label the item currently being processed.
+    pub fn set_message(&self, message: impl Into<String>) {
+        if let Some(bar) = &self.0 {
+            bar.set_message(message.into());
+        }
+    }
+
+    /// Clear the bar; the phase's own log line is the lasting record.
+    pub fn finish(self) {
+        if let Some(bar) = &self.0 {
+            bar.finish_and_clear();
+        }
+    }
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -79,7 +79,16 @@ impl Task {
     }
 
     /// Clear the bar; the phase's own log line is the lasting record.
+    /// Clearing also happens on drop, so an early `?` return on an error
+    /// path leaves no stale spinner or bar in the terminal.
     pub fn finish(self) {
+        // The Drop impl does the clearing; consuming `self` here just
+        // ends the phase deterministically at the call site.
+    }
+}
+
+impl Drop for Task {
+    fn drop(&mut self) {
         if let Some(bar) = &self.0 {
             bar.finish_and_clear();
         }

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -17,7 +17,7 @@ use serde_json::{Map, Value};
 
 use crate::ddl::{self, Acl, AclTarget, QualifiedName, RoleDef, Statement};
 use crate::models;
-use crate::{cli, pgdump};
+use crate::{cli, pgdump, progress};
 
 pub fn pull(args: &cli::Pull) -> Result<(), String> {
     if args.update {
@@ -55,7 +55,9 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
         &ddl,
         args.extract_roles,
     )?;
+    let task = progress::spinner("Rendering project");
     let files = writer::render(&assembly, args)?;
+    task.finish();
     if args.update {
         update::merge(&files, args)
     } else {
@@ -81,16 +83,20 @@ pub fn snapshot(
                 .suffix(".dump")
                 .tempfile()
                 .map_err(|e| format!("failed to create temp file: {e}"))?;
+            let task = progress::spinner("Dumping database");
             pgdump::dump(conn, ddl, file.path())?;
+            task.finish();
             let path = file.path().to_path_buf();
             temp_dump = Some(file);
             path
         }
     };
     log::info!("Loading dump from {}", dump_path.display());
+    let task = progress::spinner("Loading dump");
     let dump = libpgdump::load(&dump_path).map_err(|e| {
         format!("failed to load dump {}: {e}", dump_path.display())
     })?;
+    task.finish();
     drop(temp_dump);
     let mut assembly = Assembly::default();
     assembly.ingest(&dump)?;
@@ -240,7 +246,15 @@ impl Assembly {
         use libpgdump::ObjectType as OT;
         let mut parser = ddl::Parser::new()?;
         self.dbname = dump.dbname().to_string();
-        for entry in dump.entries() {
+        let entries = dump.entries();
+        let task = progress::bar(entries.len() as u64, "Ingesting entries");
+        for entry in entries {
+            task.set_message(format!(
+                "Ingesting {} {}",
+                entry.desc.as_str(),
+                entry.tag.as_deref().unwrap_or_default()
+            ));
+            task.inc();
             match &entry.desc {
                 OT::Database
                 | OT::SearchPath
@@ -304,6 +318,7 @@ impl Assembly {
                 _ => self.push_remaining(entry),
             }
         }
+        task.finish();
         Ok(())
     }
 
@@ -705,27 +720,43 @@ impl Assembly {
     /// style); on a formatting error the original text is kept
     pub fn format_sql(&mut self) {
         use libpgfmt::style::Style;
+        let total = self.views.len()
+            + self.materialized_views.len()
+            + self.functions.len();
+        let task = progress::bar(total as u64, "Formatting SQL");
         for view in &mut self.views {
             if let Some(query) = &view.query {
+                task.set_message(format!("Formatting view {}", view.name));
                 view.query = Some(format_query(query, "view", &view.name));
             }
+            task.inc();
         }
         for view in &mut self.materialized_views {
             if let Some(query) = &view.query {
+                task.set_message(format!(
+                    "Formatting materialized view {}",
+                    view.name
+                ));
                 view.query =
                     Some(format_query(query, "materialized view", &view.name));
             }
+            task.inc();
         }
         for function in &mut self.functions {
             let Some(definition) = &function.definition else {
+                task.inc();
                 continue;
             };
+            task.set_message(format!("Formatting function {}", function.name));
             let formatted = match function.language.as_deref() {
                 Some("plpgsql") => {
                     libpgfmt::format_plpgsql(definition, Style::Aweber)
                 }
                 Some("sql") => libpgfmt::format(definition, Style::Aweber),
-                _ => continue,
+                _ => {
+                    task.inc();
+                    continue;
+                }
             };
             match formatted {
                 Ok(formatted) => function.definition = Some(formatted),
@@ -734,7 +765,9 @@ impl Assembly {
                     function.name
                 ),
             }
+            task.inc();
         }
+        task.finish();
     }
 
     fn push_remaining(&mut self, entry: &libpgdump::Entry) {

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -17,7 +17,7 @@ use serde_json::{Map, Value};
 
 use crate::ddl::{self, Acl, AclTarget, QualifiedName, RoleDef, Statement};
 use crate::models;
-use crate::{cli, pgdump, progress};
+use crate::{cli, diagnostics, pgdump, progress};
 
 pub fn pull(args: &cli::Pull) -> Result<(), String> {
     if args.update {
@@ -43,6 +43,7 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
              or use a pgpass file instead",
         ));
     }
+    diagnostics::init(args.error_file.clone());
     let ddl = pgdump::DumpDdl {
         no_owner: args.no_owner,
         no_privileges: args.no_privileges,
@@ -299,17 +300,27 @@ impl Assembly {
                 | OT::Comment
                 | OT::Acl => {
                     let Some(defn) = &entry.defn else { continue };
-                    match parser.parse(defn) {
+                    let label = format!(
+                        "{} {}",
+                        entry.desc.as_str(),
+                        entry.tag.as_deref().unwrap_or_default()
+                    );
+                    diagnostics::enter(&label, defn);
+                    let parsed = parser.parse(defn);
+                    diagnostics::leave();
+                    match parsed {
                         Ok(statements) => {
                             for statement in cancel_revokes(statements) {
                                 self.apply(statement, entry);
                             }
                         }
                         Err(error) => {
-                            log::warn!(
-                                "Failed to parse {} {:?}: {error}",
-                                entry.desc.as_str(),
-                                entry.tag
+                            log::warn!("Failed to parse {label}: {error}");
+                            diagnostics::record_failure(
+                                "FAILED TO PARSE",
+                                &label,
+                                &error,
+                                defn,
                             );
                             self.push_remaining(entry);
                         }
@@ -748,22 +759,31 @@ impl Assembly {
                 continue;
             };
             task.set_message(format!("Formatting function {}", function.name));
+            let label = format!("function {}", function.name);
+            diagnostics::enter(&label, definition);
             let formatted = match function.language.as_deref() {
                 Some("plpgsql") => {
                     libpgfmt::format_plpgsql(definition, Style::Aweber)
                 }
                 Some("sql") => libpgfmt::format(definition, Style::Aweber),
                 _ => {
+                    diagnostics::leave();
                     task.inc();
                     continue;
                 }
             };
+            diagnostics::leave();
             match formatted {
                 Ok(formatted) => function.definition = Some(formatted),
-                Err(error) => log::warn!(
-                    "failed to format function {}: {error}",
-                    function.name
-                ),
+                Err(error) => {
+                    log::warn!("failed to format {label}: {error}");
+                    diagnostics::record_failure(
+                        "FAILED TO FORMAT",
+                        &label,
+                        &error.to_string(),
+                        definition,
+                    );
+                }
             }
             task.inc();
         }
@@ -781,12 +801,22 @@ impl Assembly {
 }
 
 fn format_query(query: &str, kind: &str, name: &str) -> String {
-    match libpgfmt::format(query, libpgfmt::style::Style::Aweber) {
+    let label = format!("{kind} {name}");
+    diagnostics::enter(&label, query);
+    let result = libpgfmt::format(query, libpgfmt::style::Style::Aweber);
+    diagnostics::leave();
+    match result {
         Ok(formatted) => {
             formatted.trim_end_matches(';').trim_end().to_string()
         }
         Err(error) => {
-            log::warn!("failed to format {kind} {name}: {error}");
+            log::warn!("failed to format {label}: {error}");
+            diagnostics::record_failure(
+                "FAILED TO FORMAT",
+                &label,
+                &error.to_string(),
+                query,
+            );
             query.to_string()
         }
     }

--- a/src/pull/writer.rs
+++ b/src/pull/writer.rs
@@ -8,7 +8,7 @@ use serde_json::{Map, Value, json};
 
 use crate::constants::PROJECT_DIRS;
 use crate::pull::{Assembly, RoleState};
-use crate::{cli, models, yamlio};
+use crate::{cli, models, progress, yamlio};
 
 /// Render the project files for an assembly as `relative path →
 /// YAML text`, honoring the `--ignore` file
@@ -90,6 +90,7 @@ pub fn write_bootstrap(
 ) -> Result<(), String> {
     log::info!("Writing project to {}", args.destination.display());
     create_directories(&args.destination, args.gitkeep)?;
+    let task = progress::bar(files.len() as u64, "Writing files");
     for (relative, content) in files {
         let path = args.destination.join(relative);
         if let Some(parent) = path.parent() {
@@ -99,7 +100,9 @@ pub fn write_bootstrap(
         }
         std::fs::write(&path, content)
             .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+        task.inc();
     }
+    task.finish();
     if args.gitkeep {
         remove_unneeded_gitkeeps(&args.destination)?;
     }


### PR DESCRIPTION
## Summary
`pull` now shows a live, per-phase progress indicator so a long run is legible instead of looking hung.

## Problem
Pulling a large production database prints a burst of ingest warnings and then goes silent through SQL formatting, project rendering, and file writing. At the default log level (`Warn`) there is no further output, so a slow `libpgfmt` call on a large view — or a genuinely stuck one — is indistinguishable from a hang. This came up running `pull` against a real production schema, where several large views also fail the `CREATE VIEW` parse and then get re-formatted by libpgfmt.

## Solution
- **New `progress` module** — indicatif bars/spinners that render on stderr **only when it is a terminal**; otherwise every call is a no-op, so piped/redirected/CI output is unchanged and the logs remain the only signal.
- **Log bridge** — on a terminal the logger is routed through `indicatif-log-bridge` so `log::warn!` lines print *above* the live bars instead of corrupting them (verified: the `WITH GRANT OPTION` warning prints on its own line, bar redraws below).
- **Instrumented pull phases** — spinners for dump / load / render; item bars for ingest, SQL formatting, and file writing. The formatting bar **names the object in flight** (`Formatting view <name>` / `function <name>`), so a stall points at a specific object rather than reading as a hang.

This is the diagnostic-first step: with the indicator in place, a re-run pinpoints exactly which object (if any) libpgfmt stalls on, which decides whether a follow-up guard/timeout in `format_sql` is warranted.

## Impact
Terminal users get visible progress by default (no `-v` needed). Non-terminal output is byte-for-byte unchanged. Two new dependencies: `indicatif` 0.18, `indicatif-log-bridge` 0.2.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (101 lib + integration) all pass. Manually exercised both paths against the fixtures schema: non-TTY (no bars, clean exit) and under a pty (bars render, messages track the current item, an injected ingest warning interleaves cleanly above the bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal-aware progress indicators (spinners and progress bars) for long-running tasks including rendering, dumping/loading, ingesting, and SQL formatting (suppressed when non-interactive).
  * Added `pull --error-file FILE` to record parse/format failures and the in-flight statement on Ctrl-C for easier reproductions.
* **Improvements**
  * Improved logging to cooperate with active progress displays, keeping output readable.
* **Documentation**
  * Updated `pull` command docs with the new `--error-file` option and failure/interrupt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->