### PR TITLE
Bump libpgfmt to 1.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "libpgfmt"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d6f80b7b0667f3a56aeb295069718015235e9aac28423799d05fab2482f81"
+checksum = "3c28ac621e0eaf0ae8256159540aca18615f599f55f2f85008434988689c9313"
 dependencies = [
  "tree-sitter",
  "tree-sitter-postgres",
@@ -1398,9 +1398,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-postgres"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162cad52646c3f61a49a539486841d67f23fcb6ca5c01958403fc28b985e551"
+checksum = "81b6b5beaa4ef890a0ccf39eee2644752cef73669b336b8723899c08c382ed0c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ indicatif = "0.18.4"
 indicatif-log-bridge = "0.2.3"
 jsonschema = { version = "0.46.5", default-features = false }
 libpgdump = "2.1"
-libpgfmt = "1.1.2"
+libpgfmt = "1.1.5"
 log = "0.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150", features = ["preserve_order"] }


### PR DESCRIPTION
## Summary
Updates the libpgfmt SQL formatter from 1.1.3 to 1.1.5.

## Details
`cargo update -p libpgfmt` moved libpgfmt 1.1.3 → 1.1.5 and pulled tree-sitter-postgres 1.2.1 → 1.2.2 along with it (within the existing `1.2` caret range).

## Testing
`cargo build`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (109) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)