### PR TITLE
Extend failure diagnostics to deploy

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -57,8 +57,13 @@ destructive statements are pending).
 | `--apply` | Execute the script in one transaction via psql (conflicts with `--dump`) |
 | `--allow-drop` | Include destructive statements in the script |
 | `-x, --no-privileges` | Do not include GRANT/REVOKE |
+| `--error-file FILE` | Where to record failures and their DDL (default `pglifecycle-errors.log`) |
 
-The connection options match `pull` (see below).
+The connection options match `pull` (see below). Like `pull`, `deploy`
+snapshots and formats the database with libpgfmt, so DDL that fails to
+parse or format — and the statement in flight if it is interrupted — is
+recorded to the error report (`--error-file`); see
+[Diagnosing parse and format failures](#diagnosing-parse-and-format-failures).
 
 ### Change reconciliation
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,6 +123,11 @@ pub struct Deploy {
     #[arg(short = 'x', long)]
     pub no_privileges: bool,
 
+    /// File to record DDL that fails to parse or format, and the
+    /// statement in flight if interrupted (for reproducing hangs)
+    #[arg(long, default_value = "pglifecycle-errors.log")]
+    pub error_file: PathBuf,
+
     #[command(flatten)]
     pub connection: Connection,
 

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -18,7 +18,9 @@ use std::io::IsTerminal;
 use crate::deploy::alter::Resolution;
 use crate::deploy::diff::{Change, Diff, ObjectKey};
 use crate::utils::quote_ident;
-use crate::{build, cli, constants, pgdump, progress, project, pull};
+use crate::{
+    build, cli, constants, diagnostics, pgdump, progress, project, pull,
+};
 
 pub fn deploy(args: &cli::Deploy) -> Result<(), String> {
     if args.connection.password && !std::io::stdin().is_terminal() {
@@ -27,6 +29,7 @@ pub fn deploy(args: &cli::Deploy) -> Result<(), String> {
              or use a pgpass file instead",
         ));
     }
+    diagnostics::init(args.error_file.clone());
     let project = project::load(&args.project)?;
     let source = source_label(args);
     log::info!("Comparing {} against {source}", project.name);


### PR DESCRIPTION
## Summary
Gives `deploy` the same error report and interrupt-capture that `pull` got in #30.

## Problem
`deploy` snapshots and formats the live database through `pull::snapshot` — so it hits the same DDL parse/format failures and the same libpgfmt hang risk. But the diagnostics report was only initialized by `pull`, so under `deploy` those failures went unrecorded and a Ctrl-C during a hang captured nothing.

## Solution
- Add `--error-file` to `deploy` (default `pglifecycle-errors.log`, matching `pull`).
- Call `diagnostics::init` at the start of `deploy()`. The `enter` / `record_failure` calls already on the formatting path then fire for `deploy` too, so a parse failure, a format failure, a 500ms format timeout, or an interrupt records the offending DDL for reproduction.

## Impact
New `deploy --error-file` option; the report is created only when there is something to report. No behavior change otherwise.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (109) all pass. `deploy --help` shows the new flag; the underlying diagnostics module is already unit-tested (report format, no-op-without-init, interrupt capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `deploy` command now supports a `--error-file` option to specify where parsing and formatting failures are recorded during deployment, defaulting to `pglifecycle-errors.log`.

* **Documentation**
  * Updated `deploy` command documentation with details on the new error file option and how connection options align with the `pull` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->