### PR TITLE
Lower the unmatched-ACL-target log to debug

### DIFF
--- a/src/build/acls.rs
+++ b/src/build/acls.rs
@@ -112,7 +112,10 @@ pub(super) fn dump_acls(
                         owner = item_owner;
                     }
                 }
-                None => log::warn!(
+                // common and benign: grants on extension-owned,
+                // foreign, or platform-managed (RDS) objects the project
+                // does not track; the grant is still emitted
+                None => log::debug!(
                     "ACL target {keyword} {target} not found in the project"
                 ),
             }


### PR DESCRIPTION
## Summary
Drop the per-grant "ACL target … not found in the project" message from warn to debug.

## Problem
A `build` against a production database emits one of these warnings for every grant whose target object the project does not track — extension-owned, foreign, or platform-managed (e.g. RDS) objects:

```
[WARN] ACL target TABLE pgq.tick not found in the project
[WARN] ACL target TABLE public.pg_stat_statements not found in the project
[WARN] ACL target TABLE rds_pgbouncer_auth.users not found in the project
...
```

There are dozens on a real schema. The grant is still emitted regardless, so these are benign noise rather than actionable warnings.

## Solution
Lower the log to `debug` (still available with `--debug`) and note inline that the grant is emitted anyway. No behavior change to the build output.

## Testing
`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (build::acls tests pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced log noise by demoting non-critical ACL dependency warnings to debug level, as these messages commonly occur for certain object types that don't require action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->