### PR TITLE
Render CREATE FOREIGN TABLE in build

### DIFF
--- a/schemata/table.yml
+++ b/schemata/table.yml
@@ -402,19 +402,12 @@ properties:
     type: string
   options:
     title: Foreign Table Options
-    description: Used to specify the details of the foreign table
+    description: >
+      Foreign table OPTIONS as an open key/value map; the available keys
+      depend on the foreign data wrapper (e.g. postgres_fdw uses
+      schema_name and table_name, file_fdw uses filename and format).
     type: object
-    properties:
-      schema:
-        title: Foreign Schema Name
-        type: string
-      name:
-        title: Foreign Table Name
-        type: string
-    required:
-      - schema
-      - name
-    additionalProperties: false
+    additionalProperties: true
   comment:
     title: Comment
     description: An optional comment about the table
@@ -428,12 +421,32 @@ additionalProperties: false
 required:
   - schema
   - name
+# a table is defined exactly one way, keyed on sql / server / parents:
+#   - a raw SQL snippet (exclusive of everything structural)
+#   - a foreign table (columns + server, optional options)
+#   - an inheritance child (parents, optionally overriding columns)
+#   - a plain table (columns, none of the above)
 oneOf:
-  - required: [parents]
-    not: {required: [columns, sql, server, options]}
   - required: [sql]
-    not: {required: [columns, parents, server, options]}
+    not:
+      anyOf:
+        - required: [columns]
+        - required: [parents]
+        - required: [server]
+        - required: [options]
+  - required: [columns, server]
+    not:
+      anyOf:
+        - required: [sql]
+        - required: [parents]
+  - required: [parents]
+    not:
+      anyOf:
+        - required: [sql]
+        - required: [server]
   - required: [columns]
-    not: {required: [ parents, sql]}
-  - required: [columns, server, options]
-    not: {required: [ parents, sql]}
+    not:
+      anyOf:
+        - required: [sql]
+        - required: [parents]
+        - required: [server]

--- a/schemata/table.yml
+++ b/schemata/table.yml
@@ -407,6 +407,8 @@ properties:
       depend on the foreign data wrapper (e.g. postgres_fdw uses
       schema_name and table_name, file_fdw uses filename and format).
     type: object
+    propertyNames:
+      pattern: ^[A-Za-z_][A-Za-z0-9_]*$
     additionalProperties: true
   comment:
     title: Comment
@@ -433,6 +435,7 @@ oneOf:
       anyOf:
         - required: [columns]
         - required: [parents]
+        - required: [like_table]
         - required: [server]
         - required: [options]
   - required: [columns, server]
@@ -440,6 +443,7 @@ oneOf:
       anyOf:
         - required: [sql]
         - required: [parents]
+        - required: [like_table]
   - not:
       anyOf:
         - required: [sql]
@@ -449,3 +453,4 @@ oneOf:
       - required: [columns]
       - required: [parents]
       - required: [from_type]
+      - required: [like_table]

--- a/schemata/table.yml
+++ b/schemata/table.yml
@@ -444,9 +444,11 @@ oneOf:
       anyOf:
         - required: [sql]
         - required: [server]
+        - required: [options]
   - required: [columns]
     not:
       anyOf:
         - required: [sql]
         - required: [parents]
         - required: [server]
+        - required: [options]

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1038,7 +1038,7 @@ impl Builder {
         }
         create.push("FOREIGN DATA WRAPPER".into());
         create.push(d.foreign_data_wrapper.clone());
-        if let Some(options) = &d.options {
+        if let Some(options) = d.options.as_ref().filter(|o| !o.is_empty()) {
             create.push(format!("OPTIONS ({})", render_options(options)));
         }
         let drop = vec!["DROP SERVER IF EXISTS".into(), self.item_name(item)];
@@ -1194,7 +1194,8 @@ impl Builder {
         create.push(")".into());
         create.push("SERVER".into());
         create.push(quote_ident(server));
-        if let Some(options) = &table.options {
+        if let Some(options) = table.options.as_ref().filter(|o| !o.is_empty())
+        {
             create.push(format!("OPTIONS ({})", render_options(options)));
         }
         let drop =

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1039,7 +1039,7 @@ impl Builder {
         create.push("FOREIGN DATA WRAPPER".into());
         create.push(d.foreign_data_wrapper.clone());
         if let Some(options) = &d.options {
-            create.push(format!("OPTIONS {}", render_options(options)));
+            create.push(format!("OPTIONS ({})", render_options(options)));
         }
         let drop = vec!["DROP SERVER IF EXISTS".into(), self.item_name(item)];
         self.add_item(item, create, drop, false)
@@ -1073,6 +1073,8 @@ impl Builder {
         };
         if let Some(sql) = &d.sql {
             self.add_item(item, vec![sql.clone()], vec![], false)?;
+        } else if let Some(server) = &d.server {
+            self.dump_foreign_table(item, d, server)?;
         } else {
             let mut create = vec!["CREATE".into()];
             if d.unlogged == Some(true) {
@@ -1162,6 +1164,61 @@ impl Builder {
         }
         for trigger in d.triggers.as_deref().unwrap_or_default() {
             self.dump_trigger(trigger, item, d)?;
+        }
+        Ok(())
+    }
+
+    /// CREATE FOREIGN TABLE — emitted with the `FOREIGN TABLE` archive
+    /// desc (and its own DROP), registered in dump_id_map so the table's
+    /// triggers/comments attach. Foreign servers sort before foreign
+    /// tables in the archive, so no explicit dependency edge is needed.
+    fn dump_foreign_table(
+        &mut self,
+        item: &Item,
+        table: &crate::models::Table,
+        server: &str,
+    ) -> Result<(), String> {
+        let mut create = vec![
+            "CREATE FOREIGN TABLE".into(),
+            self.item_name(item),
+            "(".into(),
+        ];
+        let columns: Vec<String> = table
+            .columns
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(render_table_column)
+            .collect();
+        create.push(columns.join(", "));
+        create.push(")".into());
+        create.push("SERVER".into());
+        create.push(quote_ident(server));
+        if let Some(options) = &table.options {
+            create.push(format!("OPTIONS ({})", render_options(options)));
+        }
+        let drop =
+            vec!["DROP FOREIGN TABLE IF EXISTS".into(), self.item_name(item)];
+        let dump_id = self.add_entry(
+            "FOREIGN TABLE",
+            &table.schema,
+            &table.name,
+            &table.owner,
+            &create,
+            &drop,
+            &[],
+            None,
+        )?;
+        self.dump_id_map.insert(item.id, dump_id);
+        if let Some(comment) = &table.comment {
+            self.add_comment(
+                "FOREIGN TABLE",
+                &table.schema,
+                &table.name,
+                &table.owner,
+                dump_id,
+                comment,
+            )?;
         }
         Ok(())
     }
@@ -2020,4 +2077,106 @@ fn render_parameters(parameters: &Map<String, Value>) -> String {
         .map(|(k, v)| format!("{k} = {}", postgres_value(v)))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use serde_json::{Map, json};
+
+    use super::*;
+    use crate::constants::ObjectType;
+    use crate::models::Table;
+
+    fn column(name: &str, data_type: &str, not_null: bool) -> Column {
+        Column {
+            name: name.into(),
+            data_type: data_type.into(),
+            nullable: not_null.then_some(false),
+            default: None,
+            collation: None,
+            check_constraint: None,
+            generated: None,
+            comment: None,
+        }
+    }
+
+    fn foreign_table(options: Option<Map<String, Value>>) -> Item {
+        Item {
+            id: 1,
+            desc: ObjectType::Table,
+            definition: Definition::Table(Table {
+                name: "orders".into(),
+                schema: "fdw_warehouse".into(),
+                owner: "app".into(),
+                sql: None,
+                unlogged: None,
+                from_type: None,
+                parents: None,
+                like_table: None,
+                columns: Some(vec![
+                    column("id", "integer", true),
+                    column("total", "numeric", false),
+                ]),
+                indexes: None,
+                primary_key: None,
+                check_constraints: None,
+                unique_constraints: None,
+                foreign_keys: None,
+                triggers: None,
+                partition: None,
+                partitions: None,
+                access_method: None,
+                storage_parameters: None,
+                tablespace: None,
+                index_tablespace: None,
+                server: Some("warehouse".into()),
+                options,
+                comment: None,
+            }),
+            dependencies: BTreeSet::new(),
+        }
+    }
+
+    /// Render `item` and return the FOREIGN TABLE entry's definition SQL
+    fn foreign_table_defn(item: &Item) -> String {
+        let dump = libpgdump::new("t", "UTF-8", "18.0").unwrap();
+        let mut builder = Builder {
+            dump,
+            dump_id_map: HashMap::new(),
+            superuser: "postgres".into(),
+        };
+        builder.dump_item(item).unwrap();
+        builder
+            .dump
+            .entries()
+            .iter()
+            .find(|e| e.desc == libpgdump::ObjectType::ForeignTable)
+            .and_then(|e| e.defn.clone())
+            .expect("a FOREIGN TABLE entry")
+    }
+
+    #[test]
+    fn renders_foreign_table_with_options() {
+        let mut options = Map::new();
+        options.insert("schema_name".into(), json!("public"));
+        options.insert("table_name".into(), json!("orders"));
+        assert_eq!(
+            foreign_table_defn(&foreign_table(Some(options))),
+            "CREATE FOREIGN TABLE fdw_warehouse.orders ( id integer NOT \
+             NULL, total numeric ) SERVER warehouse OPTIONS (schema_name \
+             'public', table_name 'orders');\n"
+        );
+    }
+
+    #[test]
+    fn renders_foreign_table_without_options() {
+        let defn = foreign_table_defn(&foreign_table(None));
+        assert_eq!(
+            defn,
+            "CREATE FOREIGN TABLE fdw_warehouse.orders ( id integer NOT \
+             NULL, total numeric ) SERVER warehouse;\n"
+        );
+    }
 }

--- a/src/ddl/table.rs
+++ b/src/ddl/table.rs
@@ -41,6 +41,8 @@ pub(crate) fn create_table(
         storage_parameters: None,
         tablespace: None,
         index_tablespace: None,
+        server: None,
+        options: None,
         comment: None,
     };
     let mut columns = Vec::new();

--- a/src/deploy/alter.rs
+++ b/src/deploy/alter.rs
@@ -157,6 +157,8 @@ fn table(repo: &Table, db: &Table) -> Resolution {
         || repo.storage_parameters != db.storage_parameters
         || repo.tablespace != db.tablespace
         || repo.index_tablespace != db.index_tablespace
+        || repo.server != db.server
+        || repo.options != db.options
     {
         return Resolution::Replace;
     }

--- a/src/models/table.rs
+++ b/src/models/table.rs
@@ -47,6 +47,14 @@ pub struct Table {
     pub tablespace: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub index_tablespace: Option<String>,
+    /// Foreign server backing a foreign table (CREATE FOREIGN TABLE ...
+    /// SERVER); its presence marks the table as foreign
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+    /// Foreign table OPTIONS (key 'value', ...); an open map, as the
+    /// keys depend on the foreign data wrapper
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Map<String, Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
 }

--- a/tests/build_parity.rs
+++ b/tests/build_parity.rs
@@ -29,6 +29,9 @@ const DEVIATIONS: &[(&str, &str, &str)] = &[
     // Python emitted CREATE ROLE for create: false roles (and
     // rendered BYPASSRLS from create_db); the Rust build skips them
     ("ROLE", "", "postgres"),
+    // Python emitted OPTIONS without the required parentheses, which
+    // does not parse
+    ("SERVER", "", "localhost"),
     // Python interpolated a Python list repr into WHEN TAG IN
     ("EVENT TRIGGER", "", "disable_alter_domain"),
     // Python emitted CREATE INDEX schema.name, which does not parse
@@ -71,6 +74,12 @@ const CORRECTED: &[(&str, &str, &str, &str)] = &[
         "SET standard_conforming_strings = 'on';\n",
     ),
     ("SEARCHPATH", "", "", "SELECT pg_catalog.set_config"),
+    (
+        "SERVER",
+        "",
+        "localhost",
+        "OPTIONS (host 'localhost', port 5432, user 'fdw_user', dbname 'postgres')",
+    ),
     (
         "EVENT TRIGGER",
         "",


### PR DESCRIPTION
## Summary
Teach `build` to emit `CREATE FOREIGN TABLE`, and add the `server`/`options` fields a foreign table needs. This is the build half of full foreign-object support (pull support follows in a later PR).

## Problem
Foreign tables silently could not be built:
- `models::Table` had no `server` or `options` fields, even though `table.yml` declared them — so a foreign table couldn't be represented, and `deny_unknown_fields` would reject one.
- `dump_table` only ever emitted plain `CREATE TABLE`.
- `dump_server` emitted `OPTIONS host '...'` **without parentheses**, which is invalid SQL (a foreign table can't restore without its server).

## Solution
- Add `server: Option<String>` and `options: Option<Map<String, Value>>` to `models::Table`. Options is an open key/value map because the valid keys depend on the foreign data wrapper (postgres_fdw uses `schema_name`/`table_name`, file_fdw uses `filename`/`format`, etc.).
- `table.yml`: `options` becomes an open object; the root `oneOf` is rewritten to be mutually exclusive (keyed on `sql` / `server` / `parents`) so a foreign table matches exactly the foreign-table branch. The previous branches both matched a foreign table (`required: [columns]` didn't exclude `server`).
- `build` emits `CREATE FOREIGN TABLE <name> ( <cols> ) SERVER <server> OPTIONS (...)` with a `FOREIGN TABLE` archive desc and its own `DROP FOREIGN TABLE IF EXISTS`. Foreign servers sort before foreign tables in the archive, so no explicit dependency edge is needed.
- Fix `dump_server` to wrap `OPTIONS` in parentheses. The build-parity fixture captured Python's matching broken output, so `SERVER` joins the documented deviations with its corrected form.

## Impact
- Projects containing foreign tables now build. No effect on non-foreign tables.
- Anyone whose project already had a foreign server gets valid `CREATE SERVER ... OPTIONS (...)` SQL (previously unparseable).

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` pass. Added golden unit tests for foreign-table rendering (with and without options). Verified end to end against PostgreSQL 17: a hand-authored foreign table builds and `pg_restore --no-owner` recreates it with the correct server, columns, and nullability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for foreign tables with an external server and per-wrapper option key/value pairs.
  * SQL generation now emits `CREATE FOREIGN TABLE` (with columns) and includes an `OPTIONS (...)` clause when options are provided.
* **Improvements**
  * Refined table-definition validation to use clearer, mutually exclusive definition modes and to enforce foreign-table-only `options`.
  * Deployment now replaces tables when the external server or options change.
* **Tests**
  * Updated SQL parity assertions to reflect corrected/expected `SERVER OPTIONS` formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->