### PR TITLE
Emit project YAML with serde_norway, drop the custom emitter

### DIFF
--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -1,10 +1,11 @@
 //! The `create` command: scaffold an empty project directory
 
-use std::fmt::Write as _;
 use std::fs;
 
+use serde_json::json;
+
 use crate::cli;
-use crate::constants;
+use crate::{constants, yamlio};
 
 pub fn create(args: &cli::Create) -> Result<(), String> {
     let dest = &args.destination;
@@ -31,10 +32,12 @@ pub fn create(args: &cli::Create) -> Result<(), String> {
             fs::write(path.join(".gitkeep"), "").map_err(|e| e.to_string())?;
         }
     }
-    let mut yaml = String::from("---\n");
-    let _ = writeln!(yaml, "name: {name}");
-    let _ = writeln!(yaml, "encoding: {}", args.encoding);
-    let _ = writeln!(yaml, "stdstrings: {}", !args.no_stdstrings);
-    let _ = writeln!(yaml, "superuser: {}", args.superuser);
-    fs::write(dest.join("project.yaml"), yaml).map_err(|e| e.to_string())
+    let project = json!({
+        "name": name,
+        "encoding": args.encoding,
+        "stdstrings": !args.no_stdstrings,
+        "superuser": args.superuser,
+    });
+    fs::write(dest.join("project.yaml"), yamlio::dump(&project))
+        .map_err(|e| e.to_string())
 }

--- a/src/yamlio.rs
+++ b/src/yamlio.rs
@@ -32,11 +32,10 @@ pub fn load_str(content: &str) -> Result<Value, serde_norway::Error> {
     Value::deserialize(serde_norway::Deserializer::from_str(content))
 }
 
-/// Render a value as a YAML document with a `---` header
+/// Render a value as a YAML document
 pub fn dump(value: &Value) -> String {
-    let body = serde_norway::to_string(value)
-        .expect("serializing a serde_json::Value to YAML cannot fail");
-    format!("---\n{body}")
+    serde_norway::to_string(value)
+        .expect("serializing a serde_json::Value to YAML cannot fail")
 }
 
 #[cfg(test)]
@@ -44,11 +43,6 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-
-    #[test]
-    fn starts_with_document_marker() {
-        assert!(dump(&json!({"name": "x"})).starts_with("---\n"));
-    }
 
     #[test]
     fn round_trips_nested_structures() {

--- a/src/yamlio.rs
+++ b/src/yamlio.rs
@@ -1,13 +1,12 @@
-//! YAML load/save (ports yaml.py + the ruamel emission style)
+//! YAML load/save (ports yaml.py)
 //!
-//! Loading goes through serde_norway into `serde_json::Value` (built with
-//! `preserve_order`, so mappings keep file order). Emission is a small
-//! custom emitter because no maintained serde YAML emitter offers scalar
-//! style control: multi-line strings must emit as literal block scalars
-//! to match the ruamel.yaml output the project format was built on
-//! (mapping indent 2, sequence indent 4, dash offset 2).
+//! Both directions go through serde_norway (the maintained successor to
+//! the deprecated serde-yaml): loading deserializes into a
+//! `serde_json::Value` (built with `preserve_order`, so mappings keep
+//! file order) and emission serializes that `Value` back. serde_norway
+//! renders multi-line strings as literal block scalars, so formatted
+//! view queries and function bodies stay readable.
 
-use std::fmt::Write;
 use std::path::Path;
 
 use serde::Deserialize;
@@ -35,144 +34,9 @@ pub fn load_str(content: &str) -> Result<Value, serde_norway::Error> {
 
 /// Render a value as a YAML document with a `---` header
 pub fn dump(value: &Value) -> String {
-    let mut out = String::from("---\n");
-    match value {
-        Value::Object(_) | Value::Array(_) => emit(&mut out, value, 0),
-        scalar => {
-            out.push_str(&scalar_repr(scalar, 0));
-            out.push('\n');
-        }
-    }
-    out
-}
-
-fn emit(out: &mut String, value: &Value, indent: usize) {
-    match value {
-        Value::Object(map) => {
-            for (key, val) in map {
-                pad(out, indent);
-                out.push_str(&plain_or_quoted(key));
-                out.push(':');
-                emit_nested(out, val, indent);
-            }
-        }
-        Value::Array(items) => {
-            for item in items {
-                pad(out, indent);
-                out.push('-');
-                emit_nested(out, item, indent + 2);
-            }
-        }
-        scalar => {
-            pad(out, indent);
-            out.push_str(&scalar_repr(scalar, indent));
-            out.push('\n');
-        }
-    }
-}
-
-/// Emit a mapping value or sequence item after its `key:` / `-` prefix
-fn emit_nested(out: &mut String, value: &Value, indent: usize) {
-    match value {
-        Value::Object(map) if !map.is_empty() => {
-            out.push('\n');
-            emit(out, value, indent + 2);
-        }
-        Value::Array(items) if !items.is_empty() => {
-            out.push('\n');
-            emit(out, value, indent + 2);
-        }
-        Value::Object(_) => out.push_str(" {}\n"),
-        Value::Array(_) => out.push_str(" []\n"),
-        scalar => {
-            out.push(' ');
-            out.push_str(&scalar_repr(scalar, indent));
-            out.push('\n');
-        }
-    }
-}
-
-fn pad(out: &mut String, indent: usize) {
-    for _ in 0..indent {
-        out.push(' ');
-    }
-}
-
-fn scalar_repr(value: &Value, indent: usize) -> String {
-    match value {
-        Value::Null => String::new(),
-        Value::Bool(b) => b.to_string(),
-        Value::Number(n) => n.to_string(),
-        Value::String(s) if s.contains('\n') => block_scalar(s, indent),
-        Value::String(s) => plain_or_quoted(s),
-        _ => unreachable!("containers handled by emit"),
-    }
-}
-
-/// Literal block scalar (`|` / `|-` / `|+`) with content indented two
-/// spaces past the current level, matching ruamel.yaml
-fn block_scalar(value: &str, indent: usize) -> String {
-    let header = if value.ends_with('\n') {
-        if value.ends_with("\n\n") { "|+" } else { "|" }
-    } else {
-        "|-"
-    };
-    let mut out = String::from(header);
-    for line in value.trim_end_matches('\n').split('\n') {
-        out.push('\n');
-        if !line.is_empty() {
-            let _ = write!(out, "{:width$}{line}", "", width = indent + 2);
-        }
-    }
-    for _ in value.trim_end_matches('\n').len()..value.len().saturating_sub(1)
-    {
-        out.push('\n');
-    }
-    out
-}
-
-fn plain_or_quoted(value: &str) -> String {
-    if is_plain_safe(value) {
-        value.to_string()
-    } else {
-        format!("'{}'", value.replace('\'', "''"))
-    }
-}
-
-/// Conservative plain-scalar test: anything ambiguous gets single-quoted
-fn is_plain_safe(value: &str) -> bool {
-    if value.is_empty()
-        || value != value.trim()
-        || value.starts_with([
-            '!', '&', '*', '-', '?', '#', '|', '>', '@', '`', '"', '\'', '%',
-            '[', ']', '{', '}', ',', ' ',
-        ])
-    {
-        return false;
-    }
-    if value.contains(": ")
-        || value.ends_with(':')
-        || value.contains(" #")
-        || value.contains('\t')
-    {
-        return false;
-    }
-    // strings that would parse as another scalar type need quoting
-    let lowered = value.to_ascii_lowercase();
-    if matches!(
-        lowered.as_str(),
-        "null" | "~" | "true" | "false" | "yes" | "no" | "on" | "off"
-    ) {
-        return false;
-    }
-    !looks_numeric(value)
-}
-
-fn looks_numeric(value: &str) -> bool {
-    value.parse::<i64>().is_ok()
-        || value.parse::<f64>().is_ok()
-        || (value.starts_with("0x") && value.len() > 2)
-        || (value.starts_with("0o") && value.len() > 2)
+    let body = serde_norway::to_string(value)
+        .expect("serializing a serde_json::Value to YAML cannot fail");
+    format!("---\n{body}")
 }
 
 #[cfg(test)]
@@ -180,6 +44,11 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn starts_with_document_marker() {
+        assert!(dump(&json!({"name": "x"})).starts_with("---\n"));
+    }
 
     #[test]
     fn round_trips_nested_structures() {
@@ -200,22 +69,23 @@ mod tests {
     fn multiline_strings_emit_literal_blocks() {
         let value = json!({"query": "SELECT id\n  FROM users\n"});
         let text = dump(&value);
-        assert!(text.contains("query: |\n  SELECT id\n    FROM users\n"));
+        // a literal block scalar keeps the SQL readable rather than a
+        // single double-quoted line with `\n` escapes
+        assert!(text.contains("query: |"), "expected block scalar:\n{text}");
+        assert!(text.contains("\n  SELECT id\n"), "{text}");
         assert_eq!(load_str(&text).unwrap(), value);
     }
 
     #[test]
-    fn preserves_multiple_trailing_newlines() {
+    fn round_trips_multiple_trailing_newlines() {
         for body in ["text\n\n", "text\n\n\n"] {
             let value = json!({ "body": body });
-            let emitted = dump(&value);
-            assert!(emitted.contains("|+"));
-            assert_eq!(load_str(&emitted).unwrap(), value);
+            assert_eq!(load_str(&dump(&value)).unwrap(), value);
         }
     }
 
     #[test]
-    fn quotes_ambiguous_scalars() {
+    fn round_trips_ambiguous_scalars() {
         let value = json!({
             "a": "true", "b": "123", "c": "===", "d": "with: colon",
             "e": "", "f": "trailing \n", "g": "it's",

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -24,7 +24,7 @@ fn creates_skeleton_project() {
     let yaml = fs::read_to_string(tmp.join("project.yaml")).unwrap();
     assert_eq!(
         yaml,
-        "---\nname: pglc-test-create\nencoding: UTF-8\n\
+        "name: pglc-test-create\nencoding: UTF-8\n\
          stdstrings: true\nsuperuser: postgres\n"
     );
 }
@@ -62,7 +62,7 @@ fn create_honors_options() {
     let yaml = fs::read_to_string(tmp.join("project.yaml")).unwrap();
     assert_eq!(
         yaml,
-        "---\nname: example\nencoding: LATIN1\n\
+        "name: example\nencoding: LATIN1\n\
          stdstrings: false\nsuperuser: admin\n"
     );
 }


### PR DESCRIPTION
## Summary
Replaces the hand-written YAML emitter with `serde_norway` (the maintained serde-yaml successor already used for loading), fixing the verbose block-sequence style, dropping the `---` document marker, and removing all hand-rolled YAML (the custom emitter and `create`'s `writeln!` builder).

## Problem
`pull`/`build` rendered block sequences with the dash on its own line and the mapping keys over-indented:

```yaml
extensions:
  -
      name: pg_cron
      schema: pg_catalog
```

That diverged from the project's compact contract. Separately, `create` hand-built `project.yaml` with raw `writeln!`, which would emit invalid YAML for a project name containing a colon or leading symbol.

## Solution
- `yamlio::dump` now serializes the `serde_json::Value` through `serde_norway::to_string`. It emits the compact `- key:` form and renders multi-line strings as literal block scalars (`|-`), so formatted view queries and function bodies stay readable — the original reason for the custom emitter.
- The `---` document marker is **no longer emitted**.
- `skeleton::create` builds a `Value` and emits it via `yamlio::dump` too, so scalars are quoted correctly; no hand-rolled YAML remains in the codebase.
- Removed the custom `emit`/`block_scalar`/`plain_or_quoted`/`is_plain_safe`/… helpers (~140 lines).

### Output deltas vs the old emitter
- Compact block sequences (`- name: ...`) instead of dash-on-its-own-line.
- Sequence dashes sit at the parent key's column (serde_norway's zero-indent block style).
- Short scalar arrays render as multi-line blocks rather than flow `[a, b]`.
- No leading `---`.
- Multi-line SQL still uses literal block scalars.

This reformats every generated file, so a `pull --update` against an existing project will rewrite them once.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (109) all pass. Emitter tests assert the round-trip invariant (`load(dump(v)) == v`) and block-scalar usage rather than an exact byte layout; verified serde_norway round-trips the prior edge cases (multiple trailing newlines, ambiguous scalars). `create` integration tests updated for the new output. Manually pulled the fixtures schema (compact, no `---`) and confirmed the pulled project still `build`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Multiline YAML strings are now emitted as literal block scalars (using `|`) for more consistent readability.
* **Behavior Changes**
  * Generated `project.yaml` content has updated YAML formatting, including removal of the leading YAML document start marker before the `name`/`encoding` fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->