### PR TITLE
Support WITH GRANT OPTION in ACLs

### DIFF
--- a/schemata/acls.yml
+++ b/schemata/acls.yml
@@ -12,7 +12,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [SELECT, INSERT, UPDATE, DELETE, ALL]
+          pattern: "^(SELECT|INSERT|UPDATE|DELETE|ALL)( WITH GRANT OPTION)?$"
   databases:
     type: object
     propertyNames:
@@ -21,7 +21,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [CREATE, CONNECT, TEMP, TEMPORARY, ALL]
+          pattern: "^(CREATE|CONNECT|TEMP|TEMPORARY|ALL)( WITH GRANT OPTION)?$"
   domains:
     type: object
     propertyNames:
@@ -30,7 +30,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [USAGE, ALL]
+          pattern: "^(USAGE|ALL)( WITH GRANT OPTION)?$"
   foreign_data_wrappers:
     type: object
     propertyNames:
@@ -39,7 +39,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [USAGE, ALL]
+          pattern: "^(USAGE|ALL)( WITH GRANT OPTION)?$"
   foreign_servers:
     type: object
     propertyNames:
@@ -48,7 +48,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [USAGE, ALL]
+          pattern: "^(USAGE|ALL)( WITH GRANT OPTION)?$"
   functions:
     type: object
     propertyNames:
@@ -57,7 +57,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [EXECUTE, ALL]
+          pattern: "^(EXECUTE|ALL)( WITH GRANT OPTION)?$"
   groups:
     type: array
     items:
@@ -71,7 +71,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [USAGE, ALL]
+          pattern: "^(USAGE|ALL)( WITH GRANT OPTION)?$"
   large_objects:
     type: object
     propertyNames:
@@ -80,7 +80,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [SELECT, UPDATE, ALL]
+          pattern: "^(SELECT|UPDATE|ALL)( WITH GRANT OPTION)?$"
   roles:
     type: array
     items:
@@ -94,7 +94,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [CREATE, USAGE, ALL]
+          pattern: "^(CREATE|USAGE|ALL)( WITH GRANT OPTION)?$"
   sequences:
     type: object
     propertyNames:
@@ -103,7 +103,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [SELECT, UPDATE, USAGE, ALL]
+          pattern: "^(SELECT|UPDATE|USAGE|ALL)( WITH GRANT OPTION)?$"
   tables:
     type: object
     propertyNames:
@@ -112,7 +112,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [SELECT, INSERT, UPDATE, DELETE, ALL]
+          pattern: "^(SELECT|INSERT|UPDATE|DELETE|ALL)( WITH GRANT OPTION)?$"
   tablespaces:
     type: object
     propertyNames:
@@ -121,7 +121,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [CREATE, USAGE, ALL]
+          pattern: "^(CREATE|USAGE|ALL)( WITH GRANT OPTION)?$"
   types:
     type: object
     propertyNames:
@@ -130,7 +130,7 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [USAGE, ALL]
+          pattern: "^(USAGE|ALL)( WITH GRANT OPTION)?$"
   views:
     type: object
     propertyNames:
@@ -139,5 +139,5 @@ properties:
       "^.*$":
         type: array
         items:
-          enum: [SELECT, ALL]
+          pattern: "^(SELECT|ALL)( WITH GRANT OPTION)?$"
 additionalProperties: false

--- a/src/build/acls.rs
+++ b/src/build/acls.rs
@@ -19,6 +19,10 @@ use crate::utils::quote_ident;
 
 use super::Builder;
 
+/// Marker appended to a privilege in acls.yml when it was granted with
+/// grant option (e.g. `SELECT WITH GRANT OPTION`)
+const GRANT_OPTION_SUFFIX: &str = " WITH GRANT OPTION";
+
 /// PostgreSQL grants on views and materialized views use the same
 /// TABLE/COLUMN syntax as tables, so relation ACLs may target any of
 /// the three
@@ -154,19 +158,44 @@ fn collect(
             if privileges.is_empty() {
                 continue;
             }
+            // privileges carrying ` WITH GRANT OPTION` need their own
+            // statement (the option applies to every privilege in it)
+            let (grantable, plain): (Vec<String>, Vec<String>) = privileges
+                .into_iter()
+                .partition(|p| p.ends_with(GRANT_OPTION_SUFFIX));
+            let grantable: Vec<String> = grantable
+                .iter()
+                .map(|p| p.trim_end_matches(GRANT_OPTION_SUFFIX).to_string())
+                .collect();
             let entry = objects.entry((index, object.clone())).or_default();
-            let statement =
-                statement(revoke, keyword, key, object, &privileges, role);
-            if revoke {
-                entry.revokes.push(statement);
-            } else {
-                entry.grants.push(statement);
+            for (privileges, grant_option) in
+                [(plain, false), (grantable, true)]
+            {
+                if privileges.is_empty() {
+                    continue;
+                }
+                let statement = statement(
+                    revoke,
+                    keyword,
+                    key,
+                    object,
+                    &privileges,
+                    role,
+                    grant_option,
+                );
+                if revoke {
+                    entry.revokes.push(statement);
+                } else {
+                    entry.grants.push(statement);
+                }
             }
         }
     }
 }
 
-/// One GRANT or REVOKE statement for a role on an object
+/// One GRANT or REVOKE statement for a role on an object. With
+/// `grant_option`, a GRANT gains a trailing `WITH GRANT OPTION` and a
+/// REVOKE a leading `GRANT OPTION FOR`.
 pub(crate) fn statement(
     revoke: bool,
     keyword: &str,
@@ -174,6 +203,7 @@ pub(crate) fn statement(
     object: &str,
     privileges: &[String],
     role: &str,
+    grant_option: bool,
 ) -> String {
     let (privileges, object) = match section {
         // `schema.table.column` → `SELECT(column) ON TABLE schema.table`
@@ -193,13 +223,23 @@ pub(crate) fn statement(
         _ => (privileges.join(", "), quote_object(object)),
     };
     if revoke {
+        let option = if grant_option {
+            "GRANT OPTION FOR "
+        } else {
+            ""
+        };
         format!(
-            "REVOKE {privileges} ON {keyword} {object} FROM {};",
+            "REVOKE {option}{privileges} ON {keyword} {object} FROM {};",
             quote_role(role)
         )
     } else {
+        let option = if grant_option {
+            " WITH GRANT OPTION"
+        } else {
+            ""
+        };
         format!(
-            "GRANT {privileges} ON {keyword} {object} TO {};",
+            "GRANT {privileges} ON {keyword} {object} TO {}{option};",
             quote_role(role)
         )
     }
@@ -363,5 +403,74 @@ mod tests {
             .find(|e| e.desc == libpgdump::ObjectType::Schema)
             .expect("schema entry");
         assert_eq!(acl.dependencies, vec![schema.dump_id]);
+    }
+
+    #[test]
+    fn statement_renders_grant_option() {
+        let privileges = [String::from("SELECT")];
+        assert_eq!(
+            statement(false, "TABLE", "tables", "t.x", &privileges, "r", true),
+            "GRANT SELECT ON TABLE t.x TO r WITH GRANT OPTION;"
+        );
+        assert_eq!(
+            statement(true, "TABLE", "tables", "t.x", &privileges, "r", true),
+            "REVOKE GRANT OPTION FOR SELECT ON TABLE t.x FROM r;"
+        );
+    }
+
+    #[test]
+    fn grantable_privileges_get_their_own_grant() {
+        // `INSERT WITH GRANT OPTION` splits off from the plain grant
+        let role: models::Role = serde_json::from_value(json!({
+            "name": "app",
+            "create": false,
+            "grants": {"tables": {"test.users":
+                ["SELECT", "INSERT WITH GRANT OPTION"]}},
+        }))
+        .unwrap();
+        let table: models::Table = serde_json::from_value(json!({
+            "name": "users", "schema": "test", "owner": "postgres",
+            "columns": [{"name": "id", "data_type": "uuid"}],
+        }))
+        .unwrap();
+        let project = Project {
+            name: String::from("acls"),
+            encoding: String::from("UTF8"),
+            stdstrings: true,
+            superuser: String::from("postgres"),
+            default_schema: String::from("public"),
+            path: std::path::PathBuf::new(),
+            inventory: vec![
+                Item {
+                    id: 0,
+                    desc: ObjectType::Table,
+                    definition: Definition::Table(table),
+                    dependencies: BTreeSet::new(),
+                },
+                Item {
+                    id: 1,
+                    desc: ObjectType::Role,
+                    definition: Definition::Role(role),
+                    dependencies: BTreeSet::new(),
+                },
+            ],
+        };
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("acls.dump");
+        crate::build::build(&project, &path).unwrap();
+        let dump = libpgdump::load(&path).unwrap();
+        let acl = dump
+            .entries()
+            .iter()
+            .find(|e| e.desc == libpgdump::ObjectType::Acl)
+            .expect("ACL entry");
+        assert_eq!(
+            acl.defn.as_deref(),
+            Some(
+                "GRANT SELECT ON TABLE test.users TO app;\n\
+                 GRANT INSERT ON TABLE test.users TO app \
+                 WITH GRANT OPTION;\n"
+            )
+        );
     }
 }

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -549,13 +549,6 @@ impl Assembly {
     }
 
     fn apply_acl(&mut self, acl: &Acl) {
-        if acl.with_grant_option {
-            log::warn!(
-                "WITH GRANT OPTION is not representable in acls.yml; \
-                 dropping it for {:?}",
-                acl.objects
-            );
-        }
         let section = section_key(acl.target);
         for role in &acl.roles {
             let state = self.role(role);
@@ -566,17 +559,24 @@ impl Assembly {
             };
             for object in &acl.objects {
                 for privilege in &acl.privileges {
+                    // grant option is carried on the privilege string
+                    // (acls.yml), e.g. `SELECT WITH GRANT OPTION`
+                    let name = if acl.with_grant_option {
+                        format!("{} WITH GRANT OPTION", privilege.name)
+                    } else {
+                        privilege.name.clone()
+                    };
                     match &privilege.columns {
                         Some(columns) => {
                             for column in columns {
                                 maps.add(
                                     "columns",
                                     &format!("{object}.{column}"),
-                                    &privilege.name,
+                                    &name,
                                 );
                             }
                         }
-                        None => maps.add(section, object, &privilege.name),
+                        None => maps.add(section, object, &name),
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Stops `pull` from dropping `WITH GRANT OPTION` and lets `build` emit it. Representation B: the grant option is carried on the privilege string, e.g. `SELECT WITH GRANT OPTION`.

> Stacked on #39 → #38; base retargets as those merge.

## Problem
The parser already captured `with_grant_option`, but `acls.yml` had no way to represent it, so `pull` discarded it with `WITH GRANT OPTION is not representable in acls.yml; dropping it for [...]` and `build` could never re-emit it. On a database that uses grant option (e.g. the `pgq.event_*` tables granted to `pgq`) the pulled project silently under-represented privileges.

## Solution
- **`schemata/acls.yml`** — each privilege item becomes a pattern that accepts an optional ` WITH GRANT OPTION` suffix on the enum value (per section, preserving the existing privilege sets).
- **`pull` (`apply_acl`)** — appends the suffix when the grant is grantable; the drop-and-warn is gone.
- **`build` (`acls`)** — splits each object's privileges into plain and grantable groups and emits one statement per group: `GRANT … TO r WITH GRANT OPTION` and, for revocations, `REVOKE GRANT OPTION FOR … FROM r`.
- `statement()` gains a `grant_option` flag.

## Impact
ACLs now round-trip grant option. Existing projects (no suffix) are unaffected. Representation is human-readable per your call (B).

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (111) pass — new tests cover the renderer (GRANT + REVOKE forms) and a full build of a project with a grantable privilege. Verified live against PG17: `GRANT SELECT, INSERT ON test.users TO app WITH GRANT OPTION` pulls into `acls.yml` as `SELECT WITH GRANT OPTION` / `INSERT WITH GRANT OPTION`, validates on load, and builds back to the identical GRANT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)