### PR TITLE
Add --style to pull for the libpgfmt formatting style

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -122,7 +122,7 @@ pglifecycle pull [OPTIONS] DEST
 | `--remove-empty-dirs` | Remove empty directories after generation |
 | `--save-remaining` | Save unprocessed dump entries to `remaining.yaml` |
 | `--error-file FILE` | Where to record failures and their DDL (default `pglifecycle-errors.log`) |
-| `--style STYLE` | libpgfmt style for view queries and function bodies (default `aweber`) |
+| `--style STYLE` | libpgfmt style for view/materialized view queries and function bodies (default `aweber`) |
 | `-T, --exclude-table PATTERN` | Exclude tables/views/sequences matching `PATTERN` (repeatable; ignored with `--dump`) |
 | `-N, --exclude-schema PATTERN` | Exclude schemas matching `PATTERN` (repeatable; ignored with `--dump`) |
 | `--exclude-extension PATTERN` | Exclude extensions matching `PATTERN` (repeatable; ignored with `--dump`) |
@@ -134,8 +134,8 @@ archive is already built, so they are rejected as conflicting.
 
 The `--style` value is one of libpgfmt's styles — `river`, `mozilla`,
 `aweber`, `dbt`, `gitlab`, `kickstarter`, or `mattmc3` — and controls
-only how view queries and function bodies are formatted in the
-generated project. Note that `deploy` always re-formats the database
+only how view/materialized view queries and function bodies are
+formatted in the generated project. Note that `deploy` always re-formats the database
 side with the default (`aweber`) to compare it against the project, so
 pulling with a non-default style will make `deploy` report
 formatting-only differences for every view and function.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -122,6 +122,7 @@ pglifecycle pull [OPTIONS] DEST
 | `--remove-empty-dirs` | Remove empty directories after generation |
 | `--save-remaining` | Save unprocessed dump entries to `remaining.yaml` |
 | `--error-file FILE` | Where to record failures and their DDL (default `pglifecycle-errors.log`) |
+| `--style STYLE` | libpgfmt style for view queries and function bodies (default `aweber`) |
 | `-T, --exclude-table PATTERN` | Exclude tables/views/sequences matching `PATTERN` (repeatable; ignored with `--dump`) |
 | `-N, --exclude-schema PATTERN` | Exclude schemas matching `PATTERN` (repeatable; ignored with `--dump`) |
 | `--exclude-extension PATTERN` | Exclude extensions matching `PATTERN` (repeatable; ignored with `--dump`) |
@@ -130,6 +131,14 @@ The exclude patterns are passed through to `pg_dump` (`--exclude-table`,
 `--exclude-schema`, `--exclude-extension`) and use the same pattern
 syntax. They apply only when connecting to a database; with `--dump` the
 archive is already built, so they are rejected as conflicting.
+
+The `--style` value is one of libpgfmt's styles — `river`, `mozilla`,
+`aweber`, `dbt`, `gitlab`, `kickstarter`, or `mattmc3` — and controls
+only how view queries and function bodies are formatted in the
+generated project. Note that `deploy` always re-formats the database
+side with the default (`aweber`) to compare it against the project, so
+pulling with a non-default style will make `deploy` report
+formatting-only differences for every view and function.
 
 ### Diagnosing parse and format failures
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -265,6 +265,15 @@ pub struct Pull {
     )]
     pub exclude_extension: Vec<String>,
 
+    /// libpgfmt style for view queries and function bodies: river,
+    /// mozilla, aweber, dbt, gitlab, kickstarter, or mattmc3. Note that
+    /// `deploy` always compares using the default (aweber), so a
+    /// non-default style here makes `deploy` report formatting-only
+    /// differences
+    #[arg(long, value_name = "STYLE", default_value = "aweber",
+          value_parser = parse_style)]
+    pub style: libpgfmt::style::Style,
+
     #[command(flatten)]
     pub connection: Connection,
 
@@ -287,4 +296,10 @@ pub struct Pull {
     /// Destination directory for the project
     #[arg(value_name = "DEST")]
     pub destination: PathBuf,
+}
+
+/// Parse a libpgfmt style name for `--style`, surfacing the supported
+/// names on error.
+fn parse_style(value: &str) -> Result<libpgfmt::style::Style, String> {
+    value.parse()
 }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -34,8 +34,15 @@ pub fn deploy(args: &cli::Deploy) -> Result<(), String> {
         no_privileges: args.no_privileges,
         ..Default::default()
     };
-    let (assembly, snapshot) =
-        pull::snapshot(args.dump.as_deref(), &args.connection, &ddl, false)?;
+    // deploy compares against the project's stored SQL, which pull
+    // formats with the default style unless overridden; match it here
+    let (assembly, snapshot) = pull::snapshot(
+        args.dump.as_deref(),
+        &args.connection,
+        &ddl,
+        false,
+        libpgfmt::style::Style::Aweber,
+    )?;
     let task = progress::spinner("Diffing project against database");
     let diff = diff::diff(&project, &assembly);
     let resolutions = resolutions(&project, &diff);

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -59,6 +59,7 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
         &args.connection,
         &ddl,
         args.extract_roles,
+        args.style,
     )?;
     let task = progress::spinner("Rendering project");
     let files = writer::render(&assembly, args)?;
@@ -78,6 +79,7 @@ pub fn snapshot(
     conn: &cli::Connection,
     ddl: &pgdump::DumpDdl,
     extract_roles: bool,
+    style: libpgfmt::style::Style,
 ) -> Result<(Assembly, libpgdump::Dump), String> {
     let mut temp_dump: Option<tempfile::NamedTempFile> = None;
     let dump_path = match dump_path {
@@ -117,7 +119,7 @@ pub fn snapshot(
         })?;
         assembly.ingest_roles(&text)?;
     }
-    assembly.format_sql();
+    assembly.format_sql(style);
     Ok((assembly, dump))
 }
 
@@ -735,7 +737,7 @@ impl Assembly {
     /// style). On a formatting error — or if a single statement exceeds
     /// [`FORMAT_TIMEOUT`] (a likely upstream hang) — the original text
     /// is kept and the statement is recorded to the diagnostics report.
-    pub fn format_sql(&mut self) {
+    pub fn format_sql(&mut self, style: libpgfmt::style::Style) {
         let total = self.views.len()
             + self.materialized_views.len()
             + self.functions.len();
@@ -744,7 +746,9 @@ impl Assembly {
             if let Some(query) = &view.query {
                 task.set_message(format!("Formatting view {}", view.name));
                 let label = format!("view {}", view.name);
-                if let Some(formatted) = format_one(query, false, &label) {
+                if let Some(formatted) =
+                    format_one(query, false, &label, style)
+                {
                     view.query = Some(strip_trailing(&formatted));
                 }
             }
@@ -757,7 +761,9 @@ impl Assembly {
                     view.name
                 ));
                 let label = format!("materialized view {}", view.name);
-                if let Some(formatted) = format_one(query, false, &label) {
+                if let Some(formatted) =
+                    format_one(query, false, &label, style)
+                {
                     view.query = Some(strip_trailing(&formatted));
                 }
             }
@@ -778,7 +784,9 @@ impl Assembly {
                 }
             };
             let label = format!("function {}", function.name);
-            if let Some(formatted) = format_one(definition, plpgsql, &label) {
+            if let Some(formatted) =
+                format_one(definition, plpgsql, &label, style)
+            {
                 function.definition = Some(formatted);
             }
             task.inc();
@@ -811,15 +819,19 @@ const FORMAT_TIMEOUT: Duration = Duration::from_millis(500);
 /// formatted SQL, or `None` to mean "keep the original" — on a
 /// formatting error or a [`FORMAT_TIMEOUT`] overrun, both recorded to
 /// the diagnostics report so the offending DDL can be reproduced.
-fn format_one(sql: &str, plpgsql: bool, label: &str) -> Option<String> {
-    use libpgfmt::style::Style;
+fn format_one(
+    sql: &str,
+    plpgsql: bool,
+    label: &str,
+    style: libpgfmt::style::Style,
+) -> Option<String> {
     diagnostics::enter(label, sql);
     let owned = sql.to_string();
     let result = run_with_timeout(FORMAT_TIMEOUT, move || {
         let formatted = if plpgsql {
-            libpgfmt::format_plpgsql(&owned, Style::Aweber)
+            libpgfmt::format_plpgsql(&owned, style)
         } else {
-            libpgfmt::format(&owned, Style::Aweber)
+            libpgfmt::format(&owned, style)
         };
         formatted.map_err(|e| e.to_string())
     });
@@ -1263,7 +1275,7 @@ mod tests {
     #[test]
     fn formats_view_queries() {
         let mut assembly = assembled();
-        assembly.format_sql();
+        assembly.format_sql(libpgfmt::style::Style::Aweber);
         let query = assembly.views[0].query.as_deref().unwrap();
         assert!(query.contains('\n'), "expected formatted query: {query}");
         assert!(!query.ends_with(';'));


### PR DESCRIPTION
## Summary
Exposes libpgfmt's formatting styles on `pull` via `--style`, so the generated project's view queries and function bodies can be formatted in a chosen style.

> Stacked on #33 (`feature/format-timeout`); base moves to `main` once #33 merges.

## Problem
`pull` hardcoded the AWeber style for all SQL formatting. libpgfmt ships seven styles and there was no way to pick one.

## Solution
`--style STYLE` — one of `river`, `mozilla`, `aweber` (default), `dbt`, `gitlab`, `kickstarter`, `mattmc3`. Parsed to `libpgfmt::style::Style` and threaded through `snapshot` → `format_sql` → `format_one`.

**No project.yaml persistence (by design).** `deploy` re-formats the database side to compare it against the stored project; it continues to use the default `aweber`. The help text and docs warn that pulling with a non-default style will make `deploy` report formatting-only differences for every view/function — an accepted trade-off to avoid changing the project contract.

## Impact
New `pull --style` option; default behavior unchanged. `deploy` unaffected.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (107 lib + integration) all pass. Verified live: `--style aweber|mozilla|dbt` each produce distinctly formatted view queries in the generated YAML, and an invalid value errors with libpgfmt's supported-style message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--style` flag to the `pull` command to customize SQL formatting for generated views/queries and function bodies (default: `aweber`)
  * `deploy` always re-formats using the default style, so using a non-default `pull` style may result in formatting-only differences

* **Documentation**
  * Updated the command reference to document supported `--style` values and the `deploy` interaction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->