### PR TITLE
Improve pull fidelity and output for roles, matviews, and comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "libpgfmt"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da565efc5a03689f10ab179ccd4d972a91a2008b2236827759f18e169872ad5"
+checksum = "b558aae558a0949dd7e82147bf0ae26bdc576607928f5e7799831c2575cb33ed"
 dependencies = [
  "tree-sitter",
  "tree-sitter-postgres",
@@ -1398,9 +1398,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-postgres"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d4968176b02e91b0521a1bf115bce33106343afc85af58c4bee7f1216099ac"
+checksum = "2552ec55c9813f358da70926587b2bbfceff6a7b75456b2ddf8abfb223dcf3a7"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,7 +118,7 @@ pglifecycle pull [OPTIONS] DEST
 | Option | Description |
 | --- | --- |
 | `-D, --dump FILE` | Use an existing `pg_dump -Fc` file instead of connecting |
-| `--no-roles` | Skip cluster role/user extraction (on by default for live connections; always skipped with `--dump`) |
+| `--no-roles` | Skip cluster role/user extraction (role/user extraction is enabled by default for live connections; always skipped with `--dump`) |
 | `--include-password-hashes` | Include role password hashes in users (omitted by default via `pg_dumpall --no-role-passwords`) |
 | `-i, --ignore FILE` | File listing project paths to skip writing |
 | `--force` | Write to `DEST` even if it already exists |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -19,6 +19,7 @@ pglifecycle create [OPTIONS] DEST
 | `--no-gitkeep` | Do not create `.gitkeep` files in empty directories |
 | `--no-stdstrings` | Turn off standard conforming strings |
 | `--superuser NAME` | Superuser name (default `postgres`) |
+| `--include-mode-headers` | Prefix generated files with editor mode headers |
 
 ## build
 
@@ -120,6 +121,7 @@ pglifecycle pull [OPTIONS] DEST
 | `-D, --dump FILE` | Use an existing `pg_dump -Fc` file instead of connecting |
 | `--no-roles` | Skip cluster role/user extraction (role/user extraction is enabled by default for live connections; always skipped with `--dump`) |
 | `--include-password-hashes` | Include role password hashes in users (omitted by default via `pg_dumpall --no-role-passwords`) |
+| `--include-mode-headers` | Prefix each generated file with editor mode headers (see below) |
 | `-i, --ignore FILE` | File listing project paths to skip writing |
 | `--force` | Write to `DEST` even if it already exists |
 | `--update` | Merge into an existing project, rewriting only changed files |
@@ -145,6 +147,23 @@ formatted in the generated project. Note that `deploy` always re-formats the dat
 side with the default (`aweber`) to compare it against the project, so
 pulling with a non-default style will make `deploy` report
 formatting-only differences for every view and function.
+
+With `--include-mode-headers`, each generated file is prefixed with two
+comment lines above the `---` document marker — an Emacs modeline and a
+`# pglifecycle: <kind>` type comment (`<kind>` is the object-type noun,
+e.g. `table`, `materialized_view`, `function`) that editor extensions
+can key off to detect pglifecycle files:
+
+```yaml
+# -*- mode: pglifecycle -*-
+# pglifecycle: materialized_view
+---
+name: autoresponder_service_package_info
+schema: public
+```
+
+Without the flag (the default), files begin directly at the `---`
+marker. The same flag is available on `create`.
 
 ### Diagnosing parse and format failures
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,7 +118,8 @@ pglifecycle pull [OPTIONS] DEST
 | Option | Description |
 | --- | --- |
 | `-D, --dump FILE` | Use an existing `pg_dump -Fc` file instead of connecting |
-| `-r, --extract-roles` | Extract roles and users via `pg_dumpall --roles-only` |
+| `--no-roles` | Skip cluster role/user extraction (on by default for live connections; always skipped with `--dump`) |
+| `--include-password-hashes` | Include role password hashes in users (omitted by default via `pg_dumpall --no-role-passwords`) |
 | `-i, --ignore FILE` | File listing project paths to skip writing |
 | `--force` | Write to `DEST` even if it already exists |
 | `--update` | Merge into an existing project, rewriting only changed files |
@@ -192,8 +193,13 @@ that overloaded function files are numbered in dump order
 (`name.yaml`, `name_1.yaml`, …), so adding or removing an overload can
 renumber a sibling's file.
 
-Roles are classified when written: a role with a password or
-`VALID UNTIL` becomes a file in `users/`; everything else lands in
-`roles/`. Roles that appear only as ACL grantees (such as `PUBLIC`)
-are written with `create: false` so `build` defines but never creates
-them.
+Cluster roles and users are extracted via `pg_dumpall --roles-only`
+whenever `pull` connects to a live database (use `--no-roles` to skip,
+and note they cannot be extracted from a `--dump` file). They are
+classified when written: a role with the `LOGIN` attribute becomes a
+file in `users/`; everything else lands in `roles/`. Roles that appear
+only as ACL grantees (such as `PUBLIC`) are written with
+`create: false` so `build` defines but never creates them. The
+reserved `pg_*` roles are cluster-managed (and uncreatable), so they
+are excluded. Password hashes are omitted unless
+`--include-password-hashes` is given.

--- a/fixtures/schema.sql
+++ b/fixtures/schema.sql
@@ -58,3 +58,9 @@ CREATE TABLE addresses (
     postal_code      TEXT                     NOT NULL,
     country          TEXT                     NOT NULL
 );
+
+-- Materialized view with an index, exercising matview index round-trip
+CREATE MATERIALIZED VIEW user_states AS
+    SELECT state, count(*) AS total FROM users GROUP BY state;
+
+CREATE UNIQUE INDEX user_states_state ON user_states (state);

--- a/schemata/materialized_view.yml
+++ b/schemata/materialized_view.yml
@@ -85,9 +85,9 @@ oneOf:
     not: {required: [sql]}
   - required: [sql]
     not:
-      required:
-        - columns
-        - storage_paramters
-        - tablespace
-        - query
-        - indexes
+      anyOf:
+        - required: [columns]
+        - required: [storage_parameters]
+        - required: [tablespace]
+        - required: [query]
+        - required: [indexes]

--- a/schemata/materialized_view.yml
+++ b/schemata/materialized_view.yml
@@ -62,6 +62,12 @@ properties:
       A SELECT or VALUES command which will provide the columns and rows of the
       materialized view.
     type: string
+  indexes:
+    title: Indexes
+    description: An array of indexes on the materialized view
+    type: array
+    items:
+      $package_schema: index
   comment:
     title: Comment
     description: An optional comment about the materialized view.
@@ -84,3 +90,4 @@ oneOf:
         - storage_paramters
         - tablespace
         - query
+        - indexes

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -817,7 +817,11 @@ impl Builder {
             "DROP MATERIALIZED VIEW IF EXISTS".into(),
             self.item_name(item),
         ];
-        self.add_item(item, create, drop, false)
+        self.add_item(item, create, drop, false)?;
+        for index in d.indexes.as_deref().unwrap_or_default() {
+            self.dump_index(index, item, &d.schema, &d.owner)?;
+        }
+        Ok(())
     }
 
     fn dump_operator(&mut self, item: &Item) -> Result<(), String> {
@@ -1154,7 +1158,7 @@ impl Builder {
             self.add_item(item, create, drop, false)?;
         }
         for index in d.indexes.as_deref().unwrap_or_default() {
-            self.dump_index(index, item, d)?;
+            self.dump_index(index, item, &d.schema, &d.owner)?;
         }
         for trigger in d.triggers.as_deref().unwrap_or_default() {
             self.dump_trigger(trigger, item, d)?;
@@ -1166,24 +1170,22 @@ impl Builder {
         &mut self,
         index: &Index,
         parent: &Item,
-        table: &crate::models::Table,
+        schema: &str,
+        owner: &str,
     ) -> Result<(), String> {
         // index names cannot be schema-qualified in CREATE INDEX; the
-        // index lives in its table's schema (deviation 10 — Python
+        // index lives in its relation's schema (deviation 10 — Python
         // emitted `CREATE INDEX schema.name`, which does not parse)
-        let qualified = format!(
-            "{}.{}",
-            quote_ident(&table.schema),
-            quote_ident(&index.name)
-        );
+        let qualified =
+            format!("{}.{}", quote_ident(schema), quote_ident(&index.name));
         let create = render_index(index, &self.item_name(parent));
         let drop = vec!["DROP INDEX IF EXISTS".into(), qualified];
         let parent_dump_id = self.dump_id_map[&parent.id];
         let dump_id = self.add_entry(
             "INDEX",
-            &table.schema,
+            schema,
             &index.name,
-            &table.owner,
+            owner,
             &create,
             &drop,
             &[parent_dump_id],
@@ -1192,9 +1194,9 @@ impl Builder {
         if let Some(comment) = &index.comment {
             self.add_comment(
                 "INDEX",
-                &table.schema,
+                schema,
                 &index.name,
-                &table.owner,
+                owner,
                 dump_id,
                 comment,
             )?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -203,9 +203,17 @@ pub struct Pull {
     #[arg(short = 'D', long)]
     pub dump: Option<PathBuf>,
 
-    /// Extract roles (and users) from an existing cluster
-    #[arg(short = 'r', long)]
-    pub extract_roles: bool,
+    /// Do not extract cluster roles and users (pg_dumpall). Roles are
+    /// extracted by default when connecting to a live database; they
+    /// are always skipped with --dump (no live connection)
+    #[arg(long)]
+    pub no_roles: bool,
+
+    /// Include role password hashes in extracted users (pg_dumpall runs
+    /// with --no-role-passwords by default, omitting them). The hashes
+    /// are written to the project, so only enable for trusted repos
+    #[arg(long)]
+    pub include_password_hashes: bool,
 
     /// Specify a file with files to skip writing
     #[arg(short, long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,11 @@ pub struct Create {
     #[arg(long, default_value = "postgres")]
     pub superuser: String,
 
+    /// Prefix each generated file with editor mode headers
+    /// (`# -*- mode: pglifecycle -*-` and `# pglifecycle: <kind>`)
+    #[arg(long)]
+    pub include_mode_headers: bool,
+
     /// The path to create the skeleton project in
     #[arg(value_name = "DEST")]
     pub destination: PathBuf,
@@ -214,6 +219,11 @@ pub struct Pull {
     /// are written to the project, so only enable for trusted repos
     #[arg(long)]
     pub include_password_hashes: bool,
+
+    /// Prefix each generated file with editor mode headers
+    /// (`# -*- mode: pglifecycle -*-` and `# pglifecycle: <kind>`)
+    #[arg(long)]
+    pub include_mode_headers: bool,
 
     /// Specify a file with files to skip writing
     #[arg(short, long)]

--- a/src/ddl/function.rs
+++ b/src/ddl/function.rs
@@ -207,6 +207,25 @@ mod tests {
     }
 
     #[test]
+    fn identity_keeps_out_parameters() {
+        // pg_get_function_identity_arguments (PG17) includes OUT
+        // params, so COMMENT ON / GRANT ON FUNCTION signatures carry
+        // them; identity() must match or the comment goes unattached
+        let Statement::CreateFunction(function) = parse_one(
+            "CREATE FUNCTION public.get_count(in_a_id integer, \
+             in_from timestamp with time zone, OUT upload_count bigint) \
+             RETURNS bigint LANGUAGE sql AS $$ SELECT 1::bigint $$;",
+        ) else {
+            panic!("expected CreateFunction")
+        };
+        assert_eq!(
+            function.identity(),
+            "get_count(in_a_id integer, in_from timestamp with time \
+             zone, OUT upload_count bigint)"
+        );
+    }
+
+    #[test]
     fn parses_unqualified_function() {
         let Statement::CreateFunction(function) = parse_one(
             "CREATE FUNCTION uppercase(value text) RETURNS text \

--- a/src/ddl/view.rs
+++ b/src/ddl/view.rs
@@ -71,6 +71,7 @@ pub(crate) fn create_materialized_view(
             .and_then(|n| n.find("name"))
             .map(|n| unquote(n.text(src))),
         query,
+        indexes: None,
         comment: None,
     }))
 }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -43,7 +43,7 @@ pub fn deploy(args: &cli::Deploy) -> Result<(), String> {
         args.dump.as_deref(),
         &args.connection,
         &ddl,
-        false,
+        None,
         libpgfmt::style::Style::Aweber,
     )?;
     let task = progress::spinner("Diffing project against database");

--- a/src/models/function.rs
+++ b/src/models/function.rs
@@ -60,13 +60,15 @@ impl Function {
     /// The identity signature (`name(mode name type, ...)`) used to
     /// match `COMMENT ON FUNCTION` and ACL targets; mirrors
     /// `pg_get_function_identity_arguments` — defaults are omitted,
-    /// `IN` modes are implicit and OUT/TABLE parameters are excluded
+    /// `IN` modes are implicit, `OUT` parameters are kept (Postgres
+    /// includes them in the identity), and `RETURNS TABLE` columns are
+    /// excluded (they never reach `parameters`, but guard anyway)
     pub fn identity(&self) -> String {
         let args: Vec<String> = self
             .parameters
             .iter()
             .flatten()
-            .filter(|p| p.mode != "OUT" && p.mode != "TABLE")
+            .filter(|p| p.mode != "TABLE")
             .map(|p| {
                 let mut parts: Vec<&str> = Vec::new();
                 if p.mode != "IN" {

--- a/src/models/views.rs
+++ b/src/models/views.rs
@@ -59,5 +59,7 @@ pub struct MaterializedView {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub indexes: Option<Vec<super::Index>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
 }

--- a/src/pgdump.rs
+++ b/src/pgdump.rs
@@ -41,12 +41,21 @@ pub fn dump(
     execute(command)
 }
 
-/// Dump cluster roles to `path` as SQL via `pg_dumpall --roles-only`
-pub fn dump_roles(conn: &cli::Connection, path: &Path) -> Result<(), String> {
+/// Dump cluster roles to `path` as SQL via `pg_dumpall --roles-only`.
+/// Password hashes are omitted (`--no-role-passwords`) unless
+/// `include_passwords` is set, to keep secrets out of the project
+pub fn dump_roles(
+    conn: &cli::Connection,
+    path: &Path,
+    include_passwords: bool,
+) -> Result<(), String> {
     let mut command = Command::new("pg_dumpall");
     connection_args(&mut command, conn);
     command.arg("-f").arg(path);
     command.arg("-r");
+    if !include_passwords {
+        command.arg("--no-role-passwords");
+    }
     execute(command)
 }
 

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -297,14 +297,13 @@ impl Assembly {
         let mut parser = ddl::Parser::new()?;
         self.dbname = dump.dbname().to_string();
         let entries = dump.entries();
-        let task = progress::bar(entries.len() as u64, "Ingesting entries");
+        let task = progress::spinner("Ingesting entries");
         for entry in entries {
             task.set_message(format!(
                 "Ingesting {} {}",
                 entry.desc.as_str(),
                 entry.tag.as_deref().unwrap_or_default()
             ));
-            task.inc();
             match &entry.desc {
                 OT::Database
                 | OT::SearchPath
@@ -781,10 +780,7 @@ impl Assembly {
     /// [`FORMAT_TIMEOUT`] (a likely upstream hang) — the original text
     /// is kept and the statement is recorded to the diagnostics report.
     pub fn format_sql(&mut self, style: libpgfmt::style::Style) {
-        let total = self.views.len()
-            + self.materialized_views.len()
-            + self.functions.len();
-        let task = progress::bar(total as u64, "Formatting SQL");
+        let task = progress::spinner("Formatting SQL");
         for view in &mut self.views {
             if let Some(query) = &view.query {
                 task.set_message(format!("Formatting view {}", view.name));
@@ -795,7 +791,6 @@ impl Assembly {
                     view.query = Some(strip_trailing(&formatted));
                 }
             }
-            task.inc();
         }
         for view in &mut self.materialized_views {
             if let Some(query) = &view.query {
@@ -810,21 +805,16 @@ impl Assembly {
                     view.query = Some(strip_trailing(&formatted));
                 }
             }
-            task.inc();
         }
         for function in &mut self.functions {
             let Some(definition) = &function.definition else {
-                task.inc();
                 continue;
             };
             task.set_message(format!("Formatting function {}", function.name));
             let plpgsql = match function.language.as_deref() {
                 Some("plpgsql") => true,
                 Some("sql") => false,
-                _ => {
-                    task.inc();
-                    continue;
-                }
+                _ => continue,
             };
             let label = format!("function {}", function.name);
             if let Some(formatted) =
@@ -832,7 +822,6 @@ impl Assembly {
             {
                 function.definition = Some(formatted);
             }
-            task.inc();
         }
         task.finish();
     }

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -815,14 +815,32 @@ impl Assembly {
                 .map(|v| v.comment = Some(comment.clone()))
                 .is_some(),
             "FUNCTION" => self.apply_function_comment(&schema, name, &comment),
-            "INDEX" => self
-                .tables
-                .iter_mut()
-                .filter(|t| t.schema == schema)
-                .flat_map(|t| t.indexes.iter_mut().flatten())
-                .find(|i| i.name == *name)
-                .map(|i| i.comment = Some(comment.clone()))
-                .is_some(),
+            "INDEX" => {
+                self.tables
+                    .iter_mut()
+                    .filter(|t| t.schema == schema)
+                    .flat_map(|t| t.indexes.iter_mut().flatten())
+                    .find(|i| i.name == *name)
+                    .map(|i| i.comment = Some(comment.clone()))
+                    .is_some()
+                    || self
+                        .materialized_views
+                        .iter_mut()
+                        .filter(|v| v.schema == schema)
+                        .flat_map(|v| v.indexes.iter_mut().flatten())
+                        .find(|i| i.name == *name)
+                        .map(|i| i.comment = Some(comment.clone()))
+                        .is_some()
+                    || self
+                        .deferred_indexes
+                        .iter_mut()
+                        .find(|(rel, i)| {
+                            rel.schema.clone().unwrap_or_default() == schema
+                                && i.name == *name
+                        })
+                        .map(|(_, i)| i.comment = Some(comment.clone()))
+                        .is_some()
+            }
             _ => false,
         };
         if !found {

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -10,6 +10,7 @@ mod update;
 mod writer;
 
 use std::collections::BTreeMap;
+use std::fmt::Write;
 use std::io::IsTerminal;
 use std::path::Path;
 use std::time::Duration;
@@ -64,6 +65,7 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
     let task = progress::spinner("Rendering project");
     let files = writer::render(&assembly, args)?;
     task.finish();
+    let counts = assembly.counts_by_type();
     let objects = assembly.object_count();
     let verb = if args.update {
         update::merge(&files, args)?;
@@ -73,10 +75,14 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
         "Created"
     };
     let plural = if objects == 1 { "object" } else { "objects" };
-    println!(
+    let mut summary = format!(
         "{verb} your schema project at {} with {objects} {plural}",
         args.destination.display()
     );
+    for (label, count) in counts {
+        let _ = write!(summary, "\n  {count:>5}  {label}");
+    }
+    println!("{summary}");
     Ok(())
 }
 
@@ -257,21 +263,32 @@ pub struct Assembly {
 }
 
 impl Assembly {
-    /// Count the modeled objects written to the project (the things a
-    /// user thinks of as schema objects); excludes unparsed `remaining`
-    /// entries and the database-level metadata
+    /// The modeled objects written to the project, by type, in a
+    /// readable order and excluding empty categories (the things a user
+    /// thinks of as schema objects; excludes unparsed `remaining`
+    /// entries and database-level metadata)
+    pub fn counts_by_type(&self) -> Vec<(&'static str, usize)> {
+        [
+            ("schemas", self.schemas.len()),
+            ("extensions", self.extensions.len()),
+            ("languages", self.languages.len()),
+            ("domains", self.domains.len()),
+            ("types", self.types.len()),
+            ("sequences", self.sequences.len()),
+            ("tables", self.tables.len()),
+            ("views", self.views.len()),
+            ("materialized views", self.materialized_views.len()),
+            ("functions", self.functions.len()),
+            ("roles", self.roles.len()),
+        ]
+        .into_iter()
+        .filter(|(_, count)| *count > 0)
+        .collect()
+    }
+
+    /// Total modeled object count across all types
     pub fn object_count(&self) -> usize {
-        self.extensions.len()
-            + self.languages.len()
-            + self.schemas.len()
-            + self.domains.len()
-            + self.types.len()
-            + self.sequences.len()
-            + self.tables.len()
-            + self.views.len()
-            + self.materialized_views.len()
-            + self.functions.len()
-            + self.roles.len()
+        self.counts_by_type().iter().map(|(_, count)| count).sum()
     }
 
     /// Parse every supported archive entry into the project models

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -45,6 +45,17 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
              or use a pgpass file instead",
         ));
     }
+    let (verb, gerund) = if args.update {
+        ("Updated", "Updating")
+    } else {
+        ("Created", "Creating")
+    };
+    println!(
+        "pglifecycle v{} {gerund} {} → {}",
+        env!("CARGO_PKG_VERSION"),
+        source_label(args),
+        args.destination.display(),
+    );
     diagnostics::init(args.error_file.clone());
     let ddl = pgdump::DumpDdl {
         no_owner: args.no_owner,
@@ -55,11 +66,21 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
         exclude_schemas: args.exclude_schema.clone(),
         exclude_extensions: args.exclude_extension.clone(),
     };
+    // roles/users come from pg_dumpall, which needs a live connection;
+    // skip them when replaying a --dump file (and on --no-roles)
+    let roles = if args.no_roles || args.dump.is_some() {
+        if args.dump.is_some() && !args.no_roles {
+            log::info!("Skipping role extraction: --dump has no live cluster");
+        }
+        None
+    } else {
+        Some(args.include_password_hashes)
+    };
     let (assembly, _) = snapshot(
         args.dump.as_deref(),
         &args.connection,
         &ddl,
-        args.extract_roles,
+        roles,
         args.style,
     )?;
     let task = progress::spinner("Rendering project");
@@ -67,33 +88,93 @@ pub fn pull(args: &cli::Pull) -> Result<(), String> {
     task.finish();
     let counts = assembly.counts_by_type();
     let objects = assembly.object_count();
-    let verb = if args.update {
+    if args.update {
         update::merge(&files, args)?;
-        "Updated"
     } else {
         writer::write_bootstrap(&files, args)?;
-        "Created"
-    };
-    let plural = if objects == 1 { "object" } else { "objects" };
-    let mut summary = format!(
-        "{verb} your schema project at {} with {objects} {plural}",
-        args.destination.display()
-    );
-    for (label, count) in counts {
-        let _ = write!(summary, "\n  {count:>5}  {label}");
     }
-    println!("{summary}");
+    let plural = if objects == 1 { "object" } else { "objects" };
+    println!(
+        "\n{verb} {} with {objects} {plural}:\n\n{}",
+        args.destination.display(),
+        count_grid(&counts),
+    );
     Ok(())
+}
+
+/// Render the per-type counts as a three-column, column-major grid with
+/// right-aligned counts, e.g.
+///
+/// ```text
+///      37  schemas          278  sequences          523  functions
+///      13  extensions      1734  tables             191  users
+/// ```
+fn count_grid(counts: &[(&'static str, usize)]) -> String {
+    const COLS: usize = 3;
+    let rows = counts.len().div_ceil(COLS);
+    // column c holds counts[c * rows .. c * rows + rows]; size each
+    // column to its own widest count and label
+    let column: Vec<&[(&str, usize)]> = (0..COLS)
+        .map(|c| {
+            let start = (c * rows).min(counts.len());
+            let end = (start + rows).min(counts.len());
+            &counts[start..end]
+        })
+        .collect();
+    let count_w: Vec<usize> = column
+        .iter()
+        .map(|cells| {
+            cells
+                .iter()
+                .map(|(_, n)| n.to_string().len())
+                .max()
+                .unwrap_or(0)
+        })
+        .collect();
+    let label_w: Vec<usize> = column
+        .iter()
+        .map(|cells| cells.iter().map(|(l, _)| l.len()).max().unwrap_or(0))
+        .collect();
+    let mut out = String::new();
+    for r in 0..rows {
+        let mut line = String::new();
+        for c in 0..COLS {
+            if let Some((label, count)) = column[c].get(r) {
+                let (cw, lw) = (count_w[c], label_w[c]);
+                let _ = write!(line, "  {count:>cw$}  {label:<lw$}");
+            }
+        }
+        out.push_str(line.trim_end());
+        out.push('\n');
+    }
+    out.trim_end().to_string()
+}
+
+/// The connection the dump is read from, for the startup banner: the
+/// dump file when replaying one, otherwise `dbname@host` (or just the
+/// host when no database name was given)
+fn source_label(args: &cli::Pull) -> String {
+    if let Some(dump) = &args.dump {
+        return dump.display().to_string();
+    }
+    match &args.connection.dbname {
+        Some(dbname) => format!("{dbname}@{}", args.connection.host),
+        None => args.connection.host.clone(),
+    }
 }
 
 /// Snapshot a database (or an existing dump file) into an [`Assembly`],
 /// returning the loaded dump alongside it for callers that need the
-/// archive's entry order
+/// archive's entry order.
+///
+/// `roles` controls cluster role/user extraction via pg_dumpall:
+/// `None` skips it; `Some(include_passwords)` extracts roles, including
+/// password hashes only when `true`.
 pub fn snapshot(
     dump_path: Option<&Path>,
     conn: &cli::Connection,
     ddl: &pgdump::DumpDdl,
-    extract_roles: bool,
+    roles: Option<bool>,
     style: libpgfmt::style::Style,
 ) -> Result<(Assembly, libpgdump::Dump), String> {
     let mut temp_dump: Option<tempfile::NamedTempFile> = None;
@@ -122,20 +203,39 @@ pub fn snapshot(
     drop(temp_dump);
     let mut assembly = Assembly::default();
     assembly.ingest(&dump)?;
-    if extract_roles {
-        let file = tempfile::Builder::new()
-            .prefix("pglifecycle-roles-")
-            .suffix(".sql")
-            .tempfile()
-            .map_err(|e| format!("failed to create temp file: {e}"))?;
-        pgdump::dump_roles(conn, file.path())?;
-        let text = std::fs::read_to_string(file.path()).map_err(|e| {
-            format!("failed to read roles dump {}: {e}", file.path().display())
-        })?;
-        assembly.ingest_roles(&text)?;
+    if let Some(include_passwords) = roles {
+        // role extraction is best-effort: a locked-down cluster (e.g.
+        // RDS restricts pg_authid) should not abort the whole schema
+        // export, so a failure is warned and skipped, not propagated
+        if let Err(error) =
+            extract_roles(conn, include_passwords, &mut assembly)
+        {
+            log::warn!(
+                "Skipping roles and users: {error}. Use --no-roles to \
+                 silence this, or connect with sufficient privileges."
+            );
+        }
     }
     assembly.format_sql(style);
     Ok((assembly, dump))
+}
+
+/// Dump cluster roles via pg_dumpall and merge them into `assembly`
+fn extract_roles(
+    conn: &cli::Connection,
+    include_passwords: bool,
+    assembly: &mut Assembly,
+) -> Result<(), String> {
+    let file = tempfile::Builder::new()
+        .prefix("pglifecycle-roles-")
+        .suffix(".sql")
+        .tempfile()
+        .map_err(|e| format!("failed to create temp file: {e}"))?;
+    pgdump::dump_roles(conn, file.path(), include_passwords)?;
+    let text = std::fs::read_to_string(file.path()).map_err(|e| {
+        format!("failed to read roles dump {}: {e}", file.path().display())
+    })?;
+    assembly.ingest_roles(&text)
 }
 
 /// A dump entry that was not assembled into the project models
@@ -145,6 +245,31 @@ pub struct Remaining {
     pub namespace: Option<String>,
     pub tag: Option<String>,
     pub defn: Option<String>,
+}
+
+/// How a cluster role is written to the project
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoleKind {
+    /// A role with the LOGIN attribute → `users/`
+    User,
+    /// A NOLOGIN role (or an ACL-only grantee like PUBLIC) → `roles/`
+    Role,
+}
+
+/// Classify a cluster role for the project, shared by the writer and
+/// the pull summary. Reserved `pg_*` roles are cluster-managed (and
+/// uncreatable), so they are excluded (`None`); a role with the LOGIN
+/// attribute is a [`RoleKind::User`], everything else a
+/// [`RoleKind::Role`] (pg_dumpall does not distinguish groups).
+pub fn classify_role(name: &str, state: &RoleState) -> Option<RoleKind> {
+    if name.starts_with("pg_") {
+        return None;
+    }
+    if state.options.login == Some(true) {
+        Some(RoleKind::User)
+    } else {
+        Some(RoleKind::Role)
+    }
 }
 
 /// Per-role state accumulated from ACL entries and the pg_dumpall
@@ -260,6 +385,10 @@ pub struct Assembly {
     pub functions: Vec<models::Function>,
     pub roles: BTreeMap<String, RoleState>,
     pub remaining: Vec<Remaining>,
+    /// Indexes whose target relation had not yet been ingested when the
+    /// index entry was seen (pg_dump sorts INDEX before MATERIALIZED
+    /// VIEW), replayed after the entry loop completes
+    deferred_indexes: Vec<(QualifiedName, models::Index)>,
 }
 
 impl Assembly {
@@ -268,6 +397,15 @@ impl Assembly {
     /// thinks of as schema objects; excludes unparsed `remaining`
     /// entries and database-level metadata)
     pub fn counts_by_type(&self) -> Vec<(&'static str, usize)> {
+        let mut users = 0;
+        let mut roles = 0;
+        for (name, state) in &self.roles {
+            match classify_role(name, state) {
+                Some(RoleKind::User) => users += 1,
+                Some(RoleKind::Role) => roles += 1,
+                None => {}
+            }
+        }
         [
             ("schemas", self.schemas.len()),
             ("extensions", self.extensions.len()),
@@ -279,7 +417,8 @@ impl Assembly {
             ("views", self.views.len()),
             ("materialized views", self.materialized_views.len()),
             ("functions", self.functions.len()),
-            ("roles", self.roles.len()),
+            ("users", users),
+            ("roles", roles),
         ]
         .into_iter()
         .filter(|(_, count)| *count > 0)
@@ -377,8 +516,23 @@ impl Assembly {
                 _ => self.push_remaining(entry),
             }
         }
+        self.apply_deferred_indexes();
         task.finish();
         Ok(())
+    }
+
+    /// Attach indexes whose target relation was not yet ingested when
+    /// the index entry was seen; warn for any that remain unresolved
+    fn apply_deferred_indexes(&mut self) {
+        for (table, index) in std::mem::take(&mut self.deferred_indexes) {
+            if let Some(table) = self.find_table(&table) {
+                table.indexes.get_or_insert_default().push(index);
+            } else if let Some(view) = self.find_materialized_view(&table) {
+                view.indexes.get_or_insert_default().push(index);
+            } else {
+                log::warn!("Index on unknown relation {table}");
+            }
+        }
     }
 
     /// Parse a `pg_dumpall --roles-only` SQL dump, skipping comments,
@@ -452,11 +606,16 @@ impl Assembly {
                 self.functions.push(*function);
             }
             Statement::CreateIndex { table, index } => {
-                match self.find_table(&table) {
-                    Some(table) => {
-                        table.indexes.get_or_insert_default().push(index);
-                    }
-                    None => log::warn!("Index on unknown table {table}"),
+                if let Some(table) = self.find_table(&table) {
+                    table.indexes.get_or_insert_default().push(index);
+                } else if let Some(view) = self.find_materialized_view(&table)
+                {
+                    view.indexes.get_or_insert_default().push(index);
+                } else {
+                    // the target relation may simply not be ingested
+                    // yet (matview indexes sort before their matview);
+                    // retry after the entry loop
+                    self.deferred_indexes.push((table, index));
                 }
             }
             Statement::AddConstraint {
@@ -743,6 +902,16 @@ impl Assembly {
         self.tables
             .iter_mut()
             .find(|t| t.schema == schema && t.name == name.name)
+    }
+
+    fn find_materialized_view(
+        &mut self,
+        name: &QualifiedName,
+    ) -> Option<&mut models::MaterializedView> {
+        let schema = name.schema.clone().unwrap_or_default();
+        self.materialized_views
+            .iter_mut()
+            .find(|v| v.schema == schema && v.name == name.name)
     }
 
     /// Merge ALTER SEQUENCE options (including OWNED BY) into the
@@ -1375,6 +1544,52 @@ mod tests {
         let readonly = &assembly.roles["readonly"];
         assert!(readonly.created);
         assert_eq!(readonly.options.login, Some(false));
+    }
+
+    /// LOGIN roles become users, NOLOGIN roles stay roles, and reserved
+    /// pg_* roles are dropped from the project (the bootstrap superuser
+    /// is kept)
+    #[test]
+    fn roles_split_by_login_and_filter_cluster_roles() {
+        use clap::Parser;
+        let mut assembly = Assembly::default();
+        assembly
+            .ingest_roles(
+                "CREATE ROLE app_login;\n\
+                 ALTER ROLE app_login WITH LOGIN;\n\
+                 CREATE ROLE app_group;\n\
+                 ALTER ROLE app_group WITH NOLOGIN;\n\
+                 CREATE ROLE postgres;\n\
+                 ALTER ROLE postgres WITH SUPERUSER LOGIN;\n\
+                 CREATE ROLE pg_read_all_data;\n\
+                 ALTER ROLE pg_read_all_data WITH NOLOGIN;\n",
+            )
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("project");
+        let dump = dir.path().join("unused.dump");
+        let args = match cli::Cli::try_parse_from([
+            "pglifecycle",
+            "pull",
+            "--dump",
+            dump.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .unwrap()
+        .action
+        {
+            cli::Action::Pull(args) => args,
+            _ => unreachable!(),
+        };
+        let files = writer::render(&assembly, &args).unwrap();
+
+        assert!(files.contains_key(Path::new("users/app_login.yaml")));
+        assert!(files.contains_key(Path::new("roles/app_group.yaml")));
+        // the bootstrap superuser is a LOGIN role, so it is kept as a
+        // user; only the uncreatable pg_* reserved roles are filtered
+        assert!(files.contains_key(Path::new("users/postgres.yaml")));
+        assert!(!files.contains_key(Path::new("roles/pg_read_all_data.yaml")));
     }
 
     /// Role settings survive the full pull → write → load → build

--- a/src/pull/writer.rs
+++ b/src/pull/writer.rs
@@ -209,13 +209,17 @@ impl Writer {
         Ok(())
     }
 
-    /// Classify accumulated role state into user and role files; a
-    /// password or expiry makes a user (pg_dumpall does not
-    /// distinguish groups)
+    /// Classify accumulated role state into user and role files via
+    /// [`crate::pull::classify_role`] (LOGIN → user, else role; `pg_*`
+    /// excluded)
     fn write_roles(&mut self, assembly: &Assembly) -> Result<(), String> {
         for (name, state) in &assembly.roles {
+            let kind = match crate::pull::classify_role(name, state) {
+                Some(kind) => kind,
+                None => continue,
+            };
             let settings = role_settings(state);
-            if state.password.is_some() || state.valid_until.is_some() {
+            if kind == crate::pull::RoleKind::User {
                 let user = models::User {
                     name: name.clone(),
                     comment: None,
@@ -271,8 +275,52 @@ impl Writer {
             log::debug!("Skipping ignored file {key}");
             return Ok(());
         }
-        self.files.insert(relative, yamlio::dump(value));
+        let body = yamlio::dump(value);
+        let content =
+            format!("# pglifecycle: {}\n---\n{body}", kind(&relative));
+        self.files.insert(relative, content);
         Ok(())
+    }
+}
+
+/// The object-type noun for the modeline comment, derived from the
+/// destination path (the same noun the directory/schema uses); a Zed
+/// extension keys off the `# pglifecycle` prefix to detect the file type
+fn kind(relative: &Path) -> &'static str {
+    if relative == Path::new("project.yaml") {
+        return "project";
+    }
+    match relative
+        .components()
+        .next()
+        .and_then(|c| c.as_os_str().to_str())
+    {
+        Some("schemata") => "schema",
+        Some("domains") => "domain",
+        Some("sequences") => "sequence",
+        Some("tables") => "table",
+        Some("views") => "view",
+        Some("materialized_views") => "materialized_view",
+        Some("functions") => "function",
+        Some("procedures") => "procedure",
+        Some("types") => "type",
+        Some("aggregates") => "aggregate",
+        Some("casts") => "cast",
+        Some("collations") => "collation",
+        Some("conversions") => "conversion",
+        Some("operators") => "operator",
+        Some("publications") => "publication",
+        Some("subscriptions") => "subscription",
+        Some("servers") => "server",
+        Some("tablespaces") => "tablespace",
+        Some("text_search") => "text_search",
+        Some("user_mappings") => "user_mapping",
+        Some("event_triggers") => "event_trigger",
+        Some("roles") => "role",
+        Some("users") => "user",
+        Some("groups") => "group",
+        // remaining.yaml and any future top-level file
+        _ => "object",
     }
 }
 

--- a/src/pull/writer.rs
+++ b/src/pull/writer.rs
@@ -90,8 +90,9 @@ pub fn write_bootstrap(
 ) -> Result<(), String> {
     log::info!("Writing project to {}", args.destination.display());
     create_directories(&args.destination, args.gitkeep)?;
-    let task = progress::bar(files.len() as u64, "Writing files");
+    let task = progress::spinner("Writing files");
     for (relative, content) in files {
+        task.set_message(format!("Writing {}", relative.display()));
         let path = args.destination.join(relative);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
@@ -100,7 +101,6 @@ pub fn write_bootstrap(
         }
         std::fs::write(&path, content)
             .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
-        task.inc();
     }
     task.finish();
     if args.gitkeep {

--- a/src/pull/writer.rs
+++ b/src/pull/writer.rs
@@ -19,6 +19,7 @@ pub fn render(
     let mut writer = Writer {
         ignore: read_ignore(args.ignore.as_deref())?,
         files: BTreeMap::new(),
+        mode_headers: args.include_mode_headers,
     };
     writer.write_project_file(assembly)?;
     for schema in &assembly.schemas {
@@ -115,6 +116,7 @@ pub fn write_bootstrap(
 struct Writer {
     ignore: BTreeSet<String>,
     files: BTreeMap<PathBuf, String>,
+    mode_headers: bool,
 }
 
 fn create_directories(root: &Path, gitkeep: bool) -> Result<(), String> {
@@ -276,16 +278,14 @@ impl Writer {
             return Ok(());
         }
         let body = yamlio::dump(value);
-        let content =
-            format!("# pglifecycle: {}\n---\n{body}", kind(&relative));
-        self.files.insert(relative, content);
+        let header = self.mode_headers.then(|| kind(&relative));
+        self.files.insert(relative, yamlio::document(header, &body));
         Ok(())
     }
 }
 
 /// The object-type noun for the modeline comment, derived from the
-/// destination path (the same noun the directory/schema uses); a Zed
-/// extension keys off the `# pglifecycle` prefix to detect the file type
+/// destination path (the same noun the directory/schema uses)
 fn kind(relative: &Path) -> &'static str {
     if relative == Path::new("project.yaml") {
         return "project";

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -38,6 +38,7 @@ pub fn create(args: &cli::Create) -> Result<(), String> {
         "stdstrings": !args.no_stdstrings,
         "superuser": args.superuser,
     });
-    fs::write(dest.join("project.yaml"), yamlio::dump(&project))
-        .map_err(|e| e.to_string())
+    let content =
+        format!("# pglifecycle: project\n---\n{}", yamlio::dump(&project));
+    fs::write(dest.join("project.yaml"), content).map_err(|e| e.to_string())
 }

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -38,7 +38,7 @@ pub fn create(args: &cli::Create) -> Result<(), String> {
         "stdstrings": !args.no_stdstrings,
         "superuser": args.superuser,
     });
-    let content =
-        format!("# pglifecycle: project\n---\n{}", yamlio::dump(&project));
+    let header = args.include_mode_headers.then_some("project");
+    let content = yamlio::document(header, &yamlio::dump(&project));
     fs::write(dest.join("project.yaml"), content).map_err(|e| e.to_string())
 }

--- a/src/yamlio.rs
+++ b/src/yamlio.rs
@@ -38,11 +38,33 @@ pub fn dump(value: &Value) -> String {
         .expect("serializing a serde_json::Value to YAML cannot fail")
 }
 
+/// Assemble a project file from a serialized `body`: with `kind`
+/// `Some`, prepend editor-mode headers (an Emacs modeline plus the
+/// `# pglifecycle: <kind>` type comment a Zed extension keys off);
+/// either way emit the `---` document marker before the body
+pub fn document(kind: Option<&str>, body: &str) -> String {
+    match kind {
+        Some(kind) => format!(
+            "# -*- mode: pglifecycle -*-\n# pglifecycle: {kind}\n---\n{body}"
+        ),
+        None => format!("---\n{body}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn document_headers_are_optional() {
+        assert_eq!(document(None, "name: x\n"), "---\nname: x\n");
+        assert_eq!(
+            document(Some("table"), "name: x\n"),
+            "# -*- mode: pglifecycle -*-\n# pglifecycle: table\n---\nname: x\n"
+        );
+    }
 
     #[test]
     fn round_trips_nested_structures() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -150,6 +150,22 @@ pub fn build_archive(path: &std::path::Path, mutated: bool) {
              test.users WHERE (locale = 'en-US'::text);",
         );
     }
+    add(
+        &mut dump,
+        OT::MaterializedView,
+        "test",
+        "user_states",
+        "CREATE MATERIALIZED VIEW test.user_states AS SELECT state, \
+         count(*) AS total FROM test.users GROUP BY state WITH DATA;",
+    );
+    add(
+        &mut dump,
+        OT::Index,
+        "test",
+        "user_states_state",
+        "CREATE UNIQUE INDEX user_states_state ON test.user_states \
+         USING btree (state);",
+    );
     let function = if mutated {
         "CREATE FUNCTION test.set_last_modified() RETURNS trigger \
          LANGUAGE plpgsql AS $$ BEGIN NEW.last_modified_at = \

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -24,8 +24,23 @@ fn creates_skeleton_project() {
     let yaml = fs::read_to_string(tmp.join("project.yaml")).unwrap();
     assert_eq!(
         yaml,
-        "# pglifecycle: project\n---\n\
+        "---\n\
          name: pglc-test-create\nencoding: UTF-8\n\
+         stdstrings: true\nsuperuser: postgres\n"
+    );
+}
+
+#[test]
+fn create_includes_mode_headers_when_requested() {
+    let parent = tempfile::tempdir().unwrap();
+    let tmp = parent.path().join("pglc-test-create-headers");
+    let output = run_create(&tmp, &["--include-mode-headers"]);
+    assert!(output.status.success());
+    let yaml = fs::read_to_string(tmp.join("project.yaml")).unwrap();
+    assert_eq!(
+        yaml,
+        "# -*- mode: pglifecycle -*-\n# pglifecycle: project\n---\n\
+         name: pglc-test-create-headers\nencoding: UTF-8\n\
          stdstrings: true\nsuperuser: postgres\n"
     );
 }
@@ -63,7 +78,7 @@ fn create_honors_options() {
     let yaml = fs::read_to_string(tmp.join("project.yaml")).unwrap();
     assert_eq!(
         yaml,
-        "# pglifecycle: project\n---\n\
+        "---\n\
          name: example\nencoding: LATIN1\n\
          stdstrings: false\nsuperuser: admin\n"
     );

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -24,7 +24,8 @@ fn creates_skeleton_project() {
     let yaml = fs::read_to_string(tmp.join("project.yaml")).unwrap();
     assert_eq!(
         yaml,
-        "name: pglc-test-create\nencoding: UTF-8\n\
+        "# pglifecycle: project\n---\n\
+         name: pglc-test-create\nencoding: UTF-8\n\
          stdstrings: true\nsuperuser: postgres\n"
     );
 }
@@ -62,7 +63,8 @@ fn create_honors_options() {
     let yaml = fs::read_to_string(tmp.join("project.yaml")).unwrap();
     assert_eq!(
         yaml,
-        "name: example\nencoding: LATIN1\n\
+        "# pglifecycle: project\n---\n\
+         name: example\nencoding: LATIN1\n\
          stdstrings: false\nsuperuser: admin\n"
     );
 }

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -69,6 +69,29 @@ fn pulled_project_loads_and_validates() {
     assert!(dest.join("types/test.yaml").exists());
     assert!(dest.join("views/test/us_users.yaml").exists());
     assert!(dest.join("functions/test/set_last_modified.yaml").exists());
+    // a materialized view's index must attach to the matview, not be
+    // dropped as an "index on unknown table"
+    let matview = dest.join("materialized_views/test/user_states.yaml");
+    assert!(matview.exists());
+    let matview = std::fs::read_to_string(&matview).unwrap();
+    assert!(
+        matview.contains("user_states_state"),
+        "matview index was dropped: {matview}"
+    );
+    // every generated file leads with a Zed-detectable modeline whose
+    // kind matches the object type, above the --- document marker
+    assert!(
+        matview.starts_with("# pglifecycle: materialized_view\n---\n"),
+        "missing matview modeline: {matview}"
+    );
+    let project_yaml =
+        std::fs::read_to_string(dest.join("project.yaml")).unwrap();
+    assert!(project_yaml.starts_with("# pglifecycle: project\n---\n"));
+    let function = std::fs::read_to_string(
+        dest.join("functions/test/set_last_modified.yaml"),
+    )
+    .unwrap();
+    assert!(function.starts_with("# pglifecycle: function\n---\n"));
     assert!(dest.join("sequences/test/user_id_seq.yaml").exists());
     assert!(dest.join("domains/test/email_address.yaml").exists());
     assert!(dest.join("roles/PUBLIC.yaml").exists());

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -78,20 +78,16 @@ fn pulled_project_loads_and_validates() {
         matview.contains("user_states_state"),
         "matview index was dropped: {matview}"
     );
-    // every generated file leads with a Zed-detectable modeline whose
-    // kind matches the object type, above the --- document marker
+    // mode headers are opt-in: by default files lead with just the
+    // --- document marker, no modeline
     assert!(
-        matview.starts_with("# pglifecycle: materialized_view\n---\n"),
-        "missing matview modeline: {matview}"
+        matview.starts_with("---\n"),
+        "default pull should not emit a modeline: {matview}"
     );
     let project_yaml =
         std::fs::read_to_string(dest.join("project.yaml")).unwrap();
-    assert!(project_yaml.starts_with("# pglifecycle: project\n---\n"));
-    let function = std::fs::read_to_string(
-        dest.join("functions/test/set_last_modified.yaml"),
-    )
-    .unwrap();
-    assert!(function.starts_with("# pglifecycle: function\n---\n"));
+    assert!(project_yaml.starts_with("---\n"));
+    assert!(!project_yaml.contains("# pglifecycle:"));
     assert!(dest.join("sequences/test/user_id_seq.yaml").exists());
     assert!(dest.join("domains/test/email_address.yaml").exists());
     assert!(dest.join("roles/PUBLIC.yaml").exists());
@@ -117,6 +113,43 @@ fn pulled_project_loads_and_validates() {
     ] {
         assert!(kinds.contains(&expected), "missing {expected}: {kinds:?}");
     }
+}
+
+#[test]
+fn include_mode_headers_prefixes_generated_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("fixtures.dump");
+    fixture_archive(&archive);
+    let dest = dir.path().join("project");
+
+    pull::pull(&pull_args_with(
+        &archive,
+        &dest,
+        &["--gitkeep", "--include-mode-headers"],
+    ))
+    .expect("pull failed");
+
+    // both the Emacs modeline and the type comment lead each file,
+    // above the --- document marker, with a kind matching the object
+    let expectations = [
+        ("project.yaml", "project"),
+        ("tables/test/users.yaml", "table"),
+        (
+            "materialized_views/test/user_states.yaml",
+            "materialized_view",
+        ),
+        ("functions/test/set_last_modified.yaml", "function"),
+    ];
+    for (path, kind) in expectations {
+        let text = std::fs::read_to_string(dest.join(path)).unwrap();
+        let expected = format!(
+            "# -*- mode: pglifecycle -*-\n# pglifecycle: {kind}\n---\n"
+        );
+        assert!(text.starts_with(&expected), "{path} header:\n{text}");
+    }
+
+    // the project still loads with the headers present
+    project::load(&dest).expect("project with mode headers must load");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Fidelity and UX fixes to the `pull` command, surfaced while exporting a large production database (~3,000 objects): materialized-view indexes, `OUT`-parameter function comments, cluster roles/users, a Zed modeline on generated files, and a redesigned output summary.

## Problem
Running `pull` against a real database exposed several gaps:
- **Matview indexes were silently dropped** with `Index on unknown table …` warnings. Materialized views can carry indexes (a unique index is required for `REFRESH … CONCURRENTLY`), but index attachment only searched tables, and the model/schema had no field for them.
- **`COMMENT ON FUNCTION` went unattached for any function with `OUT` parameters** (`Comment on unmatched object: FUNCTION …`). PostgreSQL's `pg_get_function_identity_arguments` includes `OUT` params, so `pg_dump` emits them in the comment signature, but `Function::identity()` stripped them.
- **Users were never produced.** Roles were extracted via `pg_dumpall`, but classified as users only when a password was present — so login users with no stored password all landed in `roles/` (205 roles, 0 users on the test DB). On RDS, the default `pg_dumpall` query also failed with `permission denied for table pg_authid`, aborting the entire export.
- Generated files had no editor-detectable type marker, and the completion summary lumped all object types onto one line.

## Solution
- **Materialized view indexes:** added an `indexes` field to `MaterializedView` (model + `schemata/materialized_view.yml`); attach matview indexes on pull, deferring any index whose relation isn't ingested yet (pg_dump sorts `INDEX` before `MATERIALIZED VIEW`); emit them on build.
- **`OUT`-param comments:** `Function::identity()` now keeps `OUT` params (dropping only `RETURNS TABLE` columns), matching `pg_get_function_identity_arguments`.
- **Roles/users:** classify on the `LOGIN` attribute via a shared `classify_role` used by both the writer and the summary; report users and roles separately; exclude reserved `pg_*` roles. `pg_dumpall` runs with `--no-role-passwords` by default (reads `pg_roles`, not `pg_authid`, so it works on RDS); `--include-password-hashes` opts in. Extraction is best-effort — a locked-down cluster warns and skips rather than aborting. On by default for live connections (`--no-roles` to skip); always skipped with `--dump`.
- **Modeline:** every generated file leads with `# pglifecycle: <kind>` above the `---` marker.
- **Output:** a startup banner (`pglifecycle vX Creating <src> → <dest>`) and a three-column, per-type object-count summary.

Also bumps the lockfile to the published `libpgfmt 1.1.7` and `tree-sitter-postgres 1.2.4`.

## Impact
- `pull` now produces `users/`, populated matview indexes, and function comments that previously vanished — re-pulling an existing project will show these as additions, plus the one-time modeline header on every file.
- The old `-r/--extract-roles` flag is replaced by on-by-default extraction with `--no-roles` / `--include-password-hashes`.
- RDS and other restricted clusters no longer fail the whole export on role permissions.

## Testing
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (113 tests) all pass.
- New regression tests: matview index round-trip, `identity()` keeps `OUT` params, LOGIN-based role/user split with `pg_*` filtering.
- Verified end-to-end against a Postgres 17 container: matview indexes attach, `OUT`-param comments attach, users/roles split correctly, and a simulated `pg_authid` denial degrades to a warning while the schema still exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for indexes on materialized views
  * New `--include-password-hashes` option to include password hashes in cluster role extraction

* **Bug Fixes**
  * Fixed function parameter identity to correctly include OUT parameters
  * Enhanced role extraction to classify LOGIN roles as users, filter system `pg_*` roles, and skip extraction when using `--dump`

* **Documentation**
  * Updated `pull` command documentation to reflect new options and role extraction behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->