### PR TITLE
Default to libpgfmt pg_dump style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "libpgfmt"
-version = "1.1.7"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b558aae558a0949dd7e82147bf0ae26bdc576607928f5e7799831c2575cb33ed"
+checksum = "161492a5a3f5e12a4085042f04627a4a8aae2cb91242017141c229a180180fff"
 dependencies = [
  "tree-sitter",
  "tree-sitter-postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ indicatif = "0.18.4"
 indicatif-log-bridge = "0.2.3"
 jsonschema = { version = "0.46.5", default-features = false }
 libpgdump = "2.1"
-libpgfmt = "1.1.6"
+libpgfmt = "1.2"
 log = "0.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150", features = ["preserve_order"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -288,12 +288,12 @@ pub struct Pull {
     )]
     pub exclude_extension: Vec<String>,
 
-    /// libpgfmt style for view queries and function bodies: river,
-    /// mozilla, aweber, dbt, gitlab, kickstarter, or mattmc3. Note that
-    /// `deploy` always compares using the default (aweber), so a
+    /// libpgfmt style for view queries and function bodies: pg_dump,
+    /// river, mozilla, aweber, dbt, gitlab, kickstarter, or mattmc3. Note
+    /// that `deploy` always compares using the default (pg_dump), so a
     /// non-default style here makes `deploy` report formatting-only
     /// differences
-    #[arg(long, value_name = "STYLE", default_value = "aweber",
+    #[arg(long, value_name = "STYLE", default_value = "pg_dump",
           value_parser = parse_style)]
     pub style: libpgfmt::style::Style,
 

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -44,7 +44,7 @@ pub fn deploy(args: &cli::Deploy) -> Result<(), String> {
         &args.connection,
         &ddl,
         None,
-        libpgfmt::style::Style::Aweber,
+        libpgfmt::style::Style::PgDump,
     )?;
     let task = progress::spinner("Diffing project against database");
     let diff = diff::diff(&project, &assembly);


### PR DESCRIPTION
## Summary
Switch the default libpgfmt formatting style from `aweber` to `pg_dump` (added in libpgfmt 1.2).

## Problem
pglifecycle formats view queries and function bodies with libpgfmt when pulling a database into a project. The previous default (`aweber`) reflows SQL into a house style that differs from what PostgreSQL itself emits via `pg_get_viewdef`/`pg_get_functiondef` (i.e. `pg_dump`). That makes pulled definitions diverge cosmetically from the source database and from `pg_dump` output.

## Solution
- Bump `libpgfmt` 1.1.6 → 1.2, which adds `Style::PgDump`.
- Change the `pull --style` default from `aweber` to `pg_dump`.
- Match `deploy`'s comparison style to the new default so it does not report formatting-only differences.

`--style` still accepts `aweber` (and the other styles) for anyone who prefers the old behavior.

## Impact
- `pull` output for view/function bodies now matches pg_dump formatting by default. Re-pulling an existing project will produce formatting-only diffs in those bodies on first run.
- No schema or behavior change beyond formatting.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (all 122 unit + integration tests) pass. Verified `pull --help` shows `[default: pg_dump]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded dependency to the latest version
  * Updated the default SQL formatting style used during database deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->