### PR TITLE
Reconcile foreign objects in deploy

### DIFF
--- a/bin/deploy-gates
+++ b/bin/deploy-gates
@@ -49,6 +49,16 @@ psql -d "${SOURCE_DB}" -q -v ON_ERROR_STOP=1 -f fixtures/schema.sql
 # cleared during convergence (gate 2)
 psql -d "${SOURCE_DB}" -q -v ON_ERROR_STOP=1 \
     -c "CREATE VIEW test.deploy_probe AS SELECT 1 AS n;"
+# foreign objects (a handler-less wrapper needs no remote to exist):
+# their options are reconciled in place during convergence (gate 2)
+psql -d "${SOURCE_DB}" -q -v ON_ERROR_STOP=1 <<'SQL'
+CREATE FOREIGN DATA WRAPPER gate_fdw OPTIONS (debug 'true');
+CREATE SERVER gate_srv FOREIGN DATA WRAPPER gate_fdw
+    OPTIONS (host 'h', dbname 'w');
+CREATE USER MAPPING FOR postgres SERVER gate_srv OPTIONS (usr 'u');
+CREATE FOREIGN TABLE test.gate_ft (id integer)
+    SERVER gate_srv OPTIONS (schema_name 'public', table_name 't');
+SQL
 
 echo "==> pull a project from ${SOURCE_DB}"
 pg_dump -d "${SOURCE_DB}" -Fc --schema-only -f "${WORKDIR}/source.dump"
@@ -74,11 +84,16 @@ echo "==> Gate 2: convergence (mutate, deploy --apply, re-deploy is empty)"
 # a domain default (in-place ALTER DOMAIN), and a database-only comment
 # on an OR REPLACE object (must be cleared with COMMENT ... IS NULL so
 # the re-deploy converges)
+# the foreign-object drift (wrapper, server, and foreign-table options)
+# must reconcile in place via the deploy ALTER renderers
 psql -d "${TARGET_DB}" -q -v ON_ERROR_STOP=1 <<'SQL'
 ALTER TABLE test.users ADD COLUMN scratch text;
 ALTER TABLE test.users ALTER COLUMN display_name SET NOT NULL;
 ALTER DOMAIN test.bcp47_locale SET DEFAULT 'en-US';
 COMMENT ON VIEW test.deploy_probe IS 'stale, not in repo';
+ALTER FOREIGN DATA WRAPPER gate_fdw OPTIONS (SET debug 'false');
+ALTER SERVER gate_srv OPTIONS (SET host 'changed', DROP dbname);
+ALTER FOREIGN TABLE test.gate_ft OPTIONS (SET table_name 'changed');
 SQL
 ./target/debug/pglifecycle deploy --apply --allow-drop -d "${TARGET_DB}" \
     "${WORKDIR}/project"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -87,7 +87,8 @@ reconciled in place where PostgreSQL can express it:
 - **Foreign data wrappers** — handler, validator, and `OPTIONS`
   (`ADD`/`SET`/`DROP`) changes, plus comments.
 - **Foreign servers** — `VERSION` and `OPTIONS` changes, plus comments;
-  a wrapper or `TYPE` change (neither is alterable) falls back.
+  a wrapper or `TYPE` change (neither is alterable) falls back, as does
+  clearing an existing `VERSION` (it cannot be removed in place).
 - **User mappings** — per-server `OPTIONS` changes; a mapping the
   project adds or drops is created or dropped. A `password` the project
   does not carry is left untouched, so a redacted pull (the default)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,6 +84,16 @@ reconciled in place where PostgreSQL can express it:
 - **Enum types** — `ALTER TYPE ... ADD VALUE` for appended values;
   reordering or removing values falls back.
 - **Extensions** — `ALTER EXTENSION ... UPDATE` / `SET SCHEMA`.
+- **Foreign data wrappers** — handler, validator, and `OPTIONS`
+  (`ADD`/`SET`/`DROP`) changes, plus comments.
+- **Foreign servers** — `VERSION` and `OPTIONS` changes, plus comments;
+  a wrapper or `TYPE` change (neither is alterable) falls back.
+- **User mappings** — per-server `OPTIONS` changes; a mapping the
+  project adds or drops is created or dropped. A `password` the project
+  does not carry is left untouched, so a redacted pull (the default)
+  never strips a live credential.
+- **Foreign tables** — `OPTIONS` changes and comments in place; a server
+  or column change falls back to drop+recreate.
 - Everything else falls back to drop+recreate.
 
 ### Destructive statements and limits

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -40,7 +40,9 @@ use crate::models::{
 };
 use crate::progress;
 use crate::project::Project;
-use crate::utils::{postgres_value, quote_ident, raw_value};
+use crate::utils::{
+    postgres_value, quote_ident, raw_value, user_mapping_subject,
+};
 
 pub fn build(project: &Project, destination: &Path) -> Result<(), String> {
     let output = assemble(project)?;
@@ -1686,7 +1688,7 @@ impl Builder {
                 "CREATE".into(),
                 "USER MAPPING".into(),
                 "FOR".into(),
-                quote_ident(&d.name),
+                user_mapping_subject(&d.name),
                 "SERVER".into(),
                 quote_ident(&server.name),
             ];
@@ -1700,7 +1702,7 @@ impl Builder {
             let drop = vec![
                 "DROP USER MAPPING IF EXISTS".into(),
                 "FOR".into(),
-                quote_ident(&d.name),
+                user_mapping_subject(&d.name),
                 "SERVER".into(),
                 quote_ident(&server.name),
             ];

--- a/src/deploy/alter.rs
+++ b/src/deploy/alter.rs
@@ -8,13 +8,16 @@
 //! data and the repo is authoritative. Only data-destructive
 //! statements (DROP COLUMN, ALTER COLUMN TYPE) are.
 
+use serde_json::{Map, Value};
+
 use crate::build;
 use crate::deploy::diff::canonical_type;
 use crate::models::{
-    CheckConstraint, Column, Definition, Domain, Extension, ForeignKey, Index,
-    Schema, Sequence, Table, Trigger, Type, View, ViewColumn,
+    CheckConstraint, Column, Definition, Domain, Extension,
+    ForeignDataWrapper, ForeignKey, Index, Schema, Sequence, Server, Table,
+    Trigger, Type, UserMapping, View, ViewColumn,
 };
-use crate::utils::quote_ident;
+use crate::utils::{postgres_value, quote_ident};
 
 /// One reconciliation statement
 pub(crate) struct Alter {
@@ -89,6 +92,14 @@ pub(crate) fn resolve(repo: &Definition, database: &Definition) -> Resolution {
             }
         }
         (Definition::View(repo), Definition::View(db)) => view(repo, db),
+        (
+            Definition::ForeignDataWrapper(repo),
+            Definition::ForeignDataWrapper(db),
+        ) => fdw(repo, db),
+        (Definition::Server(repo), Definition::Server(db)) => server(repo, db),
+        (Definition::UserMapping(repo), Definition::UserMapping(db)) => {
+            user_mapping(repo, db)
+        }
         _ => Resolution::Replace,
     }
 }
@@ -145,6 +156,12 @@ fn view_columns_compatible(repo: &View, db: &View) -> bool {
 }
 
 fn table(repo: &Table, db: &Table) -> Resolution {
+    // foreign tables (a `server` on either side) reconcile through a
+    // dedicated path: only OPTIONS and the comment are alterable in
+    // place, everything else rebuilds
+    if repo.server.is_some() || db.server.is_some() {
+        return foreign_table(repo, db);
+    }
     // properties only expressible by rebuilding the table
     if repo.sql != db.sql
         || repo.unlogged != db.unlogged
@@ -641,6 +658,221 @@ fn schema(repo: &Schema, db: &Schema) -> Resolution {
         )));
     }
     Resolution::Statements(alters)
+}
+
+/// Foreign-table reconciliation: only OPTIONS and the comment are
+/// alterable in place. A different server or any column/structural
+/// change rebuilds (gated behind --allow-drop). Foreign-table comments
+/// use the FOREIGN TABLE object type, matching the build.
+fn foreign_table(repo: &Table, db: &Table) -> Resolution {
+    if repo.server != db.server
+        || repo.columns != db.columns
+        || repo.sql != db.sql
+        || repo.check_constraints != db.check_constraints
+    {
+        return Resolution::Replace;
+    }
+    let name = qualified(&repo.schema, &repo.name);
+    let mut alters = Vec::new();
+    if let Some(clause) = options_delta(&repo.options, &db.options) {
+        alters.push(Alter::new(format!(
+            "ALTER FOREIGN TABLE {name} OPTIONS ({clause});\n"
+        )));
+    }
+    if repo.comment != db.comment {
+        alters.push(Alter::new(comment_on(
+            "FOREIGN TABLE",
+            &name,
+            repo.comment.as_deref(),
+        )));
+    }
+    Resolution::Statements(alters)
+}
+
+/// Foreign-data-wrapper reconciliation: handler, validator, OPTIONS,
+/// and comment are all alterable in place.
+fn fdw(repo: &ForeignDataWrapper, db: &ForeignDataWrapper) -> Resolution {
+    let name = quote_ident(&repo.name);
+    let mut alters = Vec::new();
+    if repo.handler != db.handler {
+        alters.push(Alter::new(match &repo.handler {
+            Some(handler) => format!(
+                "ALTER FOREIGN DATA WRAPPER {name} HANDLER {handler};\n"
+            ),
+            None => {
+                format!("ALTER FOREIGN DATA WRAPPER {name} NO HANDLER;\n")
+            }
+        }));
+    }
+    if repo.validator != db.validator {
+        alters.push(Alter::new(match &repo.validator {
+            Some(validator) => format!(
+                "ALTER FOREIGN DATA WRAPPER {name} VALIDATOR {validator};\n"
+            ),
+            None => {
+                format!("ALTER FOREIGN DATA WRAPPER {name} NO VALIDATOR;\n")
+            }
+        }));
+    }
+    if let Some(clause) = options_delta(&repo.options, &db.options) {
+        alters.push(Alter::new(format!(
+            "ALTER FOREIGN DATA WRAPPER {name} OPTIONS ({clause});\n"
+        )));
+    }
+    if repo.comment != db.comment {
+        alters.push(Alter::new(comment_on(
+            "FOREIGN DATA WRAPPER",
+            &name,
+            repo.comment.as_deref(),
+        )));
+    }
+    Resolution::Statements(alters)
+}
+
+/// Server reconciliation: VERSION, OPTIONS, and comment alter in place.
+/// The owning foreign-data wrapper and the server TYPE cannot be
+/// altered, and VERSION cannot be cleared, so those changes rebuild.
+fn server(repo: &Server, db: &Server) -> Resolution {
+    if repo.foreign_data_wrapper != db.foreign_data_wrapper
+        || repo.server_type != db.server_type
+        || (repo.version.is_none() && db.version.is_some())
+    {
+        return Resolution::Replace;
+    }
+    let name = quote_ident(&repo.name);
+    let mut alters = Vec::new();
+    if repo.version != db.version
+        && let Some(version) = &repo.version
+    {
+        alters.push(Alter::new(format!(
+            "ALTER SERVER {name} VERSION {};\n",
+            string_literal(version)
+        )));
+    }
+    if let Some(clause) = options_delta(&repo.options, &db.options) {
+        alters.push(Alter::new(format!(
+            "ALTER SERVER {name} OPTIONS ({clause});\n"
+        )));
+    }
+    if repo.comment != db.comment {
+        alters.push(Alter::new(comment_on(
+            "SERVER",
+            &name,
+            repo.comment.as_deref(),
+        )));
+    }
+    Resolution::Statements(alters)
+}
+
+/// User-mapping reconciliation: each (user, server) mapping is a
+/// distinct database object, so a mapping the repo adds is created, one
+/// it drops is dropped, and a shared one's OPTIONS are altered in place.
+fn user_mapping(repo: &UserMapping, db: &UserMapping) -> Resolution {
+    let user = quote_ident(&repo.name);
+    let mut alters = Vec::new();
+    for server in &repo.servers {
+        let name = quote_ident(&server.name);
+        match db.servers.iter().find(|s| s.name == server.name) {
+            None => {
+                let mut sql =
+                    format!("CREATE USER MAPPING FOR {user} SERVER {name}");
+                if let Some(clause) = options_clause(&server.options) {
+                    sql.push_str(&format!(" OPTIONS ({clause})"));
+                }
+                sql.push_str(";\n");
+                alters.push(Alter::new(sql));
+            }
+            Some(existing) => {
+                // a redacted pull omits the password, so a project that
+                // does not carry one must not drop the live credential
+                let db_options =
+                    keep_redacted_password(&server.options, &existing.options);
+                if let Some(clause) =
+                    options_delta(&server.options, &db_options)
+                {
+                    alters.push(Alter::new(format!(
+                        "ALTER USER MAPPING FOR {user} SERVER {name} \
+                         OPTIONS ({clause});\n"
+                    )));
+                }
+            }
+        }
+    }
+    for server in &db.servers {
+        if !repo.servers.iter().any(|s| s.name == server.name) {
+            alters.push(Alter::new(format!(
+                "DROP USER MAPPING IF EXISTS FOR {user} SERVER {};\n",
+                quote_ident(&server.name)
+            )));
+        }
+    }
+    Resolution::Statements(alters)
+}
+
+/// An `OPTIONS (...)` body reconciling `repo` against `db`: `ADD` for
+/// keys only in the repo, `SET` for changed values, `DROP` for keys
+/// only in the database. `None` when the option sets are equal. The
+/// option set is not data, so a removed option is not gated.
+fn options_delta(
+    repo: &Option<Map<String, Value>>,
+    db: &Option<Map<String, Value>>,
+) -> Option<String> {
+    let empty = Map::new();
+    let repo = repo.as_ref().unwrap_or(&empty);
+    let db = db.as_ref().unwrap_or(&empty);
+    if repo == db {
+        return None;
+    }
+    let mut parts = Vec::new();
+    for (key, value) in repo {
+        match db.get(key) {
+            None => parts.push(format!("ADD {key} {}", postgres_value(value))),
+            Some(existing) if existing != value => {
+                parts.push(format!("SET {key} {}", postgres_value(value)))
+            }
+            _ => {}
+        }
+    }
+    for key in db.keys() {
+        if !repo.contains_key(key) {
+            parts.push(format!("DROP {key}"));
+        }
+    }
+    (!parts.is_empty()).then(|| parts.join(", "))
+}
+
+/// The database options with a `password` removed when the project does
+/// not carry one (a redacted pull omits it), so the delta neither drops
+/// nor changes a credential the project cannot see.
+fn keep_redacted_password(
+    repo: &Option<Map<String, Value>>,
+    db: &Option<Map<String, Value>>,
+) -> Option<Map<String, Value>> {
+    let repo_has_password =
+        repo.as_ref().is_some_and(|m| m.contains_key("password"));
+    if repo_has_password {
+        return db.clone();
+    }
+    let mut db = db.clone().unwrap_or_default();
+    db.remove("password");
+    (!db.is_empty()).then_some(db)
+}
+
+/// A `key 'value'` option list for a freshly created object (no diff)
+fn options_clause(options: &Option<Map<String, Value>>) -> Option<String> {
+    let options = options.as_ref().filter(|o| !o.is_empty())?;
+    Some(
+        options
+            .iter()
+            .map(|(key, value)| format!("{key} {}", postgres_value(value)))
+            .collect::<Vec<_>>()
+            .join(", "),
+    )
+}
+
+/// A single-quoted SQL string literal with embedded quotes doubled
+fn string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 /// The `COMMENT ON` statement to reconcile a comment that changed
@@ -1279,5 +1511,199 @@ mod tests {
             sql(&alters),
             vec!["COMMENT ON SCHEMA test IS $$App schema$$;\n"]
         );
+    }
+
+    fn parse_fdw(value: serde_json::Value) -> ForeignDataWrapper {
+        serde_json::from_value(value).expect("fdw deserializes")
+    }
+
+    #[test]
+    fn fdw_handler_options_and_comment_alter_in_place() {
+        let db = parse_fdw(serde_json::json!({
+            "name": "wh", "owner": "postgres",
+            "options": {"debug": "false"},
+        }));
+        let mut repo = db.clone();
+        repo.handler = Some("postgres_fdw_handler".into());
+        repo.options = Some(
+            serde_json::from_value(serde_json::json!({"debug": "true"}))
+                .unwrap(),
+        );
+        repo.comment = Some("warehouse".into());
+        let alters = statements(fdw(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "ALTER FOREIGN DATA WRAPPER wh HANDLER \
+                 postgres_fdw_handler;\n",
+                "ALTER FOREIGN DATA WRAPPER wh OPTIONS (SET debug 'true');\n",
+                "COMMENT ON FOREIGN DATA WRAPPER wh IS $$warehouse$$;\n",
+            ]
+        );
+        assert!(alters.iter().all(|a| !a.destructive));
+    }
+
+    #[test]
+    fn fdw_handler_removal_emits_no_handler() {
+        let db = parse_fdw(serde_json::json!({
+            "name": "wh", "owner": "postgres",
+            "handler": "h", "validator": "v",
+        }));
+        let mut repo = db.clone();
+        repo.handler = None;
+        repo.validator = None;
+        let alters = statements(fdw(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "ALTER FOREIGN DATA WRAPPER wh NO HANDLER;\n",
+                "ALTER FOREIGN DATA WRAPPER wh NO VALIDATOR;\n",
+            ]
+        );
+    }
+
+    fn parse_server(value: serde_json::Value) -> Server {
+        serde_json::from_value(value).expect("server deserializes")
+    }
+
+    #[test]
+    fn server_version_and_options_alter_in_place() {
+        let db = parse_server(serde_json::json!({
+            "name": "wh", "foreign_data_wrapper": "postgres_fdw",
+            "version": "14", "options": {"host": "old", "port": "5432"},
+        }));
+        let mut repo = db.clone();
+        repo.version = Some("17".into());
+        repo.options = Some(
+            serde_json::from_value(
+                serde_json::json!({"host": "new", "dbname": "w"}),
+            )
+            .unwrap(),
+        );
+        let alters = statements(server(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "ALTER SERVER wh VERSION '17';\n",
+                "ALTER SERVER wh OPTIONS (SET host 'new', ADD dbname 'w', \
+                 DROP port);\n",
+            ]
+        );
+    }
+
+    #[test]
+    fn server_type_change_replaces() {
+        let db = parse_server(serde_json::json!({
+            "name": "wh", "foreign_data_wrapper": "postgres_fdw",
+            "type": "oracle",
+        }));
+        let mut repo = db.clone();
+        repo.server_type = Some("mysql".into());
+        assert!(matches!(server(&repo, &db), Resolution::Replace));
+    }
+
+    fn parse_user_mapping(value: serde_json::Value) -> UserMapping {
+        serde_json::from_value(value).expect("user mapping deserializes")
+    }
+
+    #[test]
+    fn user_mapping_adds_alters_and_drops_per_server() {
+        let db = parse_user_mapping(serde_json::json!({
+            "name": "app",
+            "servers": [
+                {"name": "keep", "options": {"user": "old"}},
+                {"name": "gone", "options": {"user": "x"}},
+            ],
+        }));
+        let repo = parse_user_mapping(serde_json::json!({
+            "name": "app",
+            "servers": [
+                {"name": "keep", "options": {"user": "new"}},
+                {"name": "fresh", "options": {"user": "y"}},
+            ],
+        }));
+        let alters = statements(user_mapping(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "ALTER USER MAPPING FOR app SERVER keep OPTIONS \
+                 (SET user 'new');\n",
+                "CREATE USER MAPPING FOR app SERVER fresh OPTIONS \
+                 (user 'y');\n",
+                "DROP USER MAPPING IF EXISTS FOR app SERVER gone;\n",
+            ]
+        );
+        assert!(alters.iter().all(|a| !a.destructive));
+    }
+
+    #[test]
+    fn user_mapping_keeps_redacted_password() {
+        // the project (redacted pull) carries only `user`; the database
+        // mapping also has a password — deploy must not drop it
+        let db = parse_user_mapping(serde_json::json!({
+            "name": "app",
+            "servers": [{
+                "name": "wh",
+                "options": {"user": "remote", "password": "secret"},
+            }],
+        }));
+        let repo = parse_user_mapping(serde_json::json!({
+            "name": "app",
+            "servers": [{"name": "wh", "options": {"user": "remote"}}],
+        }));
+        let alters = statements(user_mapping(&repo, &db));
+        assert!(
+            alters.is_empty(),
+            "a redacted password must not diff: {:?}",
+            sql(&alters)
+        );
+    }
+
+    fn foreign_table_value(
+        options: serde_json::Value,
+        comment: Option<&str>,
+    ) -> serde_json::Value {
+        let mut value = serde_json::json!({
+            "name": "remote", "schema": "test", "owner": "postgres",
+            "columns": [{"name": "id", "data_type": "integer"}],
+            "server": "wh", "options": options,
+        });
+        if let Some(comment) = comment {
+            value["comment"] = comment.into();
+        }
+        value
+    }
+
+    #[test]
+    fn foreign_table_options_alter_in_place() {
+        let repo = parse_table(foreign_table_value(
+            serde_json::json!({"schema_name": "public", "table_name": "t"}),
+            Some("remote orders"),
+        ));
+        let db = parse_table(foreign_table_value(
+            serde_json::json!({"schema_name": "public", "table_name": "old"}),
+            None,
+        ));
+        let alters = statements(table(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "ALTER FOREIGN TABLE test.remote OPTIONS (SET table_name \
+                 't');\n",
+                "COMMENT ON FOREIGN TABLE test.remote IS $$remote orders$$;\n",
+            ]
+        );
+        assert!(alters.iter().all(|a| !a.destructive));
+    }
+
+    #[test]
+    fn foreign_table_server_change_replaces() {
+        let repo = parse_table(foreign_table_value(
+            serde_json::json!({"table_name": "t"}),
+            None,
+        ));
+        let mut db = repo.clone();
+        db.server = Some("other".into());
+        assert!(matches!(table(&repo, &db), Resolution::Replace));
     }
 }

--- a/src/deploy/alter.rs
+++ b/src/deploy/alter.rs
@@ -17,7 +17,7 @@ use crate::models::{
     ForeignDataWrapper, ForeignKey, Index, Schema, Sequence, Server, Table,
     Trigger, Type, UserMapping, View, ViewColumn,
 };
-use crate::utils::{postgres_value, quote_ident};
+use crate::utils::{postgres_value, quote_ident, user_mapping_subject};
 
 /// One reconciliation statement
 pub(crate) struct Alter {
@@ -768,7 +768,7 @@ fn server(repo: &Server, db: &Server) -> Resolution {
 /// distinct database object, so a mapping the repo adds is created, one
 /// it drops is dropped, and a shared one's OPTIONS are altered in place.
 fn user_mapping(repo: &UserMapping, db: &UserMapping) -> Resolution {
-    let user = quote_ident(&repo.name);
+    let user = user_mapping_subject(&repo.name);
     let mut alters = Vec::new();
     for server in &repo.servers {
         let name = quote_ident(&server.name);
@@ -1634,6 +1634,27 @@ mod tests {
             ]
         );
         assert!(alters.iter().all(|a| !a.destructive));
+    }
+
+    #[test]
+    fn user_mapping_public_subject_is_unquoted() {
+        let db = parse_user_mapping(serde_json::json!({
+            "name": "PUBLIC",
+            "servers": [{"name": "gone", "options": {"user": "x"}}],
+        }));
+        let repo = parse_user_mapping(serde_json::json!({
+            "name": "PUBLIC",
+            "servers": [{"name": "fresh", "options": {"user": "y"}}],
+        }));
+        let alters = statements(user_mapping(&repo, &db));
+        assert_eq!(
+            sql(&alters),
+            vec![
+                "CREATE USER MAPPING FOR PUBLIC SERVER fresh OPTIONS \
+                 (user 'y');\n",
+                "DROP USER MAPPING IF EXISTS FOR PUBLIC SERVER gone;\n",
+            ]
+        );
     }
 
     #[test]

--- a/src/deploy/diff.rs
+++ b/src/deploy/diff.rs
@@ -99,8 +99,10 @@ pub struct Diff {
     /// classified [`Change::Changed`] (the ALTER renderers need both
     /// sides)
     pub changed: BTreeMap<usize, Definition>,
-    /// Objects in the database with no repo counterpart → DROP
-    pub removed: Vec<ObjectKey>,
+    /// Objects in the database with no repo counterpart → DROP, keyed
+    /// to their database-side definition (some drops, e.g. user
+    /// mappings, need more than the key to render)
+    pub removed: BTreeMap<ObjectKey, Definition>,
 }
 
 /// Object types deploy does not manage: roles, users, and groups
@@ -151,11 +153,10 @@ pub fn diff(project: &Project, assembly: &Assembly) -> Diff {
         };
         items.insert(item.id, change);
     }
-    let removed = database.into_keys().collect();
     Diff {
         items,
         changed,
-        removed,
+        removed: database,
     }
 }
 
@@ -166,13 +167,16 @@ fn modeled(desc: ObjectType) -> bool {
         desc,
         ObjectType::Domain
             | ObjectType::Extension
+            | ObjectType::ForeignDataWrapper
             | ObjectType::Function
             | ObjectType::MaterializedView
             | ObjectType::ProceduralLanguage
             | ObjectType::Schema
             | ObjectType::Sequence
+            | ObjectType::Server
             | ObjectType::Table
             | ObjectType::Type
+            | ObjectType::UserMapping
             | ObjectType::View
     )
 }
@@ -218,6 +222,18 @@ fn database_index(assembly: &Assembly) -> BTreeMap<ObjectKey, Definition> {
     }
     for d in &assembly.functions {
         insert(ObjectType::Function, Definition::Function(d.clone()));
+    }
+    for d in &assembly.foreign_data_wrappers {
+        insert(
+            ObjectType::ForeignDataWrapper,
+            Definition::ForeignDataWrapper(d.clone()),
+        );
+    }
+    for d in &assembly.servers {
+        insert(ObjectType::Server, Definition::Server(d.clone()));
+    }
+    for d in &assembly.user_mappings {
+        insert(ObjectType::UserMapping, Definition::UserMapping(d.clone()));
     }
     index
 }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -17,6 +17,7 @@ use std::io::IsTerminal;
 
 use crate::deploy::alter::Resolution;
 use crate::deploy::diff::{Change, Diff, ObjectKey};
+use crate::models::Definition;
 use crate::utils::quote_ident;
 use crate::{
     build, cli, constants, diagnostics, pgdump, progress, project, pull,
@@ -168,7 +169,7 @@ fn plan(
     // pg_dump archives are stored in dependency order, so dropping in
     // reverse entry order removes dependents before dependencies
     let wanted: std::collections::BTreeSet<&ObjectKey> =
-        diff.removed.iter().collect();
+        diff.removed.keys().collect();
     let mut emitted: std::collections::BTreeSet<&ObjectKey> =
         std::collections::BTreeSet::new();
     let ordered: Vec<&ObjectKey> = snapshot
@@ -184,7 +185,7 @@ fn plan(
                 true,
                 Statement {
                     label: key.to_string(),
-                    sql: drop_sql(key),
+                    sql: drop_sql(key, diff.removed.get(key)),
                 },
             );
         }
@@ -192,13 +193,13 @@ fn plan(
     // database-only objects whose snapshot entry could not be keyed
     // (should not happen for modeled types) still need dropping;
     // append them after the ordered ones
-    for key in &diff.removed {
+    for (key, definition) in &diff.removed {
         if !emitted.contains(key) {
             push(
                 true,
                 Statement {
                     label: key.to_string(),
-                    sql: drop_sql(key),
+                    sql: drop_sql(key, Some(definition)),
                 },
             );
         }
@@ -368,8 +369,23 @@ fn render_script(plan: &Plan, project: &str, source: &str) -> String {
     script
 }
 
-/// `DROP <type> IF EXISTS <name>` for a database-only object
-fn drop_sql(key: &ObjectKey) -> String {
+/// `DROP <type> IF EXISTS <name>` for a database-only object. User
+/// mappings are keyed by their user but dropped per server, so they
+/// render from the definition; everything else needs only the key.
+fn drop_sql(key: &ObjectKey, definition: Option<&Definition>) -> String {
+    if let Some(Definition::UserMapping(mapping)) = definition {
+        return mapping
+            .servers
+            .iter()
+            .map(|server| {
+                format!(
+                    "DROP USER MAPPING IF EXISTS FOR {} SERVER {};\n",
+                    quote_ident(&mapping.name),
+                    quote_ident(&server.name),
+                )
+            })
+            .collect();
+    }
     // function keys are identity signatures and must not be quoted
     // wholesale; everything else gets identifier quoting
     let name = match key.desc {
@@ -392,20 +408,30 @@ fn entry_key(entry: &libpgdump::Entry) -> Option<ObjectKey> {
     let desc = match entry.desc {
         OT::Domain => constants::ObjectType::Domain,
         OT::Extension => constants::ObjectType::Extension,
+        OT::ForeignDataWrapper => constants::ObjectType::ForeignDataWrapper,
+        // foreign tables key as tables (the project models them as
+        // tables with a `server`), so a removed one orders and drops
+        // alongside ordinary tables
+        OT::ForeignTable => constants::ObjectType::Table,
         OT::Function => constants::ObjectType::Function,
         OT::MaterializedView => constants::ObjectType::MaterializedView,
         OT::ProceduralLanguage => constants::ObjectType::ProceduralLanguage,
         OT::Schema => constants::ObjectType::Schema,
         OT::Sequence => constants::ObjectType::Sequence,
+        OT::ForeignServer | OT::Server => constants::ObjectType::Server,
         OT::Table => constants::ObjectType::Table,
         OT::Type => constants::ObjectType::Type,
+        OT::UserMapping => constants::ObjectType::UserMapping,
         OT::View => constants::ObjectType::View,
         _ => return None,
     };
     let schema = match desc {
         constants::ObjectType::Extension
+        | constants::ObjectType::ForeignDataWrapper
         | constants::ObjectType::ProceduralLanguage
-        | constants::ObjectType::Schema => String::new(),
+        | constants::ObjectType::Schema
+        | constants::ObjectType::Server
+        | constants::ObjectType::UserMapping => String::new(),
         _ => entry.namespace.clone().unwrap_or_default(),
     };
     Some(ObjectKey {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,6 +15,18 @@ pub fn quote_ident(value: &str) -> String {
     }
 }
 
+/// Quote a USER MAPPING subject, leaving `PUBLIC` as an unquoted
+/// keyword. PostgreSQL's CREATE/ALTER/DROP USER MAPPING grammar treats
+/// `PUBLIC` as a keyword, so quoting it (`"PUBLIC"`) produces invalid
+/// SQL; every other user name is a normal identifier.
+pub fn user_mapping_subject(name: &str) -> String {
+    if name.eq_ignore_ascii_case("PUBLIC") {
+        String::from("PUBLIC")
+    } else {
+        quote_ident(name)
+    }
+}
+
 /// Return a Postgres value as a string, quoted if required. Mirrors
 /// utils.postgres_value including Python's `str()` rendering of bools
 /// (`True`/`False`), which the Phase 3 round-trip work will revisit.
@@ -65,6 +77,14 @@ mod tests {
         assert_eq!(quote_ident("uuid-ossp"), "\"uuid-ossp\"");
         assert_eq!(quote_ident("==="), "\"===\"");
         assert_eq!(quote_ident("Has\"Quote"), "\"Has\"\"Quote\"");
+    }
+
+    #[test]
+    fn user_mapping_subjects_keep_public_unquoted() {
+        assert_eq!(user_mapping_subject("PUBLIC"), "PUBLIC");
+        assert_eq!(user_mapping_subject("public"), "PUBLIC");
+        assert_eq!(user_mapping_subject("app_user"), "app_user");
+        assert_eq!(user_mapping_subject("Mixed"), "\"Mixed\"");
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -232,3 +232,61 @@ pub fn foreign_archive(path: &std::path::Path) {
     );
     dump.save(path).expect("failed to save archive");
 }
+
+/// The foreign archive as a diverged database: the FDW, server, and
+/// foreign-table options differ from [`foreign_archive`], and an extra
+/// database-only server has no project counterpart. Used to exercise
+/// deploy's in-place foreign-object ALTERs and the gated DROP.
+pub fn mutated_foreign_archive(path: &std::path::Path) {
+    let mut dump = libpgdump::new("foreign", "UTF8", "18.0").unwrap();
+    add(&mut dump, OT::Schema, "", "test", "CREATE SCHEMA test;");
+    add(
+        &mut dump,
+        OT::ForeignDataWrapper,
+        "",
+        "local_files",
+        "CREATE FOREIGN DATA WRAPPER local_files OPTIONS (debug 'false');",
+    );
+    add(
+        &mut dump,
+        OT::Server,
+        "",
+        "wh",
+        "CREATE SERVER wh FOREIGN DATA WRAPPER postgres_fdw OPTIONS \
+         (host 'old.example', dbname 'warehouse');",
+    );
+    // a server only in the database → DROP (gated)
+    add(
+        &mut dump,
+        OT::Server,
+        "",
+        "orphan",
+        "CREATE SERVER orphan FOREIGN DATA WRAPPER postgres_fdw OPTIONS \
+         (host 'gone');",
+    );
+    add(
+        &mut dump,
+        OT::UserMapping,
+        "",
+        "postgres",
+        "CREATE USER MAPPING FOR postgres SERVER wh OPTIONS \
+         (user 'remote_app', password 'sup3rsecret');",
+    );
+    add(
+        &mut dump,
+        OT::ForeignTable,
+        "test",
+        "remote_orders",
+        "CREATE FOREIGN TABLE test.remote_orders (id integer NOT NULL, \
+         total numeric) SERVER wh OPTIONS (schema_name 'public', \
+         table_name 'legacy_orders');",
+    );
+    add(
+        &mut dump,
+        OT::Comment,
+        "test",
+        "remote_orders",
+        "COMMENT ON FOREIGN TABLE test.remote_orders IS 'Remote orders';",
+    );
+    dump.save(path).expect("failed to save archive");
+}

--- a/tests/deploy.rs
+++ b/tests/deploy.rs
@@ -6,7 +6,9 @@
 mod common;
 
 use clap::Parser;
-use common::{fixture_archive, mutated_archive};
+use common::{
+    fixture_archive, foreign_archive, mutated_archive, mutated_foreign_archive,
+};
 use pglifecycle::{cli, deploy, pull};
 
 fn pull_project(archive: &std::path::Path, dest: &std::path::Path) {
@@ -202,6 +204,75 @@ fn script_header_is_self_describing() {
     assert!(script.contains("-- project: fixtures\n"));
     assert!(script.contains("-- source: dump "));
     assert!(script.contains("-- destructive statements: none\n"));
+}
+
+#[test]
+fn foreign_objects_alter_in_place_and_drop_when_gated() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("foreign.dump");
+    foreign_archive(&baseline);
+    let mutated = dir.path().join("mutated.dump");
+    mutated_foreign_archive(&mutated);
+    // the project is the baseline; the "database" has diverged options
+    // and an extra server
+    let project = dir.path().join("project");
+    pull_project(&baseline, &project);
+
+    let gated = deploy_script(&project, &mutated, &[]);
+
+    // the FDW, server, and foreign-table option drift reconciles in
+    // place — no rebuilds
+    assert!(
+        gated.contains(
+            "ALTER FOREIGN DATA WRAPPER local_files OPTIONS (SET debug \
+             'true');"
+        ),
+        "missing FDW options alter in:\n{gated}"
+    );
+    assert!(
+        gated.contains("ALTER SERVER wh OPTIONS (SET host 'db.example');"),
+        "missing server options alter in:\n{gated}"
+    );
+    assert!(
+        gated.contains(
+            "ALTER FOREIGN TABLE test.remote_orders OPTIONS (SET table_name \
+             'orders');"
+        ),
+        "missing foreign-table options alter in:\n{gated}"
+    );
+    // the redacted user-mapping password must not be dropped
+    assert!(
+        !gated.contains("DROP password"),
+        "deploy must not drop a redacted password:\n{gated}"
+    );
+    // the database-only server is a gated drop
+    assert!(
+        !gated.contains("DROP SERVER"),
+        "server drop must be gated:\n{gated}"
+    );
+    assert!(gated.contains("excluded"), "header must note exclusions");
+
+    let script = deploy_script(&project, &mutated, &["--allow-drop"]);
+    assert!(
+        script.contains("DROP SERVER IF EXISTS orphan;"),
+        "missing database-only server drop in:\n{script}"
+    );
+}
+
+#[test]
+fn matching_foreign_objects_are_an_empty_plan() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("foreign.dump");
+    foreign_archive(&archive);
+    let project = dir.path().join("project");
+    pull_project(&archive, &project);
+
+    let script = deploy_script(&project, &archive, &[]);
+
+    assert!(
+        script.contains("-- no changes"),
+        "expected an empty plan, got:\n{script}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Close the deploy-side gap for foreign objects: `deploy` now reconciles changes to foreign data wrappers, servers, user mappings, and foreign tables, not just creates and drops them.

## Problem
`deploy` could create foreign objects when missing and drop them when project-absent, but it never reconciled *changes*:
- Foreign data wrappers, servers, and user mappings were not in the diff's `modeled()` set, so a change to (say) a server's options or a wrapper's handler was classified `Undiffable` and left untouched.
- Foreign-table option changes fell back to drop+recreate (gated), even though PostgreSQL can alter them in place.
- The generic `drop_sql` emitted `DROP USER MAPPING IF EXISTS <user>`, which is invalid SQL — user mappings drop per server (`FOR <user> SERVER <srv>`) — and database-only foreign objects were dropped unordered.

## Solution
- **Diffable** (`diff.rs`): add FDW, server, and user mapping to `modeled()` and `database_index()`, and retain removed objects' definitions so drops can render correctly.
- **In-place ALTER renderers** (`alter.rs`):
  - **FDW** — `HANDLER`/`VALIDATOR` (incl. `NO HANDLER`/`NO VALIDATOR`), `OPTIONS`, comment.
  - **Server** — `VERSION`, `OPTIONS`, comment; a wrapper or `TYPE` change (neither alterable) rebuilds.
  - **User mapping** — per-server `OPTIONS`, with `CREATE`/`DROP` for servers the project adds or removes.
  - **Foreign table** — `OPTIONS` and comment in place; a server or column change rebuilds.
  - A shared `OPTIONS (ADD/SET/DROP …)` delta renderer backs all four.
- **Redacted-password safety**: a `password` option the project does not carry is left untouched, so a redacted pull (the default) never strips a live credential.
- **Correct DROP**: `entry_key` now orders removed foreign objects (user-mapping/foreign-table → server → FDW), and user mappings render the per-server drop form.

## Impact
`deploy` plans are now complete for foreign objects. No change to objects that already matched (verified by an empty-plan test). Drops remain gated behind `--allow-drop` as before.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (140 lib + integration tests, +8 new). New coverage: alter.rs unit tests for each renderer and the redacted-password case; two `tests/deploy.rs` integration tests over synthesized foreign archives (in-place ALTERs + gated/allowed server drop, and a matching-foreign empty plan). `bin/deploy-gates` is extended to drive wrapper/server/foreign-table option drift end-to-end against compose PG17 (run locally with `just deploy-gates`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded deploy reconciliation to include PostgreSQL foreign data wrappers, foreign servers, user mappings, and foreign tables, with in-place updates for OPTIONS and comments.
* **Improvements**
  * More accurate handling of foreign-object drift (including redeploy verification), and safer handling of user-mapping credentials so redacted passwords aren’t accidentally changed.
  * Foreign-object drops are better qualified and gated behind explicit `--allow-drop` where required.
  * Improved generation of `USER MAPPING ... FOR` subjects, treating `PUBLIC` as a special-case.
* **Documentation**
  * Updated `deploy` change-reconciliation rules for the additional foreign-object categories and password redaction behavior.
* **Tests**
  * Added integration tests covering foreign-object drift, credential preservation, gated drops, and no-op deploy detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->