### PR TITLE
Add a build progress banner and completion summary

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -31,6 +31,7 @@ mod acls;
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::time::Instant;
 
 use serde_json::{Map, Value};
 
@@ -43,10 +44,12 @@ use crate::project::Project;
 use crate::utils::{postgres_value, quote_ident, raw_value};
 
 pub fn build(project: &Project, destination: &Path) -> Result<(), String> {
-    log::info!(
-        "Saving build artifact to {} for {}",
+    let started = Instant::now();
+    println!(
+        "pglifecycle v{} Building {} → {}",
+        env!("CARGO_PKG_VERSION"),
+        project.name,
         destination.display(),
-        project.name
     );
     let output = assemble(project)?;
     let task = progress::spinner("Saving archive");
@@ -59,6 +62,11 @@ pub fn build(project: &Project, destination: &Path) -> Result<(), String> {
         "Saved pg_dump -Fc compatible dump to {} with {} entries",
         destination.display(),
         output.dump.entries().len(),
+    );
+    println!(
+        "\nBuilt {} in {:.2?}",
+        destination.display(),
+        started.elapsed(),
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary
Give `build` the same kind of stdout feedback `pull` already prints: an up-front banner of what it is doing and a closing summary line.

## Problem
`build` ran silently unless invoked with `-v`/`--debug` (its only output was `log::info!`/`log::debug!` records). `pull`, by contrast, always prints a `pglifecycle v… <gerund> <source> → <dest>` banner on start and a summary on completion. The asymmetry meant a plain `build` gave no indication of what it was building or how long it took.

## Solution
- **Startup banner** (always on stdout): `pglifecycle v<ver> Building <project> → <destination>`, replacing the gated `log::info!` startup line.
- **Completion summary**: `Built <destination> in <duration>`, reporting the dump-file path and elapsed time (via `Instant::now()` / `{:.2?}`).

Per request, the summary reports the dump path and duration rather than object counts — counts are not meaningful for an archive build. The existing debug entry-count log is retained.

Example:
```
pglifecycle v2.0.0-alpha.0 Building test-project → /tmp/test-build.dump

Built /tmp/test-build.dump in 8.02ms
```

## Impact
Stdout-only, purely additive feedback for the `build` command; no change to the archive itself. Branched off `main`, independent of the foreign-object work in #46.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (132 lib + integration tests pass); ran `build` against `test-project` to confirm the banner and summary render.