### PR TITLE
Add a Justfile for build, test, gates, docs, and release tasks

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,110 @@
+# pglifecycle task runner. Run `just` to list recipes.
+#
+# The round-trip and deploy gates need PostgreSQL; they bring up the
+# compose.yaml container and discover its dynamically-mapped port.
+
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+# List available recipes
+default:
+    @just --list
+
+# --- Build -----------------------------------------------------------
+
+# Debug build
+build:
+    cargo build
+
+# Optimized release build
+release:
+    cargo build --release
+
+# Run the binary (e.g. `just run pull --help`)
+run *ARGS:
+    cargo run -- {{ARGS}}
+
+# Remove build artifacts
+clean:
+    cargo clean
+
+# --- Quality ---------------------------------------------------------
+
+# Format sources in place
+fmt:
+    cargo fmt
+
+# Verify formatting (CI gate)
+fmt-check:
+    cargo fmt --check
+
+# Lint with warnings denied (CI gate)
+lint:
+    cargo clippy --all-targets -- -D warnings
+
+# Unit + integration tests (CI gate)
+test:
+    cargo test
+
+# The full CI trio: format check, lint, test
+check: fmt-check lint test
+
+# Run all pre-commit hooks
+pre-commit:
+    pre-commit run --all-files
+
+# --- Database (compose PG17) -----------------------------------------
+
+# Start the PostgreSQL container and wait until healthy
+db-up:
+    docker compose up -d --wait
+
+# Stop and remove the PostgreSQL container
+db-down:
+    docker compose down
+
+# Print the host port the container's 5432 is mapped to
+db-port:
+    @docker compose port postgres 5432 | cut -d: -f2
+
+# --- Gates (PLAN.md) -------------------------------------------------
+
+# Phase 3 round-trip gate (schema → pull → build → restore → diff)
+round-trip: build db-up
+    PGHOST=localhost \
+    PGPORT="$(docker compose port postgres 5432 | cut -d: -f2)" \
+    PGUSER=postgres \
+    bin/round-trip
+
+# Phase 6 deploy gates (equivalence, convergence, safety)
+deploy-gates: build db-up
+    PGHOST=localhost \
+    PGPORT="$(docker compose port postgres 5432 | cut -d: -f2)" \
+    PGUSER=postgres \
+    bin/deploy-gates
+
+# Both PLAN.md gates
+gates: round-trip deploy-gates
+
+# --- Docs ------------------------------------------------------------
+
+# Build the documentation site (strict, as CI does)
+docs:
+    mkdocs build --strict
+
+# Serve the documentation locally with live reload
+docs-serve:
+    mkdocs serve
+
+# --- Release ---------------------------------------------------------
+#
+# Tagged releases are cut on GitHub: creating a release triggers the
+# Release and Publish workflows, which build the cross-platform
+# binaries, update the Homebrew tap, and `cargo publish` to crates.io.
+# These recipes are for local verification before tagging.
+
+# Dry-run the crates.io publish
+publish-dry:
+    cargo publish --dry-run
+
+# Everything CI checks plus both database gates, before a release
+pre-release: check gates docs publish-dry


### PR DESCRIPTION
## Summary
Add a `Justfile` that wraps the project's existing tooling so the common workflows are discoverable from `just --list`.

## Problem
The build/test/lint/gate/docs/release commands live across `cargo`, `docker compose`, `mkdocs`, and the `bin/` gate scripts. There was no single entry point, and the round-trip / deploy gates require discovering the compose container's dynamically-mapped Postgres port by hand.

## Solution
Recipes that shell out to the same commands CI and the `bin/` scripts already use:

- `build` / `release` / `run` / `clean`
- `fmt`, `fmt-check`, `lint`, `test`, and `check` (the CI trio: fmt-check + clippy + test), plus `pre-commit`
- `db-up` / `db-down` / `db-port` for the compose PG17 container
- `round-trip` and `deploy-gates` — bring up the container and pass its mapped port to `bin/round-trip` / `bin/deploy-gates` (the PLAN.md Phase 3 / Phase 6 gates)
- `docs` / `docs-serve` (mkdocs) and `publish-dry` / `pre-release`

## Impact
Additive convenience only — nothing about the build, test, or release pipeline changes. Tagged releases are still cut on GitHub (the Release/Publish workflows handle binaries, the Homebrew tap, and `cargo publish`); the release recipes are for local verification before tagging.

## Testing
`just --list` renders all recipes; `just fmt-check` / `just lint` / `just build` run their underlying cargo commands. The database-gate recipes were reviewed against the existing `bin/` scripts but not run end-to-end in this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a development task runner configuration to automate builds, releases, testing, code quality checks, database management, and documentation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->