### PR TITLE
Print a summary line at the end of pull

### DIFF
--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -64,11 +64,20 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
     let task = progress::spinner("Rendering project");
     let files = writer::render(&assembly, args)?;
     task.finish();
-    if args.update {
-        update::merge(&files, args)
+    let objects = assembly.object_count();
+    let verb = if args.update {
+        update::merge(&files, args)?;
+        "Updated"
     } else {
-        writer::write_bootstrap(&files, args)
-    }
+        writer::write_bootstrap(&files, args)?;
+        "Created"
+    };
+    let plural = if objects == 1 { "object" } else { "objects" };
+    println!(
+        "{verb} your schema project at {} with {objects} {plural}",
+        args.destination.display()
+    );
+    Ok(())
 }
 
 /// Snapshot a database (or an existing dump file) into an [`Assembly`],
@@ -248,6 +257,23 @@ pub struct Assembly {
 }
 
 impl Assembly {
+    /// Count the modeled objects written to the project (the things a
+    /// user thinks of as schema objects); excludes unparsed `remaining`
+    /// entries and the database-level metadata
+    pub fn object_count(&self) -> usize {
+        self.extensions.len()
+            + self.languages.len()
+            + self.schemas.len()
+            + self.domains.len()
+            + self.types.len()
+            + self.sequences.len()
+            + self.tables.len()
+            + self.views.len()
+            + self.materialized_views.len()
+            + self.functions.len()
+            + self.roles.len()
+    }
+
     /// Parse every supported archive entry into the project models
     pub fn ingest(&mut self, dump: &libpgdump::Dump) -> Result<(), String> {
         use libpgdump::ObjectType as OT;


### PR DESCRIPTION
## Summary
Ends a `pull` with a one-line result instead of trailing off after the progress bars.

> Stacked on #38 (libpgfmt 1.1.6); base retargets to main once #38 merges. (Only Cargo.* differ between them, no source overlap.)

## Solution
- `Assembly::object_count()` — counts the modeled schema objects (extensions, languages, schemas, domains, types, sequences, tables, views, materialized views, functions, roles); excludes unparsed `remaining` entries and database-level metadata.
- `pull` prints, once the write succeeds:
  - `Created your schema project at <path> with N objects` (bootstrap)
  - `Updated your schema project at <path> with N objects` (`--update`)

  to stdout (pull has no other stdout), with singular/plural handling.

## Impact
Purely additive output; no behavior change. (Wording is easy to tweak — e.g. "schema repo" instead of "schema project" — say the word.)

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (109) pass. Verified against the fixtures schema: bootstrap prints `Created … with 11 objects`, a no-op `--update` prints `Updated … with 11 objects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)