### PR TITLE
Add pg_dump exclude options to pull

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -122,6 +122,14 @@ pglifecycle pull [OPTIONS] DEST
 | `--remove-empty-dirs` | Remove empty directories after generation |
 | `--save-remaining` | Save unprocessed dump entries to `remaining.yaml` |
 | `--error-file FILE` | Where to record failures and their DDL (default `pglifecycle-errors.log`) |
+| `-T, --exclude-table PATTERN` | Exclude tables/views/sequences matching `PATTERN` (repeatable; ignored with `--dump`) |
+| `-N, --exclude-schema PATTERN` | Exclude schemas matching `PATTERN` (repeatable; ignored with `--dump`) |
+| `--exclude-extension PATTERN` | Exclude extensions matching `PATTERN` (repeatable; ignored with `--dump`) |
+
+The exclude patterns are passed through to `pg_dump` (`--exclude-table`,
+`--exclude-schema`, `--exclude-extension`) and use the same pattern
+syntax. They apply only when connecting to a database; with `--dump` the
+archive is already built, so they are rejected as conflicting.
 
 ### Diagnosing parse and format failures
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -236,6 +236,35 @@ pub struct Pull {
     #[arg(long, default_value = "pglifecycle-errors.log")]
     pub error_file: PathBuf,
 
+    /// Exclude tables matching PATTERN (also matches views,
+    /// materialized views, and sequences); repeatable. Ignored with
+    /// --dump
+    #[arg(
+        short = 'T',
+        long = "exclude-table",
+        value_name = "PATTERN",
+        conflicts_with = "dump"
+    )]
+    pub exclude_table: Vec<String>,
+
+    /// Exclude schemas matching PATTERN; repeatable. Ignored with --dump
+    #[arg(
+        short = 'N',
+        long = "exclude-schema",
+        value_name = "PATTERN",
+        conflicts_with = "dump"
+    )]
+    pub exclude_schema: Vec<String>,
+
+    /// Exclude extensions matching PATTERN; repeatable. Ignored with
+    /// --dump
+    #[arg(
+        long = "exclude-extension",
+        value_name = "PATTERN",
+        conflicts_with = "dump"
+    )]
+    pub exclude_extension: Vec<String>,
+
     #[command(flatten)]
     pub connection: Connection,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -237,7 +237,7 @@ pub struct Pull {
     pub error_file: PathBuf,
 
     /// Exclude tables matching PATTERN (also matches views,
-    /// materialized views, and sequences); repeatable. Ignored with
+    /// materialized views, and sequences); repeatable. Conflicts with
     /// --dump
     #[arg(
         short = 'T',
@@ -247,7 +247,7 @@ pub struct Pull {
     )]
     pub exclude_table: Vec<String>,
 
-    /// Exclude schemas matching PATTERN; repeatable. Ignored with --dump
+    /// Exclude schemas matching PATTERN; repeatable. Conflicts with --dump
     #[arg(
         short = 'N',
         long = "exclude-schema",
@@ -256,7 +256,7 @@ pub struct Pull {
     )]
     pub exclude_schema: Vec<String>,
 
-    /// Exclude extensions matching PATTERN; repeatable. Ignored with
+    /// Exclude extensions matching PATTERN; repeatable. Conflicts with
     /// --dump
     #[arg(
         long = "exclude-extension",

--- a/src/pgdump.rs
+++ b/src/pgdump.rs
@@ -5,13 +5,21 @@ use std::process::{Command, Stdio};
 
 use crate::cli;
 
-/// DDL suppression flags passed through to pg_dump
+/// DDL suppression flags and object exclusions passed through to
+/// pg_dump
 #[derive(Default)]
 pub struct DumpDdl {
     pub no_owner: bool,
     pub no_privileges: bool,
     pub no_security_labels: bool,
     pub no_tablespaces: bool,
+    /// `--exclude-table` patterns (also match views, materialized
+    /// views, and sequences, as in pg_dump)
+    pub exclude_tables: Vec<String>,
+    /// `--exclude-schema` patterns
+    pub exclude_schemas: Vec<String>,
+    /// `--exclude-extension` patterns
+    pub exclude_extensions: Vec<String>,
 }
 
 /// Dump the database schema described by the connection options to
@@ -29,16 +37,7 @@ pub fn dump(
     command.arg("-f").arg(path);
     command.arg("-Fc");
     command.arg("--schema-only");
-    for (flag, enabled) in [
-        ("--no-owner", ddl.no_owner),
-        ("--no-privileges", ddl.no_privileges),
-        ("--no-security-labels", ddl.no_security_labels),
-        ("--no-tablespaces", ddl.no_tablespaces),
-    ] {
-        if enabled {
-            command.arg(flag);
-        }
-    }
+    command.args(ddl_args(ddl));
     execute(command)
 }
 
@@ -81,6 +80,33 @@ pub fn apply(conn: &cli::Connection, script: &Path) -> Result<(), String> {
     Ok(())
 }
 
+/// The DDL-suppression and object-exclusion flags for a pg_dump
+/// invocation, in a stable order
+fn ddl_args(ddl: &DumpDdl) -> Vec<String> {
+    let mut args = Vec::new();
+    for (flag, enabled) in [
+        ("--no-owner", ddl.no_owner),
+        ("--no-privileges", ddl.no_privileges),
+        ("--no-security-labels", ddl.no_security_labels),
+        ("--no-tablespaces", ddl.no_tablespaces),
+    ] {
+        if enabled {
+            args.push(flag.to_string());
+        }
+    }
+    for (flag, patterns) in [
+        ("--exclude-table", &ddl.exclude_tables),
+        ("--exclude-schema", &ddl.exclude_schemas),
+        ("--exclude-extension", &ddl.exclude_extensions),
+    ] {
+        for pattern in patterns {
+            args.push(flag.to_string());
+            args.push(pattern.clone());
+        }
+    }
+    args
+}
+
 fn connection_args(command: &mut Command, conn: &cli::Connection) {
     command.arg("-h").arg(&conn.host);
     command.arg("-p").arg(conn.port.to_string());
@@ -111,4 +137,42 @@ fn execute(mut command: Command) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ddl_args_emits_suppressions_and_exclusions() {
+        let ddl = DumpDdl {
+            no_owner: true,
+            no_privileges: false,
+            no_security_labels: false,
+            no_tablespaces: true,
+            exclude_tables: vec!["public.big".into(), "report.*_vw".into()],
+            exclude_schemas: vec!["pgq".into()],
+            exclude_extensions: vec!["pg_cron".into()],
+        };
+        assert_eq!(
+            ddl_args(&ddl),
+            vec![
+                "--no-owner",
+                "--no-tablespaces",
+                "--exclude-table",
+                "public.big",
+                "--exclude-table",
+                "report.*_vw",
+                "--exclude-schema",
+                "pgq",
+                "--exclude-extension",
+                "pg_cron",
+            ]
+        );
+    }
+
+    #[test]
+    fn ddl_args_empty_by_default() {
+        assert!(ddl_args(&DumpDdl::default()).is_empty());
+    }
 }

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -49,6 +49,9 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
         no_privileges: args.no_privileges,
         no_security_labels: args.no_security_labels,
         no_tablespaces: args.no_tablespaces,
+        exclude_tables: args.exclude_table.clone(),
+        exclude_schemas: args.exclude_schema.clone(),
+        exclude_extensions: args.exclude_extension.clone(),
     };
     let (assembly, _) = snapshot(
         args.dump.as_deref(),


### PR DESCRIPTION
## Summary
Exposes pg_dump's exclusion flags on `pull` so unwanted objects can be left out at the source.

## Problem
Pulling a large production database pulls in everything pg_dump emits — including objects irrelevant to the project (monitoring schemas like `pgq`, generated partition tables) or ones that trip downstream processing. There was no way to scope a pull short of editing the result afterward.

## Solution
Three repeatable options on `pull`, passed straight through to `pg_dump` with its native pattern syntax:

- `-T, --exclude-table PATTERN` — also matches views, materialized views, and sequences (as in pg_dump)
- `-N, --exclude-schema PATTERN`
- `--exclude-extension PATTERN`

They apply only when connecting to a database; with `--dump` the archive is already built, so the combination is rejected (`conflicts_with = "dump"`). Threaded through `DumpDdl`; the flag-building is extracted into a pure `ddl_args` helper and unit-tested.

## Impact
New `pull` options; default behavior unchanged (no exclusions). Also a practical workaround for the libpgfmt hang — exclude the offending schema/objects until the upstream loop is fixed.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (107 lib + integration) all pass, including new `ddl_args` unit tests (flag ordering, empty default). Verified live against PG17: `-T test.users` drops the table from the project, `-N test` drops the whole schema, and `--dump` + `-T` errors with a clear conflict message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repeatable `-T/--exclude-table`, `-N/--exclude-schema`, and `--exclude-extension` options to the `pull` command to filter database objects when connecting to a live database.
  * Exclusion filters are passed through to pg_dump with matching flag semantics and are rejected/ignored when using `--dump`.

* **Documentation**
  * Updated the `pull` command docs to describe the new options, their pattern syntax, and their live-connection vs `--dump` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->