### PR TITLE
Capture failing and in-flight DDL to an error report in pull

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +164,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -224,6 +239,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +260,18 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "displaydoc"
@@ -748,6 +786,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +892,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +958,7 @@ name = "pglifecycle"
 version = "2.0.0-alpha.0"
 dependencies = [
  "clap",
+ "ctrlc",
  "include_dir",
  "indicatif",
  "indicatif-log-bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.88"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
+ctrlc = "3.5.2"
 include_dir = "0.7.4"
 indicatif = "0.18.4"
 indicatif-log-bridge = "0.2.3"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -121,6 +121,20 @@ pglifecycle pull [OPTIONS] DEST
 | `--gitkeep` | Create `.gitkeep` files in empty directories |
 | `--remove-empty-dirs` | Remove empty directories after generation |
 | `--save-remaining` | Save unprocessed dump entries to `remaining.yaml` |
+| `--error-file FILE` | Where to record failures and their DDL (default `pglifecycle-errors.log`) |
+
+### Diagnosing parse and format failures
+
+DDL that fails to parse, or SQL that fails to format, is logged and the
+offending statement is written to the error report (`--error-file`,
+default `pglifecycle-errors.log` in the working directory) alongside its
+full DDL, so a failure can be correlated with the exact statement that
+produced it. The file is created only when there is something to report.
+
+If `pull` is interrupted with Ctrl-C — for example because the formatter
+is stuck on a pathological statement — the statement in flight at that
+moment is written to the same report before exiting, turning a hang into
+a reproducer.
 
 Connection options mirror the PostgreSQL client tools and honor the
 standard `PGHOST`, `PGPORT`, `PGUSER`, and `PGDATABASE` environment

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,11 @@ pub struct Pull {
     #[arg(long)]
     pub save_remaining: bool,
 
+    /// File to record DDL that fails to parse or format, and the
+    /// statement in flight if interrupted (for reproducing hangs)
+    #[arg(long, default_value = "pglifecycle-errors.log")]
+    pub error_file: PathBuf,
+
     #[command(flatten)]
     pub connection: Connection,
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,218 @@
+//! Failure diagnostics for `pull`: a correlatable error report for DDL
+//! that fails to parse or format, plus capture of the statement in
+//! flight when the process is interrupted.
+//!
+//! The motivating case is an upstream formatter (libpgfmt) that loops
+//! forever on a pathological view: progress shows which object it
+//! stalled on, but reproducing the bug needs the exact SQL. [`enter`]
+//! records the statement about to be handed to the parser/formatter,
+//! and the Ctrl-C handler — which `ctrlc` runs on its own thread, so it
+//! fires even while the main thread is wedged — writes that SQL to the
+//! report before exiting. Parse/format errors are recorded the same
+//! way, so a single file correlates every failure with its DDL.
+//!
+//! When [`init`] has not been called (e.g. outside `pull`), every entry
+//! point is a no-op.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+struct State {
+    path: PathBuf,
+    /// The statement currently being parsed/formatted, captured on
+    /// interrupt; `None` between operations.
+    current: Mutex<Option<InFlight>>,
+    /// Whether the report file has been opened this run; the first
+    /// write truncates any stale file, later writes append.
+    opened: AtomicBool,
+}
+
+#[derive(Clone)]
+struct InFlight {
+    label: String,
+    sql: String,
+}
+
+static STATE: OnceLock<State> = OnceLock::new();
+
+/// Initialize the error report at `path` and install the interrupt
+/// handler that records the in-flight statement before exiting. Safe to
+/// call once per process; later calls are ignored.
+pub fn init(path: PathBuf) {
+    if STATE
+        .set(State {
+            path,
+            current: Mutex::new(None),
+            opened: AtomicBool::new(false),
+        })
+        .is_err()
+    {
+        return;
+    }
+    let _ = ctrlc::set_handler(|| {
+        if let Some(state) = STATE.get() {
+            report_interrupt(state);
+        }
+        std::process::exit(130);
+    });
+}
+
+/// Record the statement in flight (if any) to the report; called from
+/// the interrupt handler before exiting.
+fn report_interrupt(state: &State) {
+    let Some(in_flight) = state.current.lock().ok().and_then(|g| g.clone())
+    else {
+        return;
+    };
+    write(
+        state,
+        &format!("INTERRUPTED while processing {}", in_flight.label),
+        "SIGINT received while this statement was in flight (a likely \
+         parser/formatter hang)",
+        &in_flight.sql,
+    );
+    eprintln!(
+        "\nInterrupted while processing {}; its DDL was written to {}",
+        in_flight.label,
+        state.path.display()
+    );
+}
+
+/// Mark `sql` (labelled e.g. `view public.foo`) as the statement now in
+/// flight, so an interrupt during it captures the offending DDL. Pair
+/// every call with [`leave`].
+pub fn enter(label: impl Into<String>, sql: &str) {
+    if let Some(state) = STATE.get()
+        && let Ok(mut guard) = state.current.lock()
+    {
+        *guard = Some(InFlight {
+            label: label.into(),
+            sql: sql.to_string(),
+        });
+    }
+}
+
+/// Clear the in-flight statement after it completed.
+pub fn leave() {
+    if let Some(state) = STATE.get()
+        && let Ok(mut guard) = state.current.lock()
+    {
+        *guard = None;
+    }
+}
+
+/// Record a parse/format failure and its DDL to the report.
+pub fn record_failure(category: &str, label: &str, error: &str, sql: &str) {
+    if let Some(state) = STATE.get() {
+        write(state, &format!("{category}: {label}"), error, sql);
+    }
+}
+
+/// Append a delimited record; the first write of the run truncates a
+/// stale report and writes a header.
+fn write(state: &State, heading: &str, detail: &str, sql: &str) {
+    let fresh = !state.opened.swap(true, Ordering::SeqCst);
+    let file = OpenOptions::new()
+        .create(true)
+        .append(!fresh)
+        .write(true)
+        .truncate(fresh)
+        .open(&state.path);
+    let Ok(mut file) = file else {
+        log::warn!(
+            "failed to write the error report at {}",
+            state.path.display()
+        );
+        return;
+    };
+    let header = if fresh {
+        "# pglifecycle error report\n# Each record below is a failure and \
+         the DDL that produced it.\n\n"
+    } else {
+        ""
+    };
+    let _ = write!(
+        file,
+        "{header}=== {heading} ===\n{detail}\n--- DDL ---\n{}\n--- END ---\n\n",
+        sql.trim_end()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_failure_is_noop_without_init() {
+        // STATE is never set in this test process path; the call must
+        // simply do nothing rather than panic.
+        record_failure("FAILED TO PARSE", "VIEW x.y", "boom", "CREATE ...");
+        enter("view x.y", "CREATE VIEW ...");
+        leave();
+    }
+
+    #[test]
+    fn write_truncates_then_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State {
+            path: dir.path().join("errors.log"),
+            current: Mutex::new(None),
+            opened: AtomicBool::new(false),
+        };
+        write(
+            &state,
+            "FAILED TO PARSE: VIEW a.b",
+            "syntax error",
+            "CREATE A",
+        );
+        write(&state, "FAILED TO FORMAT: VIEW c.d", "loop", "CREATE C");
+        let body = std::fs::read_to_string(&state.path).unwrap();
+        assert!(body.starts_with("# pglifecycle error report"));
+        assert!(body.contains(
+            "=== FAILED TO PARSE: VIEW a.b ===\nsyntax \
+                                error\n--- DDL ---\nCREATE A\n--- END ---"
+        ));
+        assert!(body.contains("=== FAILED TO FORMAT: VIEW c.d ==="));
+        // the header appears exactly once (only the first write is fresh)
+        assert_eq!(body.matches("# pglifecycle error report").count(), 1);
+    }
+
+    #[test]
+    fn interrupt_records_the_in_flight_statement() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State {
+            path: dir.path().join("errors.log"),
+            current: Mutex::new(Some(InFlight {
+                label: "view report.weekly_production_trial_accounts".into(),
+                sql: "CREATE VIEW report.weekly_production_trial_accounts \
+                      AS SELECT 1;"
+                    .into(),
+            })),
+            opened: AtomicBool::new(false),
+        };
+        report_interrupt(&state);
+        let body = std::fs::read_to_string(&state.path).unwrap();
+        assert!(body.contains(
+            "=== INTERRUPTED while processing view \
+             report.weekly_production_trial_accounts ==="
+        ));
+        assert!(body.contains(
+            "CREATE VIEW report.weekly_production_trial_accounts AS SELECT 1;"
+        ));
+    }
+
+    #[test]
+    fn interrupt_with_nothing_in_flight_writes_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State {
+            path: dir.path().join("errors.log"),
+            current: Mutex::new(None),
+            opened: AtomicBool::new(false),
+        };
+        report_interrupt(&state);
+        assert!(!state.path.exists());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cli;
 pub mod constants;
 pub mod ddl;
 pub mod deploy;
+pub mod diagnostics;
 pub mod models;
 pub mod pgdump;
 pub mod progress;

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -17,7 +17,7 @@ use serde_json::{Map, Value};
 
 use crate::ddl::{self, Acl, AclTarget, QualifiedName, RoleDef, Statement};
 use crate::models;
-use crate::{cli, pgdump, progress};
+use crate::{cli, diagnostics, pgdump, progress};
 
 pub fn pull(args: &cli::Pull) -> Result<(), String> {
     if args.update {
@@ -43,6 +43,7 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
              or use a pgpass file instead",
         ));
     }
+    diagnostics::init(args.error_file.clone());
     let ddl = pgdump::DumpDdl {
         no_owner: args.no_owner,
         no_privileges: args.no_privileges,
@@ -299,17 +300,27 @@ impl Assembly {
                 | OT::Comment
                 | OT::Acl => {
                     let Some(defn) = &entry.defn else { continue };
-                    match parser.parse(defn) {
+                    let label = format!(
+                        "{} {}",
+                        entry.desc.as_str(),
+                        entry.tag.as_deref().unwrap_or_default()
+                    );
+                    diagnostics::enter(&label, defn);
+                    let parsed = parser.parse(defn);
+                    diagnostics::leave();
+                    match parsed {
                         Ok(statements) => {
                             for statement in cancel_revokes(statements) {
                                 self.apply(statement, entry);
                             }
                         }
                         Err(error) => {
-                            log::warn!(
-                                "Failed to parse {} {:?}: {error}",
-                                entry.desc.as_str(),
-                                entry.tag
+                            log::warn!("Failed to parse {label}: {error}");
+                            diagnostics::record_failure(
+                                "FAILED TO PARSE",
+                                &label,
+                                &error,
+                                defn,
                             );
                             self.push_remaining(entry);
                         }
@@ -748,22 +759,31 @@ impl Assembly {
                 continue;
             };
             task.set_message(format!("Formatting function {}", function.name));
+            let label = format!("function {}", function.name);
+            diagnostics::enter(&label, definition);
             let formatted = match function.language.as_deref() {
                 Some("plpgsql") => {
                     libpgfmt::format_plpgsql(definition, Style::Aweber)
                 }
                 Some("sql") => libpgfmt::format(definition, Style::Aweber),
                 _ => {
+                    diagnostics::leave();
                     task.inc();
                     continue;
                 }
             };
+            diagnostics::leave();
             match formatted {
                 Ok(formatted) => function.definition = Some(formatted),
-                Err(error) => log::warn!(
-                    "failed to format function {}: {error}",
-                    function.name
-                ),
+                Err(error) => {
+                    log::warn!("failed to format {label}: {error}");
+                    diagnostics::record_failure(
+                        "FAILED TO FORMAT",
+                        &label,
+                        &error.to_string(),
+                        definition,
+                    );
+                }
             }
             task.inc();
         }
@@ -781,12 +801,22 @@ impl Assembly {
 }
 
 fn format_query(query: &str, kind: &str, name: &str) -> String {
-    match libpgfmt::format(query, libpgfmt::style::Style::Aweber) {
+    let label = format!("{kind} {name}");
+    diagnostics::enter(&label, query);
+    let result = libpgfmt::format(query, libpgfmt::style::Style::Aweber);
+    diagnostics::leave();
+    match result {
         Ok(formatted) => {
             formatted.trim_end_matches(';').trim_end().to_string()
         }
         Err(error) => {
-            log::warn!("failed to format {kind} {name}: {error}");
+            log::warn!("failed to format {label}: {error}");
+            diagnostics::record_failure(
+                "FAILED TO FORMAT",
+                &label,
+                &error.to_string(),
+                query,
+            );
             query.to_string()
         }
     }


### PR DESCRIPTION
## Summary
`pull` now writes a correlatable **error report** for DDL that fails to parse or format, and — critically — captures the statement *in flight* when the process is interrupted, so a formatter hang can be turned into a reproducer.

> Stacked on #29 (`feature/pull-progress`); base will move to `main` once #29 merges.

## Problem
Pulling a large production database stalled indefinitely (multiple days before cancellation) — an infinite loop in libpgfmt on one pathological view. The progress bar (#29) revealed *which* view (`Formatting view weekly_production_trial_accounts`), but reproducing and fixing the upstream bug needs the **exact SQL**, and there was no way to get it: the process was wedged, and parse failures only scrolled past as `WARN` lines with no DDL attached.

## Solution
A new `diagnostics` module backing a single error report (`--error-file`, default `pglifecycle-errors.log`):

- **Parse and format failures** are recorded with their full DDL, so every failure correlates to the statement that produced it (previously parse failures were warn-only).
- **Interrupt capture** — the statement about to be parsed/formatted is tracked via `enter`/`leave`; the Ctrl-C handler writes that DDL to the report before exiting. This works because `ctrlc` runs its handler on a dedicated thread, so it fires even while the main thread is stuck in libpgfmt's loop. Hit Ctrl-C on a hang and the offending `CREATE VIEW` lands in the report.
- The file is created **only when there's something to report**; outside `pull` the module is uninitialized and every entry point is a no-op (so `deploy`'s use of `pull::snapshot` is unaffected).

This is the deliberate alternative to a formatting timeout (a separate, later PR): rather than mask the hang, make it diagnosable so the root cause can be fixed in libpgfmt. The exclude-options PR is also separate.

## Impact
New `--error-file` option on `pull`. No behavior change when there are no failures. Two-thread interrupt handling adds the `ctrlc` dependency.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (105 lib + integration) all pass. Unit tests cover the report format (truncate-then-append, single header), the no-op-without-init path, and the interrupt-capture path (records the in-flight statement; writes nothing when idle). Manually verified end-to-end against the fixtures schema: lazy file creation (no failures → no file), and confirmed the current grammar already handles several constructs from the production failures (CTEs, window/FILTER, casts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)