### PR TITLE
Emit role membership grants in build

### DIFF
--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -72,5 +72,22 @@ grants:
       - USAGE
 ```
 
+- Role memberships live in the same place, as `roles:`/`groups:`
+  arrays naming the roles the grantee is a member of. `build` emits
+  them as `GRANT role TO grantee` (or `REVOKE ... FROM` under
+  `revocations:`). The granted role does not have to be a project
+  file — reserved roles like `pg_read_all_data` can only ever be
+  referenced, never created, and this is how to express membership in
+  them:
+
+```yaml
+---
+name: alice
+grants:
+  roles:
+    - developers
+    - pg_read_all_data
+```
+
 - `create: false` defines a role without creating it — used for
   built-in pseudo-roles like `PUBLIC`.

--- a/src/build/acls.rs
+++ b/src/build/acls.rs
@@ -53,10 +53,28 @@ const SECTIONS: &[(&str, &str, &[ObjectType])] = &[
     ("types", "TYPE", &[ObjectType::Type]),
 ];
 
+/// Membership ACL sections: `(Acls field, tag keyword)`. Both grant
+/// role membership; `groups` exists for hand-authored projects since
+/// pg_dumpall does not distinguish groups from roles on pull
+const MEMBERSHIP_SECTIONS: &[(&str, &str)] =
+    &[("groups", "GROUP"), ("roles", "ROLE")];
+
+/// A granted role and its grantees may each be defined as a role,
+/// group, or user file
+const ROLES: &[ObjectType] =
+    &[ObjectType::Role, ObjectType::Group, ObjectType::User];
+
 #[derive(Default)]
 struct ObjectAcl {
     revokes: Vec<String>,
     grants: Vec<String>,
+}
+
+#[derive(Default)]
+struct MembershipAcl {
+    revokes: Vec<String>,
+    grants: Vec<String>,
+    grantees: Vec<String>,
 }
 
 pub(super) fn dump_acls(
@@ -140,7 +158,120 @@ pub(super) fn dump_acls(
             )
             .map_err(|e| format!("failed to add ACL {tag}: {e}"))?;
     }
+    dump_memberships(builder, project, &index)
+}
+
+/// Emit `GRANT role TO grantee` / `REVOKE role FROM grantee` entries
+/// from the `roles` and `groups` ACL sections, grouped per granted
+/// role like the object ACLs above. Each entry depends on the granted
+/// role's and every grantee's create entry so the topological sort
+/// restores memberships after the roles exist.
+fn dump_memberships(
+    builder: &mut Builder,
+    project: &Project,
+    index: &ObjectIndex,
+) -> Result<(), String> {
+    let mut memberships: BTreeMap<(usize, String), MembershipAcl> =
+        BTreeMap::new();
+    for item in &project.inventory {
+        let (grants, revocations) = match &item.definition {
+            Definition::Group(d) => (&d.grants, &d.revocations),
+            Definition::Role(d) => (&d.grants, &d.revocations),
+            Definition::User(d) => (&d.grants, &d.revocations),
+            _ => continue,
+        };
+        let grantee = item.definition.name();
+        for (acls, revoke) in [(revocations, true), (grants, false)] {
+            let Some(acls) = acls else {
+                continue;
+            };
+            for (section, (key, _)) in MEMBERSHIP_SECTIONS.iter().enumerate() {
+                let roles = match *key {
+                    "groups" => &acls.groups,
+                    _ => &acls.roles,
+                };
+                for role in roles.iter().flatten() {
+                    let entry = memberships
+                        .entry((section, role.clone()))
+                        .or_default();
+                    let statement = if revoke {
+                        format!(
+                            "REVOKE {} FROM {};",
+                            quote_role(role),
+                            quote_role(&grantee)
+                        )
+                    } else {
+                        format!(
+                            "GRANT {} TO {};",
+                            quote_role(role),
+                            quote_role(&grantee)
+                        )
+                    };
+                    if revoke {
+                        entry.revokes.push(statement);
+                    } else {
+                        entry.grants.push(statement);
+                    }
+                    if !entry.grantees.contains(&grantee) {
+                        entry.grantees.push(grantee.clone());
+                    }
+                }
+            }
+        }
+    }
+    for ((section, role), acl) in &memberships {
+        let (_, keyword) = MEMBERSHIP_SECTIONS[*section];
+        let tag = format!("{keyword} {role}");
+        let mut dependencies = Vec::new();
+        match find_role(builder, index, role) {
+            Some(dump_id) => dependencies.push(dump_id),
+            // common and benign: predefined pg_* roles, PUBLIC, and
+            // platform-managed (RDS) roles are never project files,
+            // and create: false roles emit no create entry; the
+            // membership grant is still emitted
+            None => log::debug!(
+                "Membership target {keyword} {role} not found in the \
+                 project"
+            ),
+        }
+        for grantee in &acl.grantees {
+            if let Some(dump_id) = find_role(builder, index, grantee) {
+                dependencies.push(dump_id);
+            }
+        }
+        let mut statements = acl.revokes.clone();
+        statements.extend(acl.grants.iter().cloned());
+        let defn = format!("{}\n", statements.join("\n"));
+        builder
+            .dump
+            .add_entry(
+                libpgdump::ObjectType::Acl,
+                Some(""),
+                Some(&tag),
+                Some(&builder.superuser),
+                Some(&defn),
+                None,
+                None,
+                &dependencies,
+            )
+            .map_err(|e| format!("failed to add ACL {tag}: {e}"))?;
+    }
     Ok(())
+}
+
+/// Find a role/group/user's entry id. Membership targets are
+/// schemaless, so the name is looked up whole (never schema-split as
+/// in [`find_object`]); `None` also covers `create: false` roles,
+/// which have no create entry.
+fn find_role(
+    builder: &Builder,
+    index: &ObjectIndex,
+    name: &str,
+) -> Option<i32> {
+    ROLES.iter().find_map(|desc| {
+        let item = index.objects.get(&(*desc, None, name.to_string()))?;
+        builder.dump_id_map.get(&item.id).copied()
+    })
 }
 
 /// Render one role's ACLs into the per-object statement map
@@ -523,5 +654,163 @@ mod tests {
                  WITH GRANT OPTION;\n"
             )
         );
+    }
+
+    fn membership_project(inventory: Vec<Item>) -> Project {
+        Project {
+            name: String::from("memberships"),
+            encoding: String::from("UTF8"),
+            stdstrings: true,
+            superuser: String::from("postgres"),
+            default_schema: String::from("public"),
+            path: std::path::PathBuf::new(),
+            inventory,
+        }
+    }
+
+    fn item(id: usize, desc: ObjectType, definition: Definition) -> Item {
+        Item {
+            id,
+            desc,
+            definition,
+            dependencies: BTreeSet::new(),
+        }
+    }
+
+    fn build_dump(project: &Project) -> libpgdump::Dump {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("memberships.dump");
+        crate::build::build(project, &path).unwrap();
+        libpgdump::load(&path).unwrap()
+    }
+
+    fn find_acl<'a>(
+        dump: &'a libpgdump::Dump,
+        tag: &str,
+    ) -> &'a libpgdump::Entry {
+        dump.entries()
+            .iter()
+            .find(|e| {
+                e.desc == libpgdump::ObjectType::Acl
+                    && e.tag.as_deref() == Some(tag)
+            })
+            .unwrap_or_else(|| panic!("missing ACL entry {tag}"))
+    }
+
+    #[test]
+    fn emits_role_membership_grants_with_dependencies() {
+        let developers: models::Role = serde_json::from_value(json!({
+            "name": "developers",
+        }))
+        .unwrap();
+        let alice: models::User = serde_json::from_value(json!({
+            "name": "alice",
+            "grants": {"roles": ["developers"]},
+        }))
+        .unwrap();
+        let project = membership_project(vec![
+            item(0, ObjectType::Role, Definition::Role(developers)),
+            item(1, ObjectType::User, Definition::User(alice)),
+        ]);
+        let dump = build_dump(&project);
+        let acl = find_acl(&dump, "ROLE developers");
+        assert_eq!(acl.namespace.as_deref().unwrap_or_default(), "");
+        assert_eq!(acl.owner.as_deref(), Some("postgres"));
+        assert_eq!(acl.defn.as_deref(), Some("GRANT developers TO alice;\n"));
+        // the membership sorts after both the granted role's and the
+        // grantee's create entries
+        let role = dump
+            .entries()
+            .iter()
+            .find(|e| e.tag.as_deref() == Some("developers"))
+            .expect("role entry");
+        let user = dump
+            .entries()
+            .iter()
+            .find(|e| e.tag.as_deref() == Some("alice"))
+            .expect("user entry");
+        assert_eq!(acl.dependencies, vec![role.dump_id, user.dump_id]);
+    }
+
+    #[test]
+    fn emits_role_membership_revocations() {
+        let developers: models::Role = serde_json::from_value(json!({
+            "name": "developers",
+        }))
+        .unwrap();
+        let alice: models::User = serde_json::from_value(json!({
+            "name": "alice",
+            "grants": {"roles": ["developers"]},
+            "revocations": {"roles": ["developers"]},
+        }))
+        .unwrap();
+        let project = membership_project(vec![
+            item(0, ObjectType::Role, Definition::Role(developers)),
+            item(1, ObjectType::User, Definition::User(alice)),
+        ]);
+        let dump = build_dump(&project);
+        let acl = find_acl(&dump, "ROLE developers");
+        assert_eq!(
+            acl.defn.as_deref(),
+            Some(
+                "REVOKE developers FROM alice;\n\
+                 GRANT developers TO alice;\n"
+            )
+        );
+    }
+
+    #[test]
+    fn emits_group_membership_grants() {
+        let admins: models::Group = serde_json::from_value(json!({
+            "name": "admins",
+        }))
+        .unwrap();
+        let bob: models::Role = serde_json::from_value(json!({
+            "name": "bob",
+            "grants": {"groups": ["admins"]},
+        }))
+        .unwrap();
+        let project = membership_project(vec![
+            item(0, ObjectType::Group, Definition::Group(admins)),
+            item(1, ObjectType::Role, Definition::Role(bob)),
+        ]);
+        let dump = build_dump(&project);
+        let acl = find_acl(&dump, "GROUP admins");
+        assert_eq!(acl.defn.as_deref(), Some("GRANT admins TO bob;\n"));
+        let group = dump
+            .entries()
+            .iter()
+            .find(|e| e.desc == libpgdump::ObjectType::Group)
+            .expect("group entry");
+        assert!(acl.dependencies.contains(&group.dump_id));
+    }
+
+    #[test]
+    fn emits_membership_grants_on_roles_absent_from_the_project() {
+        // predefined pg_* roles are filtered on pull and can never be
+        // project files; the membership grant must still be emitted
+        let alice: models::User = serde_json::from_value(json!({
+            "name": "alice",
+            "grants": {"roles": ["pg_read_all_data"]},
+        }))
+        .unwrap();
+        let project = membership_project(vec![item(
+            0,
+            ObjectType::User,
+            Definition::User(alice),
+        )]);
+        let dump = build_dump(&project);
+        let acl = find_acl(&dump, "ROLE pg_read_all_data");
+        assert_eq!(
+            acl.defn.as_deref(),
+            Some("GRANT pg_read_all_data TO alice;\n")
+        );
+        // only the grantee's create entry is resolvable
+        let user = dump
+            .entries()
+            .iter()
+            .find(|e| e.tag.as_deref() == Some("alice"))
+            .expect("user entry");
+        assert_eq!(acl.dependencies, vec![user.dump_id]);
     }
 }

--- a/src/build/acls.rs
+++ b/src/build/acls.rs
@@ -191,6 +191,17 @@ fn dump_memberships(
                     _ => &acls.roles,
                 };
                 for role in roles.iter().flatten() {
+                    // PostgreSQL does not permit PUBLIC as either
+                    // operand of a role membership grant
+                    if role.eq_ignore_ascii_case("public")
+                        || grantee.eq_ignore_ascii_case("public")
+                    {
+                        return Err(format!(
+                            "invalid membership ACL ({role} to \
+                             {grantee}): PostgreSQL does not permit \
+                             PUBLIC in role memberships"
+                        ));
+                    }
                     let entry = memberships
                         .entry((section, role.clone()))
                         .or_default();
@@ -225,7 +236,7 @@ fn dump_memberships(
         let mut dependencies = Vec::new();
         match find_role(builder, index, role) {
             Some(dump_id) => dependencies.push(dump_id),
-            // common and benign: predefined pg_* roles, PUBLIC, and
+            // common and benign: predefined pg_* roles and
             // platform-managed (RDS) roles are never project files,
             // and create: false roles emit no create entry; the
             // membership grant is still emitted
@@ -812,5 +823,55 @@ mod tests {
             .find(|e| e.tag.as_deref() == Some("alice"))
             .expect("user entry");
         assert_eq!(acl.dependencies, vec![user.dump_id]);
+    }
+
+    fn build_error(project: &Project) -> String {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("memberships.dump");
+        crate::build::build(project, &path).unwrap_err()
+    }
+
+    #[test]
+    fn rejects_public_as_the_granted_role() {
+        // PostgreSQL prohibits `GRANT PUBLIC TO alice`
+        let alice: models::User = serde_json::from_value(json!({
+            "name": "alice",
+            "grants": {"roles": ["PUBLIC"]},
+        }))
+        .unwrap();
+        let project = membership_project(vec![item(
+            0,
+            ObjectType::User,
+            Definition::User(alice),
+        )]);
+        let error = build_error(&project);
+        assert!(
+            error.contains("PUBLIC in role memberships"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_public_as_the_grantee() {
+        // PostgreSQL prohibits `GRANT developers TO PUBLIC`
+        let developers: models::Role = serde_json::from_value(json!({
+            "name": "developers",
+        }))
+        .unwrap();
+        let public: models::Role = serde_json::from_value(json!({
+            "name": "PUBLIC",
+            "create": false,
+            "grants": {"roles": ["developers"]},
+        }))
+        .unwrap();
+        let project = membership_project(vec![
+            item(0, ObjectType::Role, Definition::Role(developers)),
+            item(1, ObjectType::Role, Definition::Role(public)),
+        ]);
+        let error = build_error(&project);
+        assert!(
+            error.contains("PUBLIC in role memberships"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/src/pull/mod.rs
+++ b/src/pull/mod.rs
@@ -2267,4 +2267,84 @@ mod tests {
             ]
         );
     }
+
+    /// Role membership grants survive the full pull → write → load →
+    /// build path: captured from the pg_dumpall roles dump into the
+    /// grantee's `grants: {roles: [...]}`, then rendered back as
+    /// `GRANT role TO grantee` ACL entries in the build archive —
+    /// including grants on reserved pg_* roles, which are filtered
+    /// from the project as files but remain valid membership targets
+    #[test]
+    fn role_membership_round_trips_through_build() {
+        use clap::Parser;
+        let mut assembly = Assembly {
+            dbname: String::from("memberships"),
+            ..Assembly::default()
+        };
+        assembly
+            .ingest_roles(
+                "CREATE ROLE developers;\n\
+                 ALTER ROLE developers WITH NOLOGIN;\n\
+                 CREATE ROLE alice;\n\
+                 ALTER ROLE alice WITH LOGIN;\n\
+                 GRANT developers TO alice GRANTED BY postgres;\n\
+                 GRANT pg_read_all_data TO alice GRANTED BY postgres;\n",
+            )
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("project");
+        let dump = dir.path().join("unused.dump");
+        let args = match cli::Cli::try_parse_from([
+            "pglifecycle",
+            "pull",
+            "--dump",
+            dump.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .unwrap()
+        .action
+        {
+            cli::Action::Pull(args) => args,
+            _ => unreachable!(),
+        };
+        let files = writer::render(&assembly, &args).unwrap();
+        writer::write_bootstrap(&files, &args).unwrap();
+
+        let project = crate::project::load(&dest).unwrap();
+        let alice = project
+            .inventory
+            .iter()
+            .find_map(|item| match &item.definition {
+                models::Definition::User(user) if user.name == "alice" => {
+                    Some(user)
+                }
+                _ => None,
+            })
+            .expect("alice user");
+        assert_eq!(
+            alice.grants.as_ref().and_then(|g| g.roles.clone()),
+            Some(vec![
+                String::from("developers"),
+                String::from("pg_read_all_data"),
+            ])
+        );
+
+        let archive = dir.path().join("memberships.dump");
+        crate::build::build(&project, &archive).unwrap();
+        let built = libpgdump::load(&archive).unwrap();
+        let grants: Vec<&str> = built
+            .entries()
+            .iter()
+            .filter_map(|e| e.defn.as_deref())
+            .filter(|defn| defn.starts_with("GRANT"))
+            .collect();
+        assert_eq!(
+            grants,
+            vec![
+                "GRANT developers TO alice;\n",
+                "GRANT pg_read_all_data TO alice;\n",
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Role membership grants (`GRANT some_role TO some_grantee`) round-trip into the project YAML but were silently dropped by `build`. The schema (`schemata/acls.yml`) accepts `roles:`/`groups:` arrays, and `pull` captures memberships from the `pg_dumpall` roles dump into the grantee's `grants: {roles: [...]}` — but `src/build/acls.rs` drove all emission from the 13-entry `SECTIONS` const, which never included the membership sections, so the archive was just missing the grants with no error or warning.

This matters most for PostgreSQL's predefined roles (`pg_read_all_data`, `pg_monitor`, …), which can only ever be referenced, never created: with membership emission missing there was no way to express "userX is a member of `pg_read_all_data`" in a project and have it survive `build`. The same gap affected ordinary project-defined roles (`GRANT developers TO alice`).

## What changed

`build` now emits the `roles:` and `groups:` ACL sections from role, user, and group definitions alike:

- `grants: {roles: [r]}` on grantee `g` → `GRANT r TO g;`
- `revocations: {roles: [r]}` on grantee `g` → `REVOKE r FROM g;`
- Same for `groups:`, tagged `GROUP <name>` instead of `ROLE <name>`.

Roles keep the `quote_ident` treatment the rest of `build/` applies, including the existing `PUBLIC`-is-a-keyword handling.

### Entry shape

Membership grants come from `pg_dumpall`, not `pg_dump`, so there is no native single-database TOC precedent. I followed the shape of the existing (also Rust-new) object ACL entries: desc `ACL`, grouped per granted role with tag `ROLE <name>` / `GROUP <name>` (mirroring the `<KIND> <name>` tag convention), empty namespace (roles are schemaless, same as the `ALTER ROLE ... SET` settings entries), owner = project superuser (roles are ownerless), revocations before grants within the entry.

### Dependencies / ordering

Each membership entry records dependency edges on the granted role's create entry **and** every grantee's create entry, so libpgdump's weighted topological sort restores memberships after both roles exist. Lookup goes through the existing `ObjectIndex` (roles are schemaless, so a dedicated `find_role` avoids `find_object`'s schema-splitting on dotted names).

An unresolvable granted role is normal, not an error: reserved `pg_*` roles (filtered on pull by design — unchanged here), `PUBLIC`, platform-managed roles on RDS, and `create: false` roles (deviation 11 — no create entry to depend on). Matching how `dump_acls` already treats untracked ACL targets, these log at `debug` and the statement is emitted anyway.

## Parity decision

`test-project/` is left untouched and no new deviation is registered. The Python implementation never emitted membership grants either, so adding one to `test-project/` would create a Rust entry with no Python counterpart and require a deviation 13 for coverage that unit tests provide more cheaply. Instead:

- Unit tests in `src/build/acls.rs`: grant emission, revoke emission, the `groups:` section, a granted role absent from the project (the `pg_read_all_data` case — the statement is still emitted, with only the grantee dependency), and dependency edges on both the granted role and the grantee.
- A round-trip test in `src/pull/mod.rs` (`role_membership_round_trips_through_build`, modeled on `role_settings_round_trip_through_build`) proving `GRANT developers TO alice` and `GRANT pg_read_all_data TO alice` survive pull → write YAML → load → build.
- `tests/build_parity.rs` passes unchanged.

## Docs

`docs/project-format.md` Conventions now documents membership under `grants:`/`revocations:` as `roles:`/`groups:` arrays, with the predefined-role case as the example. `docs/commands.md` needed no change: the `pull` section's role extraction and `pg_*` exclusion descriptions still hold.

## Out of scope (follow-ups)

- `WITH ADMIN OPTION` and `GRANTED BY` — `schemata/acls.yml` cannot currently express either (`roles:`/`groups:` are plain string arrays).
- `deploy` reconciliation — per `docs/commands.md`, deploy skips roles/users/groups entirely by design.

## Verification

- `just check` (fmt-check + clippy `-D warnings` + test) — clean.
- `just docs` (`mkdocs build --strict`) — clean.
- `just gates` (round-trip + deploy gates against Postgres 17 via `compose.yaml`) — all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for defining role and group memberships in project configuration.
  * Builds now emit membership `GRANT` and `REVOKE` statements.
  * Memberships referencing reserved roles are supported, even when those roles lack project files.
  * Pull and archive workflows preserve configured role memberships.

* **Documentation**
  * Added configuration guidance and examples for role and group memberships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->