### PR TITLE
Pull foreign data wrappers, servers, user mappings, and foreign tables

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -130,7 +130,7 @@ pglifecycle pull [OPTIONS] DEST
 | `--remove-empty-dirs` | Remove empty directories after generation |
 | `--save-remaining` | Save unprocessed dump entries to `remaining.yaml` |
 | `--error-file FILE` | Where to record failures and their DDL (default `pglifecycle-errors.log`) |
-| `--style STYLE` | libpgfmt style for view/materialized view queries and function bodies (default `aweber`) |
+| `--style STYLE` | libpgfmt style for view/materialized view queries and function bodies (default `pg_dump`) |
 | `-T, --exclude-table PATTERN` | Exclude tables/views/sequences matching `PATTERN` (repeatable; ignored with `--dump`) |
 | `-N, --exclude-schema PATTERN` | Exclude schemas matching `PATTERN` (repeatable; ignored with `--dump`) |
 | `--exclude-extension PATTERN` | Exclude extensions matching `PATTERN` (repeatable; ignored with `--dump`) |
@@ -141,10 +141,10 @@ syntax. They apply only when connecting to a database; with `--dump` the
 archive is already built, so they are rejected as conflicting.
 
 The `--style` value is one of libpgfmt's styles — `river`, `mozilla`,
-`aweber`, `dbt`, `gitlab`, `kickstarter`, or `mattmc3` — and controls
-only how view/materialized view queries and function bodies are
+`aweber`, `dbt`, `gitlab`, `kickstarter`, `mattmc3`, or `pg_dump` — and
+controls only how view/materialized view queries and function bodies are
 formatted in the generated project. Note that `deploy` always re-formats the database
-side with the default (`aweber`) to compare it against the project, so
+side with the default (`pg_dump`) to compare it against the project, so
 pulling with a non-default style will make `deploy` report
 formatting-only differences for every view and function.
 
@@ -221,4 +221,27 @@ only as ACL grantees (such as `PUBLIC`) are written with
 `create: false` so `build` defines but never creates them. The
 reserved `pg_*` roles are cluster-managed (and uncreatable), so they
 are excluded. Password hashes are omitted unless
-`--include-password-hashes` is given.
+`--include-password-hashes` is given. Reading hashes requires
+`pg_authid`, which managed platforms (e.g. RDS) restrict; when it is
+denied, `pull` falls back to a passwordless roles dump (warning that
+hashes were unavailable) rather than dropping all roles.
+
+### Foreign data wrappers, servers, and foreign tables
+
+Foreign objects round-trip through `pull` and `build`:
+
+- **Foreign data wrappers** are written into `project.yaml` under
+  `foreign_data_wrappers` (alongside extensions and languages), with
+  their handler, validator, and options. Extension-owned wrappers (e.g.
+  `postgres_fdw`'s own wrapper) are created by their extension and are
+  not emitted here.
+- **Foreign servers** get one file each in `servers/`, carrying the
+  wrapper name, optional `type`/`version`, and connection `options`.
+- **User mappings** get one file each in `user_mappings/`, grouping all
+  of a user's server mappings. A mapping's `password` option is a
+  secret and is **redacted by default**; pass `--include-password-hashes`
+  to write it (the same flag that controls role password hashes).
+- **Foreign tables** live in `tables/` like ordinary tables, with a
+  `server` field and an open `options` map (keys depend on the wrapper —
+  e.g. `schema_name`/`table_name` for `postgres_fdw`, `filename`/`format`
+  for `file_fdw`). `build` renders them as `CREATE FOREIGN TABLE`.

--- a/schemata/server.yml
+++ b/schemata/server.yml
@@ -43,6 +43,5 @@ properties:
     $package_schema: dependencies
 required:
   - name
-  - dependencies
   - foreign_data_wrapper
 additionalProperties: false

--- a/src/ddl/foreign.rs
+++ b/src/ddl/foreign.rs
@@ -55,10 +55,10 @@ pub(crate) fn create_server(
         .first()
         .map(|n| unquote(n.text(src)))
         .ok_or_else(|| String::from("CREATE SERVER without a name"))?;
-    let foreign_data_wrapper = names
-        .get(1)
-        .map(|n| unquote(n.text(src)))
-        .unwrap_or_default();
+    let foreign_data_wrapper =
+        names.get(1).map(|n| unquote(n.text(src))).ok_or_else(|| {
+            String::from("CREATE SERVER without a foreign data wrapper")
+        })?;
     Ok(Statement::CreateServer(Server {
         name,
         foreign_data_wrapper,
@@ -136,7 +136,13 @@ pub(crate) fn create_foreign_table(
         tablespace: None,
         index_tablespace: None,
         // the `name` after SERVER (the only bare `name` child)
-        server: node.child_of_kind("name").map(|n| unquote(n.text(src))),
+        server: Some(
+            node.child_of_kind("name")
+                .map(|n| unquote(n.text(src)))
+                .ok_or_else(|| {
+                    String::from("CREATE FOREIGN TABLE without SERVER")
+                })?,
+        ),
         options: generic_options(node, src),
         comment: None,
     })))

--- a/src/ddl/foreign.rs
+++ b/src/ddl/foreign.rs
@@ -1,0 +1,271 @@
+//! Foreign data wrappers, servers, user mappings, and foreign tables
+//! (CreateFdwStmt / CreateForeignServerStmt / CreateUserMappingStmt /
+//! CreateForeignTableStmt)
+
+use serde_json::{Map, Value};
+use tree_sitter::Node;
+
+use crate::ddl::object::string_value;
+use crate::ddl::table::column;
+use crate::ddl::{NodeExt, Statement, qualified_name, unquote};
+use crate::models::{
+    ForeignDataWrapper, Server, Table, UserMapping, UserMappingServer,
+};
+
+/// CREATE FOREIGN DATA WRAPPER → ForeignDataWrapper
+pub(crate) fn create_fdw(node: &Node, src: &str) -> Result<Statement, String> {
+    let name = node
+        .child_of_kind("name")
+        .map(|n| unquote(n.text(src)))
+        .ok_or_else(|| {
+            String::from("CREATE FOREIGN DATA WRAPPER without a name")
+        })?;
+    let mut fdw = ForeignDataWrapper {
+        name,
+        owner: String::new(),
+        handler: None,
+        validator: None,
+        options: generic_options(node, src),
+        comment: None,
+    };
+    // each fdw_option is HANDLER/VALIDATOR <name> or NO HANDLER/VALIDATOR
+    // (the latter carries kw_no and no handler_name)
+    for option in node.find_all("fdw_option") {
+        let Some(handler) = option.child_of_kind("handler_name") else {
+            continue;
+        };
+        let value = Some(handler.text(src).to_string());
+        if option.has("kw_handler") {
+            fdw.handler = value;
+        } else if option.has("kw_validator") {
+            fdw.validator = value;
+        }
+    }
+    Ok(Statement::CreateForeignDataWrapper(fdw))
+}
+
+/// CREATE SERVER → Server
+pub(crate) fn create_server(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    // two `name` children: the server, then its foreign data wrapper
+    let names = direct_children(node, "name");
+    let name = names
+        .first()
+        .map(|n| unquote(n.text(src)))
+        .ok_or_else(|| String::from("CREATE SERVER without a name"))?;
+    let foreign_data_wrapper = names
+        .get(1)
+        .map(|n| unquote(n.text(src)))
+        .unwrap_or_default();
+    Ok(Statement::CreateServer(Server {
+        name,
+        foreign_data_wrapper,
+        server_type: node
+            .child_of_kind("opt_type")
+            .and_then(|t| t.find("Sconst"))
+            .map(|s| string_value(&s, src)),
+        version: node
+            .find("foreign_server_version")
+            .and_then(|v| v.find("Sconst"))
+            .map(|s| string_value(&s, src)),
+        options: generic_options(node, src),
+        comment: None,
+    }))
+}
+
+/// CREATE USER MAPPING → UserMapping (one server entry; the assembly
+/// merges mappings that share a user)
+pub(crate) fn create_user_mapping(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let name = node
+        .child_of_kind("auth_ident")
+        .map(|a| unquote(a.text(src)))
+        .ok_or_else(|| String::from("CREATE USER MAPPING without a user"))?;
+    let server = node
+        .child_of_kind("name")
+        .map(|n| unquote(n.text(src)))
+        .ok_or_else(|| String::from("CREATE USER MAPPING without a server"))?;
+    Ok(Statement::CreateUserMapping(UserMapping {
+        name,
+        servers: vec![UserMappingServer {
+            name: server,
+            options: generic_options(node, src),
+        }],
+    }))
+}
+
+/// CREATE FOREIGN TABLE → Table with `server`/`options` set (foreign
+/// tables share the tables/ directory and the Table model)
+pub(crate) fn create_foreign_table(
+    node: &Node,
+    src: &str,
+) -> Result<Statement, String> {
+    let name = node
+        .find("qualified_name")
+        .ok_or_else(|| String::from("CREATE FOREIGN TABLE without a name"))?;
+    let name = qualified_name(&name, src)?;
+    let columns: Vec<_> = node
+        .find_all("columnDef")
+        .iter()
+        .map(|c| column(c, src))
+        .collect();
+    Ok(Statement::CreateTable(Box::new(Table {
+        name: name.name,
+        schema: name.schema.unwrap_or_default(),
+        owner: String::new(),
+        sql: None,
+        unlogged: None,
+        from_type: None,
+        parents: None,
+        like_table: None,
+        columns: (!columns.is_empty()).then_some(columns),
+        indexes: None,
+        primary_key: None,
+        check_constraints: None,
+        unique_constraints: None,
+        foreign_keys: None,
+        triggers: None,
+        partition: None,
+        partitions: None,
+        access_method: None,
+        storage_parameters: None,
+        tablespace: None,
+        index_tablespace: None,
+        // the `name` after SERVER (the only bare `name` child)
+        server: node.child_of_kind("name").map(|n| unquote(n.text(src))),
+        options: generic_options(node, src),
+        comment: None,
+    })))
+}
+
+/// Parse a `create_generic_options` (`OPTIONS (key 'value', ...)`) into
+/// a string→value map; the values are always quoted string literals
+fn generic_options(node: &Node, src: &str) -> Option<Map<String, Value>> {
+    let options = node.child_of_kind("create_generic_options")?;
+    let mut map = Map::new();
+    for elem in options.find_all("generic_option_elem") {
+        let Some(name) = elem.child_of_kind("generic_option_name") else {
+            continue;
+        };
+        let value = elem
+            .child_of_kind("generic_option_arg")
+            .and_then(|arg| arg.find("Sconst"))
+            .map(|s| string_value(&s, src))
+            .unwrap_or_default();
+        map.insert(unquote(name.text(src)), Value::String(value));
+    }
+    (!map.is_empty()).then_some(map)
+}
+
+/// Direct children of `node` of the given kind (not recursive)
+fn direct_children<'a>(node: &Node<'a>, kind: &str) -> Vec<Node<'a>> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .filter(|n| n.kind() == kind)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ddl::Parser;
+
+    fn parse_one(sql: &str) -> Statement {
+        let mut parser = Parser::new().unwrap();
+        let mut statements = parser.parse(sql).unwrap();
+        assert_eq!(statements.len(), 1, "expected one statement");
+        statements.remove(0)
+    }
+
+    #[test]
+    fn parses_fdw_with_handler_and_options() {
+        let Statement::CreateForeignDataWrapper(fdw) = parse_one(
+            "CREATE FOREIGN DATA WRAPPER warehouse HANDLER \
+             postgres_fdw_handler VALIDATOR postgres_fdw_validator \
+             OPTIONS (debug 'true');",
+        ) else {
+            panic!("expected CreateForeignDataWrapper")
+        };
+        assert_eq!(fdw.name, "warehouse");
+        assert_eq!(fdw.handler.as_deref(), Some("postgres_fdw_handler"));
+        assert_eq!(fdw.validator.as_deref(), Some("postgres_fdw_validator"));
+        assert_eq!(
+            fdw.options.unwrap().get("debug"),
+            Some(&Value::String("true".into()))
+        );
+    }
+
+    #[test]
+    fn parses_fdw_no_handler() {
+        let Statement::CreateForeignDataWrapper(fdw) = parse_one(
+            "CREATE FOREIGN DATA WRAPPER w NO HANDLER NO VALIDATOR;",
+        ) else {
+            panic!("expected CreateForeignDataWrapper")
+        };
+        assert_eq!(fdw.handler, None);
+        assert_eq!(fdw.validator, None);
+    }
+
+    #[test]
+    fn parses_server() {
+        let Statement::CreateServer(server) = parse_one(
+            "CREATE SERVER wh TYPE 'oracle' VERSION '19' FOREIGN DATA \
+             WRAPPER warehouse OPTIONS (host 'db', dbname 'w');",
+        ) else {
+            panic!("expected CreateServer")
+        };
+        assert_eq!(server.name, "wh");
+        assert_eq!(server.foreign_data_wrapper, "warehouse");
+        assert_eq!(server.server_type.as_deref(), Some("oracle"));
+        assert_eq!(server.version.as_deref(), Some("19"));
+        let options = server.options.unwrap();
+        assert_eq!(options.get("host"), Some(&Value::String("db".into())));
+        assert_eq!(options.get("dbname"), Some(&Value::String("w".into())));
+    }
+
+    #[test]
+    fn parses_user_mapping() {
+        let Statement::CreateUserMapping(mapping) = parse_one(
+            "CREATE USER MAPPING FOR app SERVER wh OPTIONS \
+             (user 'remote', password 'secret');",
+        ) else {
+            panic!("expected CreateUserMapping")
+        };
+        assert_eq!(mapping.name, "app");
+        assert_eq!(mapping.servers.len(), 1);
+        assert_eq!(mapping.servers[0].name, "wh");
+        let options = mapping.servers[0].options.as_ref().unwrap();
+        assert_eq!(options.get("user"), Some(&Value::String("remote".into())));
+        assert_eq!(
+            options.get("password"),
+            Some(&Value::String("secret".into()))
+        );
+    }
+
+    #[test]
+    fn parses_foreign_table() {
+        let Statement::CreateTable(table) = parse_one(
+            "CREATE FOREIGN TABLE fdw_warehouse.orders (id integer NOT \
+             NULL, total numeric) SERVER wh OPTIONS (schema_name \
+             'public', table_name 'orders');",
+        ) else {
+            panic!("expected CreateTable")
+        };
+        assert_eq!(table.schema, "fdw_warehouse");
+        assert_eq!(table.name, "orders");
+        assert_eq!(table.server.as_deref(), Some("wh"));
+        let columns = table.columns.unwrap();
+        assert_eq!(columns.len(), 2);
+        assert_eq!(columns[0].name, "id");
+        assert_eq!(columns[0].nullable, Some(false));
+        let options = table.options.unwrap();
+        assert_eq!(
+            options.get("schema_name"),
+            Some(&Value::String("public".into()))
+        );
+    }
+}

--- a/src/ddl/mod.rs
+++ b/src/ddl/mod.rs
@@ -7,6 +7,7 @@
 //! the tree by kind via the [`NodeExt`] helpers.
 
 mod acl;
+mod foreign;
 mod function;
 mod object;
 mod table;
@@ -44,6 +45,9 @@ pub enum Statement {
     CreateView(models::View),
     CreateMaterializedView(models::MaterializedView),
     CreateFunction(Box<models::Function>),
+    CreateForeignDataWrapper(models::ForeignDataWrapper),
+    CreateServer(models::Server),
+    CreateUserMapping(models::UserMapping),
     CreateTrigger {
         table: QualifiedName,
         trigger: models::Trigger,
@@ -208,6 +212,16 @@ fn dispatch(node: &Node, src: &str) -> Result<Vec<Statement>, String> {
         }
         "CreateFunctionStmt" => {
             Ok(vec![function::create_function(node, src)?])
+        }
+        "CreateForeignTableStmt" => {
+            Ok(vec![foreign::create_foreign_table(node, src)?])
+        }
+        "CreateFdwStmt" => Ok(vec![foreign::create_fdw(node, src)?]),
+        "CreateForeignServerStmt" => {
+            Ok(vec![foreign::create_server(node, src)?])
+        }
+        "CreateUserMappingStmt" => {
+            Ok(vec![foreign::create_user_mapping(node, src)?])
         }
         "CreateTrigStmt" => Ok(vec![trigger::create_trigger(node, src)?]),
         "CommentStmt" => Ok(vec![object::comment(node, src)?]),

--- a/src/ddl/table.rs
+++ b/src/ddl/table.rs
@@ -83,7 +83,7 @@ pub(crate) fn create_table(
     Ok(Statement::CreateTable(Box::new(table)))
 }
 
-fn column(node: &Node, src: &str) -> Column {
+pub(crate) fn column(node: &Node, src: &str) -> Column {
     let name = node
         .child_of_kind("ColId")
         .map(|n| unquote(n.text(src)))

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -383,6 +383,9 @@ pub struct Assembly {
     pub views: Vec<models::View>,
     pub materialized_views: Vec<models::MaterializedView>,
     pub functions: Vec<models::Function>,
+    pub foreign_data_wrappers: Vec<models::ForeignDataWrapper>,
+    pub servers: Vec<models::Server>,
+    pub user_mappings: Vec<models::UserMapping>,
     pub roles: BTreeMap<String, RoleState>,
     pub remaining: Vec<Remaining>,
     /// Indexes whose target relation had not yet been ingested when the
@@ -417,6 +420,9 @@ impl Assembly {
             ("views", self.views.len()),
             ("materialized views", self.materialized_views.len()),
             ("functions", self.functions.len()),
+            ("foreign data wrappers", self.foreign_data_wrappers.len()),
+            ("servers", self.servers.len()),
+            ("user mappings", self.user_mappings.len()),
             ("users", users),
             ("roles", roles),
         ]
@@ -484,6 +490,11 @@ impl Assembly {
                 | OT::FkConstraint
                 | OT::CheckConstraint
                 | OT::Trigger
+                | OT::ForeignTable
+                | OT::ForeignDataWrapper
+                | OT::ForeignServer
+                | OT::Server
+                | OT::UserMapping
                 | OT::Comment
                 | OT::Acl => {
                     let Some(defn) = &entry.defn else { continue };
@@ -604,6 +615,23 @@ impl Assembly {
             Statement::CreateFunction(mut function) => {
                 function.owner = owner;
                 self.functions.push(*function);
+            }
+            Statement::CreateForeignDataWrapper(mut fdw) => {
+                fdw.owner = owner;
+                self.foreign_data_wrappers.push(fdw);
+            }
+            Statement::CreateServer(server) => self.servers.push(server),
+            Statement::CreateUserMapping(mapping) => {
+                // group mappings by user so one UserMapping carries all
+                // its servers (matching the project model)
+                match self
+                    .user_mappings
+                    .iter_mut()
+                    .find(|m| m.name == mapping.name)
+                {
+                    Some(existing) => existing.servers.extend(mapping.servers),
+                    None => self.user_mappings.push(mapping),
+                }
             }
             Statement::CreateIndex { table, index } => {
                 if let Some(table) = self.find_table(&table) {
@@ -779,7 +807,7 @@ impl Assembly {
                 .find(|e| e.name == *name)
                 .map(|e| e.comment = Some(comment.clone()))
                 .is_some(),
-            "TABLE" => self
+            "TABLE" | "FOREIGN TABLE" => self
                 .find_table(target)
                 .map(|t| t.comment = Some(comment.clone()))
                 .is_some(),

--- a/src/pull/writer.rs
+++ b/src/pull/writer.rs
@@ -20,6 +20,7 @@ pub fn render(
         ignore: read_ignore(args.ignore.as_deref())?,
         files: BTreeMap::new(),
         mode_headers: args.include_mode_headers,
+        include_password_hashes: args.include_password_hashes,
     };
     writer.write_project_file(assembly)?;
     for schema in &assembly.schemas {
@@ -61,6 +62,13 @@ pub fn render(
     }
     writer.write_functions(assembly)?;
     writer.write_types(assembly)?;
+    for server in &assembly.servers {
+        writer.save(
+            Path::new("servers").join(format!("{}.yaml", server.name)),
+            server,
+        )?;
+    }
+    writer.write_user_mappings(assembly)?;
     writer.write_roles(assembly)?;
     if args.save_remaining && !assembly.remaining.is_empty() {
         let entries: Vec<Value> = assembly
@@ -117,6 +125,7 @@ struct Writer {
     ignore: BTreeSet<String>,
     files: BTreeMap<PathBuf, String>,
     mode_headers: bool,
+    include_password_hashes: bool,
 }
 
 fn create_directories(root: &Path, gitkeep: bool) -> Result<(), String> {
@@ -165,6 +174,12 @@ impl Writer {
             project.insert(
                 String::from("languages"),
                 serialize(&assembly.languages)?,
+            );
+        }
+        if !assembly.foreign_data_wrappers.is_empty() {
+            project.insert(
+                String::from("foreign_data_wrappers"),
+                serialize(&assembly.foreign_data_wrappers)?,
             );
         }
         self.save_value(PathBuf::from("project.yaml"), &Value::Object(project))
@@ -254,6 +269,33 @@ impl Writer {
                     &role,
                 )?;
             }
+        }
+        Ok(())
+    }
+
+    /// Write user mappings, dropping the `password` option unless
+    /// password hashes were explicitly requested (it is a secret)
+    fn write_user_mappings(
+        &mut self,
+        assembly: &Assembly,
+    ) -> Result<(), String> {
+        for mapping in &assembly.user_mappings {
+            let mut mapping = mapping.clone();
+            if !self.include_password_hashes {
+                for server in &mut mapping.servers {
+                    if let Some(options) = &mut server.options {
+                        options.remove("password");
+                        if options.is_empty() {
+                            server.options = None;
+                        }
+                    }
+                }
+            }
+            self.save(
+                Path::new("user_mappings")
+                    .join(format!("{}.yaml", mapping.name)),
+                &mapping,
+            )?;
         }
         Ok(())
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -184,3 +184,51 @@ pub fn build_archive(path: &std::path::Path, mutated: bool) {
     );
     dump.save(path).expect("failed to save archive");
 }
+
+/// A small archive exercising all four foreign-object types (FDW,
+/// server, user mapping with a secret, and a foreign table), used by
+/// the pull tests
+pub fn foreign_archive(path: &std::path::Path) {
+    let mut dump = libpgdump::new("foreign", "UTF8", "18.0").unwrap();
+    add(&mut dump, OT::Schema, "", "test", "CREATE SCHEMA test;");
+    add(
+        &mut dump,
+        OT::ForeignDataWrapper,
+        "",
+        "local_files",
+        "CREATE FOREIGN DATA WRAPPER local_files OPTIONS (debug 'true');",
+    );
+    add(
+        &mut dump,
+        OT::Server,
+        "",
+        "wh",
+        "CREATE SERVER wh FOREIGN DATA WRAPPER postgres_fdw OPTIONS \
+         (host 'db.example', dbname 'warehouse');",
+    );
+    add(
+        &mut dump,
+        OT::UserMapping,
+        "",
+        "postgres",
+        "CREATE USER MAPPING FOR postgres SERVER wh OPTIONS \
+         (user 'remote_app', password 'sup3rsecret');",
+    );
+    add(
+        &mut dump,
+        OT::ForeignTable,
+        "test",
+        "remote_orders",
+        "CREATE FOREIGN TABLE test.remote_orders (id integer NOT NULL, \
+         total numeric) SERVER wh OPTIONS (schema_name 'public', \
+         table_name 'orders');",
+    );
+    add(
+        &mut dump,
+        OT::Comment,
+        "test",
+        "remote_orders",
+        "COMMENT ON FOREIGN TABLE test.remote_orders IS 'Remote orders';",
+    );
+    dump.save(path).expect("failed to save archive");
+}

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -116,6 +116,74 @@ fn pulled_project_loads_and_validates() {
 }
 
 #[test]
+fn pulls_foreign_objects() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("foreign.dump");
+    common::foreign_archive(&archive);
+    let dest = dir.path().join("project");
+
+    pull::pull(&pull_args(&archive, &dest)).expect("pull failed");
+
+    // a FDW lands in project.yaml; the server and user mapping get their
+    // own files; the foreign table joins tables/ with server + options
+    let project_yaml =
+        std::fs::read_to_string(dest.join("project.yaml")).unwrap();
+    assert!(project_yaml.contains("foreign_data_wrappers:"));
+    assert!(project_yaml.contains("local_files"));
+    let server =
+        std::fs::read_to_string(dest.join("servers/wh.yaml")).unwrap();
+    assert!(server.contains("foreign_data_wrapper: postgres_fdw"));
+    assert!(server.contains("dbname: warehouse"));
+    let foreign_table =
+        std::fs::read_to_string(dest.join("tables/test/remote_orders.yaml"))
+            .unwrap();
+    assert!(foreign_table.contains("server: wh"));
+    assert!(foreign_table.contains("schema_name: public"));
+    assert!(foreign_table.contains("comment: Remote orders"));
+    // the user mapping's password option is a secret, redacted by
+    // default (no --include-password-hashes)
+    let mapping =
+        std::fs::read_to_string(dest.join("user_mappings/postgres.yaml"))
+            .unwrap();
+    assert!(mapping.contains("user: remote_app"));
+    assert!(
+        !mapping.contains("password"),
+        "user-mapping password must be redacted by default: {mapping}"
+    );
+
+    let project = project::load(&dest).expect("pulled project must load");
+    let kinds: Vec<&str> =
+        project.inventory.iter().map(|i| i.desc.as_str()).collect();
+    for expected in ["FOREIGN DATA WRAPPER", "SERVER", "USER MAPPING", "TABLE"]
+    {
+        assert!(kinds.contains(&expected), "missing {expected}: {kinds:?}");
+    }
+}
+
+#[test]
+fn include_password_hashes_keeps_user_mapping_password() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("foreign.dump");
+    common::foreign_archive(&archive);
+    let dest = dir.path().join("project");
+
+    pull::pull(&pull_args_with(
+        &archive,
+        &dest,
+        &["--gitkeep", "--include-password-hashes"],
+    ))
+    .expect("pull failed");
+
+    let mapping =
+        std::fs::read_to_string(dest.join("user_mappings/postgres.yaml"))
+            .unwrap();
+    assert!(
+        mapping.contains("password: sup3rsecret"),
+        "--include-password-hashes must retain the password: {mapping}"
+    );
+}
+
+#[test]
 fn include_mode_headers_prefixes_generated_files() {
     let dir = tempfile::tempdir().unwrap();
     let archive = dir.path().join("fixtures.dump");


### PR DESCRIPTION
## Summary
Complete foreign-object support by wiring up the **pull** side: foreign data wrappers, foreign servers, user mappings, and foreign tables now round-trip from a database into a project and back through `build`.

## Problem
`build` and `load` already supported these objects, but the DDL parser had no dispatch for the four foreign `CREATE` statements, so each fell through to `Statement::Unsupported` and was silently dropped on `pull` (this is what made the `fdw_warehouse` foreign tables vanish from the appdb project).

## Solution
- **`ddl/foreign.rs`** parses `CreateFdwStmt`, `CreateForeignServerStmt`, `CreateUserMappingStmt`, and `CreateForeignTableStmt`. Foreign tables reuse the `Table` model with `server`/`options` set; a shared `generic_options` helper reads `OPTIONS (key 'value', ...)`.
- **pull ingest** routes the foreign archive descs to the parser; `Assembly` gains `foreign_data_wrappers`/`servers`/`user_mappings`, `apply()` stores them (merging user mappings by user), and `counts_by_type` reports them.
- **writer** emits FDWs into `project.yaml`, servers into `servers/`, and user mappings into `user_mappings/`. A user mapping's `password` option is a secret, **redacted by default** and retained only with `--include-password-hashes` (the same flag that gates role password hashes).
- `COMMENT ON FOREIGN TABLE` now attaches to the foreign table.
- `server.yml` no longer *requires* `dependencies` — pull doesn't emit one, matching every other object type. (The property remains optional.)

Also corrects the docs `--style` default (now `pg_dump`) and documents the RDS passwordless-roles fallback.

## Impact
- `pull` now captures foreign objects that were previously dropped. Existing projects are unaffected.
- **Note:** `deploy` does not yet diff foreign objects (a Phase-6 follow-up); this PR covers pull + build only.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (132 lib + integration) pass. Added parser unit tests for all four statements and two pull integration tests (foreign-object capture with default redaction, and `--include-password-hashes` retention). Verified end to end against PostgreSQL 17: a database with a FDW, server, user mapping, and foreign table pulls into a project (password redacted by default; retained with the flag), builds, and `pg_restore --no-owner` recreates every object with correct server, columns, options, and comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for pulling foreign data wrappers, foreign servers, user mappings, and foreign tables.
  * User mapping passwords are redacted by default and preserved when `--include-password-hashes` is used.
* **Documentation**
  * Updated `pglifecycle pull` documentation for `--style`, clarified deploy/libpgfmt formatting behavior, and expanded foreign object representation details.
* **Bug Fixes**
  * Adjusted server manifest validation so `dependencies` is no longer required.
* **Tests**
  * Added integration coverage for foreign-object pulling and password redaction/retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->