### PR TITLE
Allow every object type as a dependency key (L8)

### DIFF
--- a/schemata/dependencies.yml
+++ b/schemata/dependencies.yml
@@ -4,10 +4,22 @@ $id: https://pglifecycle.readthedocs.io/en/stable/schemata/dependencies.html
 title: Dependencies
 type: object
 properties:
+  aggregates:
+    type: array
+    propertyNames:
+      pattern: ^([A-Za-z0-9_\-]+)\.([A-Za-z0-9_\-]+)$
+  collations:
+    type: array
+    propertyNames:
+      pattern: ^([A-Za-z0-9_\-]+)\.([A-Za-z0-9_\-]+)$
   domains:
     type: array
     propertyNames:
       pattern: ^([A-Za-z0-9_\-]+)\.([A-Za-z0-9_\-]+)$
+  event_triggers:
+    type: array
+    propertyNames:
+      pattern: ^([A-Za-z0-9_\-]+)$
   extensions:
     type: array
     propertyNames:
@@ -24,10 +36,26 @@ properties:
     type: array
     propertyNames:
       pattern: ^([A-Za-z0-9_\-]+)$
+  materialized_views:
+    type: array
+    propertyNames:
+      pattern: ^([A-Za-z0-9_\-]+)\.([A-Za-z0-9_\-]+)$
+  publications:
+    type: array
+    propertyNames:
+      pattern: ^([A-Za-z0-9_\-]+)$
   sequences:
     type: array
     propertyNames:
       pattern: ^([A-Za-z0-9_\-]+)\.([A-Za-z0-9_\-]+)$
+  servers:
+    type: array
+    propertyNames:
+      pattern: ^([A-Za-z0-9_\-]+)$
+  subscriptions:
+    type: array
+    propertyNames:
+      pattern: ^([A-Za-z0-9_\-]+)$
   tables:
     type: array
     propertyNames:
@@ -36,6 +64,14 @@ properties:
     type: array
     propertyNames:
       pattern: ^([A-Za-z0-9_\-]+)\.([A-Za-z0-9_\-]+)$
+  user_mappings:
+    type: array
+    propertyNames:
+      pattern: ^([A-Za-z0-9_\-]+)$
+  users:
+    type: array
+    propertyNames:
+      pattern: ^([A-Za-z0-9_\-]+)$
   views:
     type: array
     propertyNames:

--- a/src/project/validate.rs
+++ b/src/project/validate.rs
@@ -126,4 +126,35 @@ mod tests {
         assert!(items.get("properties").is_some());
         assert!(items.get("$package_schema").is_none());
     }
+
+    #[test]
+    fn dependencies_schema_accepts_every_object_type() {
+        // the dependencies schema previously listed only nine plural
+        // keys with additionalProperties: false, so a dependency on an
+        // aggregate/collation/event_trigger/materialized_view/etc. failed
+        // validation even though the loader recognized the key
+        let schema = load_schema("dependencies").unwrap();
+        let validator = jsonschema::validator_for(&schema).unwrap();
+        let widened = json!({
+            "aggregates": ["test.agg"],
+            "collations": ["test.c"],
+            "event_triggers": ["et"],
+            "materialized_views": ["test.mv"],
+            "publications": ["p"],
+            "servers": ["s"],
+            "subscriptions": ["sub"],
+            "user_mappings": ["um"],
+            "users": ["u"],
+        });
+        assert!(
+            validator.iter_errors(&widened).next().is_none(),
+            "widened dependency keys should validate"
+        );
+        // additionalProperties: false must still reject unknown keys
+        let unknown = json!({"bogus_type": ["x"]});
+        assert!(
+            validator.iter_errors(&unknown).next().is_some(),
+            "unknown dependency keys must still be rejected"
+        );
+    }
 }


### PR DESCRIPTION
Closes the last substantive item from the review-findings audit (**L8**).

## Problem

`ObjectType::from_plural_key` (`src/constants.rs`) already recognizes all 25 object types, but `schemata/dependencies.yml` listed only nine plural keys under `additionalProperties: false`. Because per-object validation runs before the `dependencies` block is stripped, a `dependencies:` block naming an **aggregate, collation, event_trigger, materialized_view, publication, server, subscription, user, or user_mapping** was rejected at validation — you could depend on `views` but not `materialized_views`. Carried over from Python's `OBJ_KEYS`; per the maintainer, 2.0 need not preserve that limitation.

## Change

- Add the nine missing keys to `schemata/dependencies.yml` (schema-qualified `schema.name` pattern for the schema-scoped types; bare pattern for the schemaless ones), alphabetized with the existing keys.
- Add a `validate` test asserting the widened keys validate and unknown keys are still rejected by `additionalProperties: false`.

Resolution already works end-to-end for these types: the loader's `index_key` normalizes the namespace to `None` for schemaless types on both insert and lookup, and `from_plural_key` maps the keys — so no loader change is needed. (`propertyNames` on a `type: array` is a JSON-Schema no-op, matching the existing entries, so the patterns are cosmetic; `additionalProperties` is the functional gate.)

## Validation

- `just check` — fmt, clippy `-D warnings`, all tests pass (new `dependencies_schema_accepts_every_object_type`).
- `just gates` — round-trip + all three deploy gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for more dependency categories, including aggregates, collations, materialized views, publications, servers, subscriptions, user mappings, and users.

* **Tests**
  * Added coverage to confirm the schema accepts the broader set of dependency object types.
  * Verified unknown dependency types are still rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->