### PR TITLE
Print the build banner before loading the project

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -31,7 +31,6 @@ mod acls;
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Instant;
 
 use serde_json::{Map, Value};
 
@@ -44,13 +43,6 @@ use crate::project::Project;
 use crate::utils::{postgres_value, quote_ident, raw_value};
 
 pub fn build(project: &Project, destination: &Path) -> Result<(), String> {
-    let started = Instant::now();
-    println!(
-        "pglifecycle v{} Building {} → {}",
-        env!("CARGO_PKG_VERSION"),
-        project.name,
-        destination.display(),
-    );
     let output = assemble(project)?;
     let task = progress::spinner("Saving archive");
     output
@@ -62,11 +54,6 @@ pub fn build(project: &Project, destination: &Path) -> Result<(), String> {
         "Saved pg_dump -Fc compatible dump to {} with {} entries",
         destination.display(),
         output.dump.entries().len(),
-    );
-    println!(
-        "\nBuilt {} in {:.2?}",
-        destination.display(),
-        started.elapsed(),
     );
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,7 @@ fn main() -> ExitCode {
         args.action.name()
     );
     let result = match &args.action {
-        cli::Action::Build(args) => project::load(&args.project)
-            .and_then(|p| build::build(&p, &args.destination)),
+        cli::Action::Build(args) => run_build(args),
         cli::Action::Create(create) => skeleton::create(create),
         cli::Action::Deploy(args) => deploy::deploy(args),
         cli::Action::Pull(args) => pull::pull(args),
@@ -29,6 +28,29 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+/// Load the project and write the archive, framing the work with an
+/// up-front banner and a closing summary on stdout (matching `pull`).
+/// The banner prints before the load so it precedes any warnings the
+/// load emits; it names the project path rather than the project's
+/// declared name, which is not known until the load completes.
+fn run_build(args: &cli::Build) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    println!(
+        "pglifecycle v{} Building {} → {}",
+        env!("CARGO_PKG_VERSION"),
+        args.project.display(),
+        args.destination.display(),
+    );
+    let project = project::load(&args.project)?;
+    build::build(&project, &args.destination)?;
+    println!(
+        "\nBuilt {} in {:.2?}",
+        args.destination.display(),
+        started.elapsed(),
+    );
+    Ok(())
 }
 
 fn configure_logging(args: &cli::Cli) {


### PR DESCRIPTION
## Summary
Make the `build` startup banner print before the project is loaded, so it appears up-front instead of after load-time warnings.

## Problem
The banner added in #47 was emitted inside `build::build`, but `main` loads the project (`project::load`) *before* calling it. Loading emits warnings — unmanaged-dependency skips, ACL-target-not-found notices, etc. — so the banner showed up after them:

```
17:11:53 [WARN] Skipping dependency from TABLE pgq_node.subscriber_info on unmanaged TABLE pgq.consumer
pglifecycle v2.0.0-alpha.0 Building app → appdb.dump
```

## Solution
Move the banner, timing, and completion summary into a `run_build` helper in `main` that prints the banner *before* the load. The banner now precedes any load warnings, and the reported duration covers the whole operation (load + assemble + save) rather than just the save.

The banner names the project **path** rather than the project's declared name, because the name is not known until the load completes — and printing before the load is the whole point. `build::build` is back to doing only the work (no stdout), so the in-memory-`Project` test callers stay quiet.

```
pglifecycle v2.0.0-alpha.0 Building test-project → /tmp/test-build.dump
17:15:52 [WARN] ACL target TABLE public.empty_table not found in the project

Built /tmp/test-build.dump in 157.26ms
```

## Impact
Stdout-only; no change to the archive. Follow-up to #47.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (132 lib + integration tests pass); ran `build` against `test-project` to confirm the banner now precedes the load warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized build status and timing information architecture. Build progress notifications and elapsed time calculations were consolidated from the core build module into the main application handler, providing a single centralized location for all build lifecycle feedback and improving code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->