### PR TITLE
Fall back to passwordless roles when pg_authid is denied

### DIFF
--- a/src/pgdump.rs
+++ b/src/pgdump.rs
@@ -43,8 +43,32 @@ pub fn dump(
 
 /// Dump cluster roles to `path` as SQL via `pg_dumpall --roles-only`.
 /// Password hashes are omitted (`--no-role-passwords`) unless
-/// `include_passwords` is set, to keep secrets out of the project
+/// `include_passwords` is set, to keep secrets out of the project.
+///
+/// Reading hashes requires `pg_authid`, which managed platforms (e.g.
+/// RDS) deny to non-superusers. When passwords were requested and the
+/// dump fails on that restriction, retry without passwords so role and
+/// user extraction still succeeds (minus hashes) rather than aborting.
 pub fn dump_roles(
+    conn: &cli::Connection,
+    path: &Path,
+    include_passwords: bool,
+) -> Result<(), String> {
+    match run_dump_roles(conn, path, include_passwords) {
+        Err(error)
+            if should_retry_without_passwords(include_passwords, &error) =>
+        {
+            log::warn!(
+                "Cannot read password hashes ({error}); retrying roles \
+                 without passwords"
+            );
+            run_dump_roles(conn, path, false)
+        }
+        result => result,
+    }
+}
+
+fn run_dump_roles(
     conn: &cli::Connection,
     path: &Path,
     include_passwords: bool,
@@ -57,6 +81,15 @@ pub fn dump_roles(
         command.arg("--no-role-passwords");
     }
     execute(command)
+}
+
+/// Whether a failed password-included roles dump should be retried
+/// without passwords: the failure is a `pg_authid` access restriction
+fn should_retry_without_passwords(
+    include_passwords: bool,
+    error: &str,
+) -> bool {
+    include_passwords && error.contains("pg_authid")
 }
 
 /// Apply a SQL script to the database in a single transaction via
@@ -183,5 +216,24 @@ mod tests {
     #[test]
     fn ddl_args_empty_by_default() {
         assert!(ddl_args(&DumpDdl::default()).is_empty());
+    }
+
+    #[test]
+    fn retries_without_passwords_on_pg_authid_denial() {
+        let error = "Failed to dump (1): pg_dumpall: error: query failed: \
+                     ERROR: permission denied for table pg_authid";
+        assert!(should_retry_without_passwords(true, error));
+    }
+
+    #[test]
+    fn does_not_retry_when_passwords_not_requested() {
+        let error = "permission denied for table pg_authid";
+        assert!(!should_retry_without_passwords(false, error));
+    }
+
+    #[test]
+    fn does_not_retry_on_unrelated_failure() {
+        let error = "Failed to dump (2): connection refused";
+        assert!(!should_retry_without_passwords(true, error));
     }
 }


### PR DESCRIPTION
## Summary
Make `pull --include-password-hashes` degrade gracefully on clusters that restrict `pg_authid` (notably AWS RDS), so roles and users are still captured even when password hashes can't be read.

## Problem
`--include-password-hashes` runs `pg_dumpall --roles-only` *without* `--no-role-passwords`, which reads `pg_authid`. Managed platforms deny `pg_authid` to non-superusers:

```
pg_dumpall: error: query failed: ERROR: permission denied for table pg_authid
```

Because role extraction is wrapped non-fatally in `pull`, that failure caused **every** role and user to be skipped — not just the hashes — leaving the project with no roles/users at all.

## Solution
Detect the `pg_authid` access failure in `pgdump::dump_roles` and retry the dump with `--no-role-passwords`, logging a warning that hashes were unavailable. Roles and users are captured (minus the unreadable hashes). The retry decision is isolated in `should_retry_without_passwords` so it can be unit-tested without a live cluster.

## Impact
- On RDS (and similar), `pull --include-password-hashes` now yields roles/users without hashes plus a warning, instead of silently dropping all of them.
- No change on clusters where `pg_authid` is readable — hashes are still included.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` pass. Added unit tests covering the retry predicate (pg_authid denial with passwords requested → retry; passwords not requested → no retry; unrelated failure → no retry). Manual verification against an RDS instance recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Role dump now includes automatic retry logic. When role dumping with passwords fails due to permission restrictions, the operation automatically retries without passwords and logs a warning, providing better resilience and more graceful error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->