### PR TITLE
Wire the progress indicator through build and deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 site/
 /target/
 !/src/build/
+pglifecycle-errors.log

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -38,6 +38,7 @@ use crate::models::{
     Column, ConstraintColumns, Definition, Index, Item, RoleOptions,
     TablePartitionColumn, Trigger, ViewColumn,
 };
+use crate::progress;
 use crate::project::Project;
 use crate::utils::{postgres_value, quote_ident, raw_value};
 
@@ -48,10 +49,12 @@ pub fn build(project: &Project, destination: &Path) -> Result<(), String> {
         project.name
     );
     let output = assemble(project)?;
+    let task = progress::spinner("Saving archive");
     output
         .dump
         .save(destination)
         .map_err(|e| format!("failed to save archive: {e}"))?;
+    task.finish();
     log::debug!(
         "Saved pg_dump -Fc compatible dump to {} with {} entries",
         destination.display(),
@@ -78,9 +81,18 @@ pub fn assemble(project: &Project) -> Result<BuildOutput, String> {
         dump_id_map: HashMap::new(),
         superuser: project.superuser.clone(),
     };
+    let task =
+        progress::bar(project.inventory.len() as u64, "Assembling archive");
     for item in &project.inventory {
+        task.set_message(format!(
+            "Assembling {} {}",
+            item.desc.as_str(),
+            item.definition.name()
+        ));
         builder.dump_item(item)?;
+        task.inc();
     }
+    task.finish();
     acls::dump_acls(&mut builder, project)?;
     // record inventory dependency edges on the entries so the weighted
     // pg_dump topological sort in libpgdump (run by save) can order

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -18,7 +18,7 @@ use std::io::IsTerminal;
 use crate::deploy::alter::Resolution;
 use crate::deploy::diff::{Change, Diff, ObjectKey};
 use crate::utils::quote_ident;
-use crate::{build, cli, constants, pgdump, project, pull};
+use crate::{build, cli, constants, pgdump, progress, project, pull};
 
 pub fn deploy(args: &cli::Deploy) -> Result<(), String> {
     if args.connection.password && !std::io::stdin().is_terminal() {
@@ -36,11 +36,15 @@ pub fn deploy(args: &cli::Deploy) -> Result<(), String> {
     };
     let (assembly, snapshot) =
         pull::snapshot(args.dump.as_deref(), &args.connection, &ddl, false)?;
+    let task = progress::spinner("Diffing project against database");
     let diff = diff::diff(&project, &assembly);
     let resolutions = resolutions(&project, &diff);
+    task.finish();
     let mut output = build::assemble(&project)?;
+    let task = progress::spinner("Planning changes");
     output.dump.sort_entries();
     let plan = plan(&diff, &resolutions, &output, &snapshot, args)?;
+    task.finish();
     report(&diff, &plan);
     let script = render_script(&plan, &project.name, &source);
     if let Some(path) = &args.output {
@@ -80,9 +84,11 @@ fn apply(plan: &Plan, script: &str, args: &cli::Deploy) -> Result<(), String> {
         format!("failed to write {}: {e}", file.path().display())
     })?;
     log::info!("Applying {} statement(s)", plan.included.len());
+    let task = progress::spinner("Applying to database");
     pgdump::apply(&args.connection, file.path()).map_err(|stderr| {
         format!("deploy failed (the transaction was rolled back):\n{stderr}")
     })?;
+    task.finish();
     log::info!("Deploy applied successfully");
     Ok(())
 }

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -21,5 +21,6 @@ pub struct Project {
 
 /// Load the project from the specified project directory
 pub fn load(path: &std::path::Path) -> Result<Project, String> {
+    let _task = crate::progress::spinner("Loading project");
     load::Loader::new(path).load()
 }


### PR DESCRIPTION
## Summary
Extends the live progress indicator (added for `pull` in #29) to `build` and `deploy`, so every long-running command reports the step it is on.

## Problem
The `progress` module is general-purpose and already initialized for every command (the log bridge needs it), but only `pull` was instrumented. `build` and `deploy`'s own phases ran silently — the same "is it hung?" ambiguity that motivated #29, just on the other commands.

## Solution
- **Spinner around project load** — in `project::load`, shared by `build` and `deploy`.
- **Bar over `build::assemble`'s inventory loop**, labelled with the object in flight. Because `assemble` is shared, this also covers `deploy`'s archive assembly.
- **Spinner around the archive save** in `build`.
- **Spinners for `deploy`'s diff, plan, and apply phases** (its snapshot phase already rode the `pull` bars).
- **Ignore `pglifecycle-errors.log`** so a `pull` run from the repo root can't accidentally commit captured DDL.

`create` is intentionally left uninstrumented — it only writes a few files and has no long-running phase, so a bar would just flash.

## Impact
Terminal users get phase-level progress on `build` and `deploy` too; non-terminal output is unchanged (bars are a no-op off a TTY).

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (105 lib + integration) all pass. Verified under a pty that `build` shows Loading project → Assembling archive (per object) → Saving, and `deploy` shows Loading project → Loading dump → Ingesting → Diffing → Planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual progress indicators throughout the application workflow. Users now receive real-time feedback during project loading, build assembly, and database deployment phases, enabling better visibility into operation status and completion times.

* **Chores**
  * Updated .gitignore to exclude generated log files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->